### PR TITLE
Helpful error message when missing top matter

### DIFF
--- a/protoc-gen-docs/htmlGenerator.go
+++ b/protoc-gen-docs/htmlGenerator.go
@@ -251,7 +251,7 @@ func (g *htmlGenerator) generateFile(name string, top *fileDescriptor, messages 
 	// if there's more than one kind of thing, divide the output in groups
 	g.grouping = numKinds > 1
 
-	g.generateFileHeader(top, len(typeList)+len(serviceList))
+	g.generateFileHeader(name, top, len(typeList)+len(serviceList))
 
 	if len(serviceList) > 0 {
 		if g.grouping {
@@ -286,8 +286,7 @@ func (g *htmlGenerator) generateFile(name string, top *fileDescriptor, messages 
 	}
 }
 
-func (g *htmlGenerator) generateFileHeader(top *fileDescriptor, numEntries int) {
-	name := g.currentPackage.name
+func (g *htmlGenerator) generateFileHeader(name string, top *fileDescriptor, numEntries int) {
 	if g.mode == jekyllHTML {
 		g.emit("---")
 
@@ -365,6 +364,9 @@ func (g *htmlGenerator) generateFileHeader(top *fileDescriptor, numEntries int) 
 	if g.perFile {
 		if top == nil {
 			croak("PANIC: null file %v", name)
+		}
+		if top.topMatter == nil {
+			croak("PANIC: per_file mode, file is missing top matter %v", name)
 		}
 		g.generateComment(newLocationDescriptor(top.topMatter.location, top), name)
 	} else {

--- a/protoc-gen-docs/htmlGenerator.go
+++ b/protoc-gen-docs/htmlGenerator.go
@@ -365,10 +365,11 @@ func (g *htmlGenerator) generateFileHeader(name string, top *fileDescriptor, num
 		if top == nil {
 			croak("PANIC: null file %v", name)
 		}
-		if top.topMatter == nil {
-			croak("PANIC: per_file mode, file is missing top matter %v", name)
+
+		loc := top.find(newPathVector(packagePath))
+		if loc != nil {
+			g.generateComment(newLocationDescriptor(loc, top), name)
 		}
-		g.generateComment(newLocationDescriptor(top.topMatter.location, top), name)
 	} else {
 		g.generateComment(g.currentPackage.location(), name)
 	}

--- a/protoc-gen-docs/pageTopMatter.go
+++ b/protoc-gen-docs/pageTopMatter.go
@@ -27,7 +27,6 @@ type pageTopMatter struct {
 	overview     string
 	homeLocation string
 	frontMatter  []string
-	location     *descriptor.SourceCodeInfo_Location
 }
 
 const (
@@ -80,7 +79,6 @@ func makeTopMatter(name string, loc *descriptor.SourceCodeInfo_Location) *pageTo
 			overview:     overview,
 			homeLocation: homeLocation,
 			frontMatter:  frontMatter,
-			location:     loc,
 		}
 	}
 	return nil


### PR DESCRIPTION
When a proto file is missing its top matter (title, overview, homeLocation, frontMatter), produce a helpful error message rather than segfault on nil dereference.