### PR TITLE
Fix over-eager type link regex to allow multiple links on one line.

### DIFF
--- a/protoc-gen-docs/htmlGenerator.go
+++ b/protoc-gen-docs/htmlGenerator.go
@@ -513,7 +513,7 @@ func (g *htmlGenerator) emit(str ...string) {
 	g.buffer.WriteByte('\n')
 }
 
-var typeLinkPattern = regexp.MustCompile(`\[.*\]\[.*\]`)
+var typeLinkPattern = regexp.MustCompile(`\[[^\]]*\]\[[^\]]*\]`)
 
 func (g *htmlGenerator) generateComment(loc locationDescriptor, name string) {
 	com := loc.GetLeadingComments()


### PR DESCRIPTION
Without this fix, "[a][b] and [c][d]" is treated as a single regex match instead of two.