### PR TITLE
Add a new compilation option per_file to generate 1 html per 1 proto.

### DIFF
--- a/protoc-gen-docs/README.md
+++ b/protoc-gen-docs/README.md
@@ -80,7 +80,7 @@ the output. The default is to camel case fields.
 protoc --docs_out=camel_case_fields=false:output_directory input_directory/file.proto
 ```
 
-Using the 'custom_style_sheet' option, you can control the style sheet used when generating full stand-alone
+Using the `custom_style_sheet` option, you can control the style sheet used when generating full stand-alone
 HTML pages. You provide the URL of the style sheet as parameter, and the URL will be inserted into the generated
 HTML.
 
@@ -89,6 +89,11 @@ You can specify multiple options together by separating them with commas:
 ```bash
 protoc --docs_out=warnings=true,mode=html_page:output_directory input_directory/file.proto
 ```
+
+Using the `per_file` option, you can change the output mode to document protos on a per-file basis. The
+file introduction text is taken from the `pkg` statement just like in the per-package (default) mode.
+In the per-package mode, only one file may document the `pkg`. If there are conflicts, the compiler
+will emit a warning and continue with the first comment it found.
 
 # Writing Docs
 

--- a/protoc-gen-docs/fileDescriptor.go
+++ b/protoc-gen-docs/fileDescriptor.go
@@ -28,6 +28,7 @@ type fileDescriptor struct {
 	services     []*serviceDescriptor                               // All services defined in this file
 	dependencies []*fileDescriptor                                  // Files imported by this file
 	locations    map[pathVector]*descriptor.SourceCodeInfo_Location // Provenance
+	topMatter    *pageTopMatter                                     // Title, overview, homeLocation, front_matter
 }
 
 func newFileDescriptor(desc *descriptor.FileDescriptorProto, parent *packageDescriptor) *fileDescriptor {
@@ -63,6 +64,9 @@ func newFileDescriptor(desc *descriptor.FileDescriptorProto, parent *packageDesc
 		f.services = append(f.services, newServiceDescriptor(s, f, path.append(i)))
 	}
 
+	// Find title/overview/etc content in comments and store it explicitly.
+	f.cacheTopMatter()
+
 	// get the transitive close of all messages and enums
 	f.aggregateMessages(f.messages)
 	f.aggregateEnums(f.enums)
@@ -85,4 +89,41 @@ func (f *fileDescriptor) aggregateMessages(messages []*messageDescriptor) {
 
 func (f *fileDescriptor) aggregateEnums(enums []*enumDescriptor) {
 	f.allEnums = append(f.allEnums, enums...)
+}
+
+func (f *fileDescriptor) cacheTopMatter() {
+	// Search above the pkg statement for top matter.
+	loc := f.find(newPathVector(packagePath))
+
+	if loc != nil && loc.LeadingDetachedComments != nil {
+		f.topMatter = makeTopMatter(f.GetName(), loc)
+	}
+}
+
+func (f *fileDescriptor) title() string {
+	if f.topMatter != nil {
+		return f.topMatter.title
+	}
+	return ""
+}
+
+func (f *fileDescriptor) overview() string {
+	if f.topMatter != nil {
+		return f.topMatter.overview
+	}
+	return ""
+}
+
+func (f *fileDescriptor) homeLocation() string {
+	if f.topMatter != nil {
+		return f.topMatter.homeLocation
+	}
+	return ""
+}
+
+func (f *fileDescriptor) frontMatter() []string {
+	if f.topMatter != nil {
+		return f.topMatter.frontMatter
+	}
+	return nil
 }

--- a/protoc-gen-docs/htmlGenerator.go
+++ b/protoc-gen-docs/htmlGenerator.go
@@ -53,14 +53,14 @@ type htmlGenerator struct {
 	emitYAML         bool
 	camelCaseFields  bool
 	customStyleSheet string
-	linkByFile       bool
+	perFile          bool
 }
 
 const (
 	deprecated = "deprecated "
 )
 
-func newHTMLGenerator(model *model, mode outputMode, genWarnings bool, emitYAML bool, camelCaseFields bool, customStyleSheet string, linkByFile bool) *htmlGenerator {
+func newHTMLGenerator(model *model, mode outputMode, genWarnings bool, emitYAML bool, camelCaseFields bool, customStyleSheet string, perFile bool) *htmlGenerator {
 	return &htmlGenerator{
 		model:            model,
 		mode:             mode,
@@ -68,7 +68,7 @@ func newHTMLGenerator(model *model, mode outputMode, genWarnings bool, emitYAML 
 		emitYAML:         emitYAML,
 		camelCaseFields:  camelCaseFields,
 		customStyleSheet: customStyleSheet,
-		linkByFile:       linkByFile,
+		perFile:          perFile,
 	}
 }
 
@@ -149,7 +149,7 @@ func (g *htmlGenerator) generateOutput(filesToGen map[*fileDescriptor]bool) *plu
 		}
 
 		if count > 0 {
-			if g.linkByFile {
+			if g.perFile {
 				g.generatePerFileOutput(filesToGen, pkg, &response)
 			} else {
 				g.generatePerPackageOutput(filesToGen, pkg, &response)
@@ -161,7 +161,7 @@ func (g *htmlGenerator) generateOutput(filesToGen map[*fileDescriptor]bool) *plu
 }
 
 func (g *htmlGenerator) descLocation(desc coreDesc) string {
-	if g.linkByFile {
+	if g.perFile {
 		return desc.fileDesc().homeLocation()
 	}
 	if desc.packageDesc().file != nil {
@@ -251,7 +251,7 @@ func (g *htmlGenerator) generateFile(name string, top *fileDescriptor, messages 
 	// if there's more than one kind of thing, divide the output in groups
 	g.grouping = numKinds > 1
 
-	g.generateFileHeader(name, top, len(typeList)+len(serviceList))
+	g.generateFileHeader(top, len(typeList)+len(serviceList))
 
 	if len(serviceList) > 0 {
 		if g.grouping {
@@ -286,7 +286,8 @@ func (g *htmlGenerator) generateFile(name string, top *fileDescriptor, messages 
 	}
 }
 
-func (g *htmlGenerator) generateFileHeader(name string, top *fileDescriptor, numEntries int) {
+func (g *htmlGenerator) generateFileHeader(top *fileDescriptor, numEntries int) {
+	name := g.currentPackage.name
 	if g.mode == jekyllHTML {
 		g.emit("---")
 
@@ -352,7 +353,7 @@ func (g *htmlGenerator) generateFileHeader(name string, top *fileDescriptor, num
 		}
 	}
 
-	if g.linkByFile {
+	if g.perFile {
 		if top == nil {
 			croak("PANIC: null file %v", name)
 		}
@@ -706,7 +707,7 @@ func (g *htmlGenerator) linkify(o coreDesc, name string) string {
 
 	if !o.isHidden() {
 		var loc string
-		if g.linkByFile {
+		if g.perFile {
 			loc = o.fileDesc().homeLocation()
 		} else if o.packageDesc().file != nil {
 			loc = o.packageDesc().file.homeLocation()

--- a/protoc-gen-docs/htmlGenerator.go
+++ b/protoc-gen-docs/htmlGenerator.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"path"
 	"regexp"
 	"sort"
 	"strconv"
@@ -44,20 +45,22 @@ type htmlGenerator struct {
 	mode   outputMode
 
 	// transient state as individual files are processed
-	currentPackage *packageDescriptor
-	grouping       bool
+	currentPackage       *packageDescriptor
+	currentTopMatterFile *fileDescriptor
+	grouping             bool
 
 	genWarnings      bool
 	emitYAML         bool
 	camelCaseFields  bool
 	customStyleSheet string
+	linkByFile       bool
 }
 
 const (
 	deprecated = "deprecated "
 )
 
-func newHTMLGenerator(model *model, mode outputMode, genWarnings bool, emitYAML bool, camelCaseFields bool, customStyleSheet string) *htmlGenerator {
+func newHTMLGenerator(model *model, mode outputMode, genWarnings bool, emitYAML bool, camelCaseFields bool, customStyleSheet string, linkByFile bool) *htmlGenerator {
 	return &htmlGenerator{
 		model:            model,
 		mode:             mode,
@@ -65,7 +68,68 @@ func newHTMLGenerator(model *model, mode outputMode, genWarnings bool, emitYAML 
 		emitYAML:         emitYAML,
 		camelCaseFields:  camelCaseFields,
 		customStyleSheet: customStyleSheet,
+		linkByFile:       linkByFile,
 	}
+}
+
+func (g *htmlGenerator) getFileContents(file *fileDescriptor, messages map[string]*messageDescriptor, enums map[string]*enumDescriptor, services map[string]*serviceDescriptor) {
+	for _, m := range file.allMessages {
+		messages[g.relativeName(m)] = m
+		g.includeUnsituatedDependencies(messages, enums, m)
+	}
+
+	for _, e := range file.allEnums {
+		enums[g.relativeName(e)] = e
+	}
+
+	for _, s := range file.services {
+		services[g.relativeName(s)] = s
+	}
+}
+
+func (g *htmlGenerator) generatePerFileOutput(filesToGen map[*fileDescriptor]bool, pkg *packageDescriptor, response *plugin.CodeGeneratorResponse) {
+	// We need to produce a file for each non-hidden file in this package.
+
+	// Decide which types need to be included in the generated file.
+	// This will be all the types in the fileToGen input files, along with any
+	// dependent types which are located in files that don't have
+	// a known location on the web.
+
+	for _, file := range pkg.files {
+		if _, ok := filesToGen[file]; ok {
+			g.currentTopMatterFile = file
+			messages := make(map[string]*messageDescriptor)
+			enums := make(map[string]*enumDescriptor)
+			services := make(map[string]*serviceDescriptor)
+			g.getFileContents(file, messages, enums, services)
+			var filename = path.Base(file.GetName())
+			var extension = path.Ext(filename)
+			var name = filename[0 : len(filename)-len(extension)]
+			rf := g.generateFile(name, file, messages, enums, services)
+			response.File = append(response.File, &rf)
+		}
+	}
+}
+
+func (g *htmlGenerator) generatePerPackageOutput(filesToGen map[*fileDescriptor]bool, pkg *packageDescriptor, response *plugin.CodeGeneratorResponse) {
+	// We need to produce a file for this package.
+
+	// Decide which types need to be included in the generated file.
+	// This will be all the types in the fileToGen input files, along with any
+	// dependent types which are located in packages that don't have
+	// a known location on the web.
+	messages := make(map[string]*messageDescriptor)
+	enums := make(map[string]*enumDescriptor)
+	services := make(map[string]*serviceDescriptor)
+
+	for _, file := range pkg.files {
+		if _, ok := filesToGen[file]; ok {
+			g.getFileContents(file, messages, enums, services)
+		}
+	}
+
+	rf := g.generateFile(pkg.name, pkg.file, messages, enums, services)
+	response.File = append(response.File, &rf)
 }
 
 func (g *htmlGenerator) generateOutput(filesToGen map[*fileDescriptor]bool) *plugin.CodeGeneratorResponse {
@@ -74,6 +138,7 @@ func (g *htmlGenerator) generateOutput(filesToGen map[*fileDescriptor]bool) *plu
 
 	for _, pkg := range g.model.packages {
 		g.currentPackage = pkg
+		g.currentTopMatterFile = pkg.file
 
 		// anything to output for this package?
 		count := 0
@@ -84,45 +149,32 @@ func (g *htmlGenerator) generateOutput(filesToGen map[*fileDescriptor]bool) *plu
 		}
 
 		if count > 0 {
-			// We need to produce a file for this package.
-
-			// Decide which types need to be included in the generated file.
-			// This will be all the types in the fileToGen input files, along with any
-			// dependent types which are located in packages that don't have
-			// a known location on the web.
-			messages := make(map[string]*messageDescriptor)
-			enums := make(map[string]*enumDescriptor)
-			services := make(map[string]*serviceDescriptor)
-
-			for _, file := range pkg.files {
-				if _, ok := filesToGen[file]; ok {
-					for _, m := range file.allMessages {
-						messages[g.relativeName(m)] = m
-						g.includeUnsituatedDependencies(messages, enums, m)
-					}
-
-					for _, e := range file.allEnums {
-						enums[g.relativeName(e)] = e
-					}
-
-					for _, s := range file.services {
-						services[g.relativeName(s)] = s
-					}
-				}
+			if g.linkByFile {
+				g.generatePerFileOutput(filesToGen, pkg, &response)
+			} else {
+				g.generatePerPackageOutput(filesToGen, pkg, &response)
 			}
-
-			rf := g.generateFile(pkg, messages, enums, services)
-			response.File = append(response.File, &rf)
 		}
 	}
 
 	return &response
 }
 
+func (g *htmlGenerator) descLocation(desc coreDesc) string {
+	if g.linkByFile {
+		return desc.fileDesc().homeLocation()
+	}
+	if desc.packageDesc().file != nil {
+		return desc.packageDesc().file.homeLocation()
+	}
+	return ""
+}
+
 func (g *htmlGenerator) includeUnsituatedDependencies(messages map[string]*messageDescriptor, enums map[string]*enumDescriptor, msg *messageDescriptor) {
 	for _, field := range msg.fields {
 		if m, ok := field.typ.(*messageDescriptor); ok {
-			if field.typ.packageDesc().homeLocation == "" {
+			// A package without a known documentation location is included in the output.
+			if g.descLocation(field.typ) == "" {
 				name := g.relativeName(m)
 				if _, ok := messages[name]; !ok {
 					messages[name] = m
@@ -130,14 +182,15 @@ func (g *htmlGenerator) includeUnsituatedDependencies(messages map[string]*messa
 				}
 			}
 		} else if e, ok := field.typ.(*enumDescriptor); ok {
-			if field.typ.packageDesc().homeLocation == "" {
+			if g.descLocation(field.typ) == "" {
 				enums[g.relativeName(e)] = e
 			}
 		}
 	}
 }
 
-func (g *htmlGenerator) generateFile(pkg *packageDescriptor, messages map[string]*messageDescriptor,
+// Generate a package documentation file or a collection of cross-linked files.
+func (g *htmlGenerator) generateFile(name string, top *fileDescriptor, messages map[string]*messageDescriptor,
 	enums map[string]*enumDescriptor, services map[string]*serviceDescriptor) plugin.CodeGeneratorResponse_File {
 	g.buffer.Reset()
 
@@ -198,7 +251,7 @@ func (g *htmlGenerator) generateFile(pkg *packageDescriptor, messages map[string
 	// if there's more than one kind of thing, divide the output in groups
 	g.grouping = numKinds > 1
 
-	g.generateFileHeader(pkg, len(typeList)+len(serviceList))
+	g.generateFileHeader(name, top, len(typeList)+len(serviceList))
 
 	if len(serviceList) > 0 {
 		if g.grouping {
@@ -228,34 +281,36 @@ func (g *htmlGenerator) generateFile(pkg *packageDescriptor, messages map[string
 	g.generateFileFooter()
 
 	return plugin.CodeGeneratorResponse_File{
-		Name:    proto.String(pkg.name + ".pb.html"),
+		Name:    proto.String(name + ".pb.html"),
 		Content: proto.String(g.buffer.String()),
 	}
 }
 
-func (g *htmlGenerator) generateFileHeader(pkg *packageDescriptor, numEntries int) {
+func (g *htmlGenerator) generateFileHeader(name string, top *fileDescriptor, numEntries int) {
 	if g.mode == jekyllHTML {
 		g.emit("---")
 
-		if pkg.title != "" {
-			g.emit("title: ", pkg.title)
+		if top != nil && top.title() != "" {
+			g.emit("title: ", top.title())
 		} else {
-			g.emit("title: ", pkg.name)
+			g.emit("title: ", name)
 		}
 
-		if pkg.overview != "" {
-			g.emit("overview: ", pkg.overview)
+		if top != nil && top.overview() != "" {
+			g.emit("overview: ", top.overview())
 		}
 
-		if pkg.homeLocation != "" {
-			g.emit("location: ", pkg.homeLocation)
+		if top != nil && top.homeLocation() != "" {
+			g.emit("location: ", top.homeLocation())
 		}
 
 		g.emit("layout: protoc-gen-docs")
 
 		// emit additional custom Jekyll front-matter fields
-		for _, fm := range pkg.frontMatter {
-			g.emit(fm)
+		if top != nil {
+			for _, fm := range top.frontMatter() {
+				g.emit(fm)
+			}
 		}
 
 		g.emit("number_of_entries: ", strconv.Itoa(numEntries))
@@ -268,15 +323,15 @@ func (g *htmlGenerator) generateFileHeader(pkg *packageDescriptor, numEntries in
 		g.emit("<meta charset=\"utf-8'>")
 		g.emit("<meta name=\"viewport' content=\"width=device-width, initial-scale=1, shrink-to-fit=no\">")
 
-		if pkg.title != "" {
-			g.emit("<meta name=\"title\" content=\"", pkg.title, "\">")
-			g.emit("<meta name=\"og:title\" content=\"", pkg.title, "\">")
-			g.emit("<title>", pkg.title, "</title>")
+		if top != nil && top.title() != "" {
+			g.emit("<meta name=\"title\" content=\"", top.title(), "\">")
+			g.emit("<meta name=\"og:title\" content=\"", top.title(), "\">")
+			g.emit("<title>", top.title(), "</title>")
 		}
 
-		if pkg.overview != "" {
-			g.emit("<meta name=\"description\" content=\"", pkg.overview, "\">")
-			g.emit("<meta name=\"og:description\" content=\"", pkg.overview, "\">")
+		if top != nil && top.overview() != "" {
+			g.emit("<meta name=\"description\" content=\"", top.overview(), "\">")
+			g.emit("<meta name=\"og:description\" content=\"", top.overview(), "\">")
 		}
 
 		if g.customStyleSheet != "" {
@@ -287,17 +342,24 @@ func (g *htmlGenerator) generateFileHeader(pkg *packageDescriptor, numEntries in
 
 		g.emit("</head>")
 		g.emit("<body>")
-		if pkg.title != "" {
-			g.emit("<h1>", pkg.title, "</h1>")
+		if top != nil && top.title() != "" {
+			g.emit("<h1>", top.title(), "</h1>")
 		}
 	} else if g.mode == htmlFragment {
 		g.emit("<!-- Generated by protoc-gen-docs -->")
-		if pkg.title != "" {
-			g.emit("<h1>", pkg.title, "</h1>")
+		if top != nil && top.title() != "" {
+			g.emit("<h1>", top.title(), "</h1>")
 		}
 	}
 
-	g.generateComment(pkg.location(), pkg.name)
+	if g.linkByFile {
+		if top == nil {
+			croak("PANIC: null file %v", name)
+		}
+		g.generateComment(newLocationDescriptor(top.topMatter.location, top), name)
+	} else {
+		g.generateComment(g.currentPackage.location(), name)
+	}
 }
 
 func (g *htmlGenerator) generateFileFooter() {
@@ -643,8 +705,13 @@ func (g *htmlGenerator) linkify(o coreDesc, name string) string {
 	}
 
 	if !o.isHidden() {
-		loc := o.packageDesc().homeLocation
-		if loc != "" && loc != g.currentPackage.homeLocation {
+		var loc string
+		if g.linkByFile {
+			loc = o.fileDesc().homeLocation()
+		} else if o.packageDesc().file != nil {
+			loc = o.packageDesc().file.homeLocation()
+		}
+		if loc != "" && (g.currentTopMatterFile == nil || loc != g.currentTopMatterFile.homeLocation()) {
 			return "<a href=\"" + loc + "#" + dottedName(o) + "\">" + name + "</a>"
 		}
 	}

--- a/protoc-gen-docs/htmlGenerator.go
+++ b/protoc-gen-docs/htmlGenerator.go
@@ -308,9 +308,18 @@ func (g *htmlGenerator) generateFileHeader(top *fileDescriptor, numEntries int) 
 		g.emit("layout: protoc-gen-docs")
 
 		// emit additional custom Jekyll front-matter fields
-		if top != nil {
-			for _, fm := range top.frontMatter() {
-				g.emit(fm)
+		if g.perFile {
+			if top != nil {
+				for _, fm := range top.frontMatter() {
+					g.emit(fm)
+				}
+			}
+		} else {
+			// Front matter may be in any of the package's files.
+			for _, file := range g.currentPackage.files {
+				for _, fm := range file.frontMatter() {
+					g.emit(fm)
+				}
 			}
 		}
 

--- a/protoc-gen-docs/main.go
+++ b/protoc-gen-docs/main.go
@@ -62,7 +62,7 @@ func main() {
 	emitYAML := false
 	camelCaseFields := true
 	customStyleSheet := ""
-	linkByFile := false
+	perFile := false
 
 	p := extractParams(request.GetParameter())
 	for k, v := range p {
@@ -106,21 +106,21 @@ func main() {
 			}
 		} else if k == "custom_style_sheet" {
 			customStyleSheet = v
-		} else if k == "link_by_file" {
+		} else if k == "per_file" {
 			switch strings.ToLower(v) {
 			case "true":
-				linkByFile = true
+				perFile = true
 			case "false":
-				linkByFile = false
+				perFile = false
 			default:
-				croak("Unknown value '%s' for link_by_file", v)
+				croak("Unknown value '%s' for per_file", v)
 			}
 		} else {
 			croak("Unknown argument '%s' specified\n", k)
 		}
 	}
 
-	m, err := newModel(&request)
+	m, err := newModel(&request, perFile)
 	if err != nil {
 		croak("Unable to create model: %v\n", err)
 	}
@@ -134,7 +134,7 @@ func main() {
 		filesToGen[fd] = true
 	}
 
-	g := newHTMLGenerator(m, mode, genWarnings, emitYAML, camelCaseFields, customStyleSheet, linkByFile)
+	g := newHTMLGenerator(m, mode, genWarnings, emitYAML, camelCaseFields, customStyleSheet, perFile)
 	response := g.generateOutput(filesToGen)
 
 	data, err = proto.Marshal(response)

--- a/protoc-gen-docs/main.go
+++ b/protoc-gen-docs/main.go
@@ -62,6 +62,7 @@ func main() {
 	emitYAML := false
 	camelCaseFields := true
 	customStyleSheet := ""
+	linkByFile := false
 
 	p := extractParams(request.GetParameter())
 	for k, v := range p {
@@ -105,6 +106,15 @@ func main() {
 			}
 		} else if k == "custom_style_sheet" {
 			customStyleSheet = v
+		} else if k == "link_by_file" {
+			switch strings.ToLower(v) {
+			case "true":
+				linkByFile = true
+			case "false":
+				linkByFile = false
+			default:
+				croak("Unknown value '%s' for link_by_file", v)
+			}
 		} else {
 			croak("Unknown argument '%s' specified\n", k)
 		}
@@ -124,7 +134,7 @@ func main() {
 		filesToGen[fd] = true
 	}
 
-	g := newHTMLGenerator(m, mode, genWarnings, emitYAML, camelCaseFields, customStyleSheet)
+	g := newHTMLGenerator(m, mode, genWarnings, emitYAML, camelCaseFields, customStyleSheet, linkByFile)
 	response := g.generateOutput(filesToGen)
 
 	data, err = proto.Marshal(response)

--- a/protoc-gen-docs/model.go
+++ b/protoc-gen-docs/model.go
@@ -28,7 +28,7 @@ type model struct {
 	packages       []*packageDescriptor
 }
 
-func newModel(request *plugin.CodeGeneratorRequest) (*model, error) {
+func newModel(request *plugin.CodeGeneratorRequest, perFile bool) (*model, error) {
 	m := &model{
 		allFilesByName: make(map[string]*fileDescriptor, len(request.ProtoFile)),
 	}
@@ -44,7 +44,7 @@ func newModel(request *plugin.CodeGeneratorRequest) (*model, error) {
 	// create all the package descriptors
 	var allFiles []*fileDescriptor
 	for pkg, files := range filesByPackage {
-		p := newPackageDescriptor(pkg, files)
+		p := newPackageDescriptor(pkg, files, perFile)
 		m.packages = append(m.packages, p)
 
 		for _, f := range p.files {

--- a/protoc-gen-docs/packageDescriptor.go
+++ b/protoc-gen-docs/packageDescriptor.go
@@ -15,7 +15,8 @@
 package main
 
 import (
-	"strings"
+	"fmt"
+	"os"
 
 	"github.com/golang/protobuf/protoc-gen-go/descriptor"
 )
@@ -23,20 +24,10 @@ import (
 // packageDescriptor describes a package, which is a composition of proto files.
 type packageDescriptor struct {
 	baseDesc
-	files        []*fileDescriptor
-	name         string
-	title        string
-	overview     string
-	homeLocation string
-	frontMatter  []string
+	files     []*fileDescriptor
+	name      string
+	topMatter *pageTopMatter
 }
-
-const (
-	title       = "$title: "
-	overview    = "$overview: "
-	location    = "$location: "
-	frontMatter = "$front_matter: "
-)
 
 func newPackageDescriptor(name string, desc []*descriptor.FileDescriptorProto) *packageDescriptor {
 	p := &packageDescriptor{
@@ -46,33 +37,23 @@ func newPackageDescriptor(name string, desc []*descriptor.FileDescriptorProto) *
 	for _, fd := range desc {
 		f := newFileDescriptor(fd, p)
 		p.files = append(p.files, f)
-
 		loc := f.find(newPathVector(packagePath))
-
+		// The package's file is one that documents the pkg statement.
+		// The first file to do this "wins".
 		if loc != nil {
 			if p.loc == nil {
 				if loc.GetLeadingComments() != "" || loc.GetTrailingComments() != "" {
 					p.loc = loc
 					p.file = f
+					// Inherit only f's topMatter, don't get title from one file
 				}
-			}
-
-			if loc.LeadingDetachedComments != nil {
-				for _, para := range loc.LeadingDetachedComments {
-					lines := strings.Split(para, "\n")
-					for _, l := range lines {
-						l = strings.Trim(l, " ")
-
-						if strings.HasPrefix(l, title) {
-							p.title = l[len(title):]
-						} else if strings.HasPrefix(l, overview) {
-							p.overview = l[len(overview):]
-						} else if strings.HasPrefix(l, location) {
-							p.homeLocation = l[len(location):]
-						} else if strings.HasPrefix(l, frontMatter) {
-							p.frontMatter = append(p.frontMatter, l[len(frontMatter):])
-						}
-					}
+			} else {
+				leading := loc.GetLeadingComments()
+				trailing := loc.GetTrailingComments()
+				if leading != "" || trailing != "" {
+					fmt.Fprintf(os.Stderr, "WARNING: package %v has a conflicting package comment in file %v.\n",
+						name, f.GetName())
+					fmt.Fprintf(os.Stderr, "Previous:\n%v\n%v\nCurrent:\n%v\n%\n", p.loc.GetLeadingComments(), p.loc.GetTrailingComments(), leading, trailing)
 				}
 			}
 		}

--- a/protoc-gen-docs/packageDescriptor.go
+++ b/protoc-gen-docs/packageDescriptor.go
@@ -29,7 +29,7 @@ type packageDescriptor struct {
 	topMatter *pageTopMatter
 }
 
-func newPackageDescriptor(name string, desc []*descriptor.FileDescriptorProto) *packageDescriptor {
+func newPackageDescriptor(name string, desc []*descriptor.FileDescriptorProto, perFile bool) *packageDescriptor {
 	p := &packageDescriptor{
 		name: name,
 	}
@@ -47,7 +47,7 @@ func newPackageDescriptor(name string, desc []*descriptor.FileDescriptorProto) *
 					p.file = f
 					// Inherit only f's topMatter, don't get title from one file
 				}
-			} else {
+			} else if !perFile {
 				leading := loc.GetLeadingComments()
 				trailing := loc.GetTrailingComments()
 				if leading != "" || trailing != "" {

--- a/protoc-gen-docs/pageTopMatter.go
+++ b/protoc-gen-docs/pageTopMatter.go
@@ -1,0 +1,87 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this currentFile except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/golang/protobuf/protoc-gen-go/descriptor"
+)
+
+type pageTopMatter struct {
+	title        string
+	overview     string
+	homeLocation string
+	frontMatter  []string
+	location     *descriptor.SourceCodeInfo_Location
+}
+
+const (
+	titleTag       = "$title: "
+	overviewTag    = "$overview: "
+	locationTag    = "$location: "
+	frontMatterTag = "$front_matter: "
+)
+
+func checkSingle(name string, old string, line string, tag string) string {
+	result := line[len(tag):]
+	if old != "" {
+		fmt.Fprint(os.Stderr, "%v has more than one %v: %v\n", name, tag, result)
+	}
+	return result
+}
+
+func makeTopMatter(name string, loc *descriptor.SourceCodeInfo_Location) *pageTopMatter {
+	hasTopMatter := false
+	title := ""
+	overview := ""
+	homeLocation := ""
+	var frontMatter []string = nil
+	for _, para := range loc.LeadingDetachedComments {
+		lines := strings.Split(para, "\n")
+		for _, l := range lines {
+			l = strings.Trim(l, " ")
+
+			empty := false
+			if strings.HasPrefix(l, titleTag) {
+				title = checkSingle(name, title, l, titleTag)
+			} else if strings.HasPrefix(l, overview) {
+				overview = checkSingle(name, overview, l, overviewTag)
+			} else if strings.HasPrefix(l, locationTag) {
+				homeLocation = checkSingle(name, homeLocation, l, locationTag)
+			} else if strings.HasPrefix(l, frontMatterTag) {
+				additional := l[len(frontMatterTag):]
+				frontMatter = append(frontMatter, additional)
+			} else {
+				empty = true
+			}
+			if !empty {
+				hasTopMatter = true
+			}
+		}
+	}
+	if hasTopMatter {
+		return &pageTopMatter{
+			title:        title,
+			overview:     overview,
+			homeLocation: homeLocation,
+			frontMatter:  frontMatter,
+			location:     loc,
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
This changes the data model for packages and files in a semantics-changing way [^semantics].
Before this change, a package would collect its title, overview, homelocation information (I call this "top matter") from leading detached comments above any `pkg` statement in the collection of files within the package. It would also clobber each value if there were a competing annotation. If a `pkg` statement were documented twice, it would silently ignore competing documentation after it found its first one. The file that "wins" the documentation assignment is defined to be the package's underlying "file" (despite comprising multiple files).

After this change, all top matter is stored in a per-file basis. A package's top matter must all be specified in the defining file. The front_matter: additions still may come from any file.

[^semantics]: The top matter change is the semantics-breaking piece. If necessary, I can re-add the behavior so that each visited file in the package has a chance to set or clobber a top matter object that the package owns in addition to its defining file, but I think the forced organization of top matter with package description is a positive cleanup.