### PR TITLE
Isotope: Add convert's application code

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -20,14 +20,35 @@
   version = "v1.0.0"
 
 [[projects]]
+  name = "github.com/gogo/protobuf"
+  packages = [
+    "proto",
+    "sortkeys"
+  ]
+  revision = "636bf0302bc95575d69441b25a2603156ffdddf1"
+  version = "v1.1.1"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/golang/glog"
+  packages = ["."]
+  revision = "23def4e6c14b4da8ac2ed8007337bc5eb5007998"
+
+[[projects]]
   name = "github.com/golang/protobuf"
   packages = [
     "proto",
     "protoc-gen-go/descriptor",
     "protoc-gen-go/plugin"
   ]
-  revision = "925541529c1fa6821df4e44ce2723319eb2be768"
-  version = "v1.0.0"
+  revision = "b4deda0973fb4c70b50d226b1af49f3da59f5265"
+  version = "v1.1.0"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/google/gofuzz"
+  packages = ["."]
+  revision = "24818f796faf91cd76ec7bddd72458fbced7a6c1"
 
 [[projects]]
   branch = "master"
@@ -40,6 +61,12 @@
   name = "github.com/hashicorp/go-multierror"
   packages = ["."]
   revision = "3d5d8f294aa03d8e98859feac328afbdf1ae0703"
+
+[[projects]]
+  name = "github.com/inconshreveable/mousetrap"
+  packages = ["."]
+  revision = "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75"
+  version = "v1.0"
 
 [[projects]]
   name = "github.com/matttproud/golang_protobuf_extensions"
@@ -90,6 +117,56 @@
   revision = "86672fcb3f950f35f2e675df2240550f2a50762f"
 
 [[projects]]
+  name = "github.com/spf13/cobra"
+  packages = ["."]
+  revision = "ef82de70bb3f60c65fb8eebacbb2d122ef517385"
+  version = "v0.0.3"
+
+[[projects]]
+  name = "github.com/spf13/pflag"
+  packages = ["."]
+  revision = "9a97c102cda95a86cec2345a6f09f55a939babf5"
+  version = "v1.0.2"
+
+[[projects]]
+  branch = "master"
+  name = "golang.org/x/net"
+  packages = [
+    "http/httpguts",
+    "http2",
+    "http2/hpack",
+    "idna"
+  ]
+  revision = "aaf60122140d3fcf75376d319f0554393160eb50"
+
+[[projects]]
+  name = "golang.org/x/text"
+  packages = [
+    "collate",
+    "collate/build",
+    "internal/colltab",
+    "internal/gen",
+    "internal/tag",
+    "internal/triegen",
+    "internal/ucd",
+    "language",
+    "secure/bidirule",
+    "transform",
+    "unicode/bidi",
+    "unicode/cldr",
+    "unicode/norm",
+    "unicode/rangetable"
+  ]
+  revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
+  version = "v0.3.0"
+
+[[projects]]
+  name = "gopkg.in/inf.v0"
+  packages = ["."]
+  revision = "d2d2541c53f18d2a059457998ce2876cc8e67cbf"
+  version = "v0.9.1"
+
+[[projects]]
   name = "gopkg.in/russross/blackfriday.v2"
   packages = ["."]
   revision = "cadec560ec52d93835bf2f15bd794700d3a2473b"
@@ -107,9 +184,46 @@
   revision = "d13f3b92c63db22136bac4e0896562404bd4ef6e"
   version = "v1.1.0"
 
+[[projects]]
+  branch = "master"
+  name = "k8s.io/api"
+  packages = [
+    "apps/v1",
+    "core/v1"
+  ]
+  revision = "f5c295feaba2cbc946f0bbb8b535fc5f6a0345ee"
+
+[[projects]]
+  branch = "master"
+  name = "k8s.io/apimachinery"
+  packages = [
+    "pkg/api/resource",
+    "pkg/apis/meta/v1",
+    "pkg/conversion",
+    "pkg/conversion/queryparams",
+    "pkg/fields",
+    "pkg/labels",
+    "pkg/runtime",
+    "pkg/runtime/schema",
+    "pkg/selection",
+    "pkg/types",
+    "pkg/util/errors",
+    "pkg/util/intstr",
+    "pkg/util/json",
+    "pkg/util/naming",
+    "pkg/util/net",
+    "pkg/util/runtime",
+    "pkg/util/sets",
+    "pkg/util/validation",
+    "pkg/util/validation/field",
+    "pkg/watch",
+    "third_party/forked/golang/reflect"
+  ]
+  revision = "ef51ab160544f9d05b68e132a4af0b0fab459954"
+
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "becb0a3d1da55c890cfe361ace75b3ae81d9bc1f5d3f7acc28b49df5fbaad2ef"
+  inputs-digest = "d8459ad20da8980f51010c66a7241612acb23a63be0a47d261685949a6744292"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/isotope/convert/README.md
+++ b/isotope/convert/README.md
@@ -1,0 +1,16 @@
+# Converter
+
+This subdirectory contains the Go command which converts topology YAML to
+various formats.
+
+The root main.go outputs a [Cobra](https://github.com/spf13/cobra) CLI for
+controlling the behavior of the program.
+
+## Conversion Outputs
+
+- __Graphviz__ (`go run main.go graphviz <topology_path> <output>`):
+  Generates [Graphviz](https://www.graphviz.org) [DOT
+  language](https://www.graphviz.org/doc/info/lang.html)
+- __Kubernetes__ (`go run main.go kubernetes <topology_path> ...`):
+  Generates services and deployments for all topology services and the
+  [Fortio](https://github.com/istio/fortio) client to load test against them.

--- a/isotope/convert/cmd/graphviz.go
+++ b/isotope/convert/cmd/graphviz.go
@@ -1,0 +1,51 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this currentFile except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"io/ioutil"
+
+	"github.com/ghodss/yaml"
+	"github.com/spf13/cobra"
+	"istio.io/tools/isotope/convert/pkg/graph"
+	"istio.io/tools/isotope/convert/pkg/graphviz"
+)
+
+// graphvizCmd represents the graphviz command
+var graphvizCmd = &cobra.Command{
+	Use:   "graphviz [YAML file] [output file]",
+	Short: "Convert a .yaml file to a Graphviz DOT language file",
+	Args:  cobra.ExactArgs(2),
+	Run: func(cmd *cobra.Command, args []string) {
+		inFileName := args[0]
+		yamlContents, err := ioutil.ReadFile(inFileName)
+		exitIfError(err)
+
+		var serviceGraph graph.ServiceGraph
+		err = yaml.Unmarshal(yamlContents, &serviceGraph)
+		exitIfError(err)
+
+		dotLang, err := graphviz.ServiceGraphToDotLanguage(serviceGraph)
+		exitIfError(err)
+
+		outFileName := args[1]
+		err = ioutil.WriteFile(outFileName, []byte(dotLang), 0644)
+		exitIfError(err)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(graphvizCmd)
+}

--- a/isotope/convert/cmd/kubernetes.go
+++ b/isotope/convert/cmd/kubernetes.go
@@ -1,0 +1,106 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this currentFile except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"io/ioutil"
+	"strings"
+
+	"github.com/ghodss/yaml"
+	"github.com/spf13/cobra"
+	"istio.io/tools/isotope/convert/pkg/graph"
+	"istio.io/tools/isotope/convert/pkg/kubernetes"
+)
+
+// kubernetesCmd represents the kubernetes command
+var kubernetesCmd = &cobra.Command{
+	Use:   "kubernetes",
+	Short: "Convert service graph YAML to manifests for performance testing",
+	Args:  cobra.ExactArgs(4),
+	Run: func(cmd *cobra.Command, args []string) {
+		inPath := args[0]
+		outPath := args[1]
+
+		serviceNodeSelectorStr := args[2]
+		serviceNodeSelector, err := extractNodeSelector(
+			serviceNodeSelectorStr)
+		exitIfError(err)
+
+		clientNodeSelectorStr := args[3]
+		clientNodeSelector, err := extractNodeSelector(clientNodeSelectorStr)
+		exitIfError(err)
+
+		serviceImage, err := cmd.PersistentFlags().GetString("service-image")
+		exitIfError(err)
+
+		serviceMaxIdleConnectionsPerHost, err :=
+			cmd.PersistentFlags().GetInt("service-max-idle-connections-per-host")
+		exitIfError(err)
+
+		clientImage, err := cmd.PersistentFlags().GetString("client-image")
+		exitIfError(err)
+
+		yamlContents, err := ioutil.ReadFile(inPath)
+		exitIfError(err)
+
+		var serviceGraph graph.ServiceGraph
+		exitIfError(yaml.Unmarshal(yamlContents, &serviceGraph))
+
+		manifests, err := kubernetes.ServiceGraphToKubernetesManifests(
+			serviceGraph, serviceNodeSelector, serviceImage,
+			serviceMaxIdleConnectionsPerHost, clientNodeSelector, clientImage)
+		exitIfError(err)
+
+		exitIfError(writeManifest(outPath, manifests))
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(kubernetesCmd)
+	kubernetesCmd.PersistentFlags().String(
+		"service-image", "", "the image to deploy for all services in the graph")
+	kubernetesCmd.PersistentFlags().Int(
+		"service-max-idle-connections-per-host", 0,
+		"maximum number of connections to keep open per host on each service")
+	kubernetesCmd.PersistentFlags().String(
+		"client-image", "", "the image to use for the load testing client job")
+}
+
+func writeManifest(path string, manifest []byte) error {
+	// 0644 allows owner to read/write and others to read.
+	return ioutil.WriteFile(path, manifest, 0644)
+}
+
+func splitByEquals(s string) (k string, v string, err error) {
+	parts := strings.Split(s, "=")
+	if len(parts) != 2 {
+		err = fmt.Errorf("%s is not a valid node selector", s)
+		return
+	}
+	k = parts[0]
+	v = parts[1]
+	return
+}
+
+func extractNodeSelector(s string) (map[string]string, error) {
+	nodeSelector := make(map[string]string, 1)
+	k, v, err := splitByEquals(s)
+	if err != nil {
+		return nodeSelector, err
+	}
+	nodeSelector[k] = v
+	return nodeSelector, nil
+}

--- a/isotope/convert/cmd/root.go
+++ b/isotope/convert/cmd/root.go
@@ -1,0 +1,43 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this currentFile except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// rootCmd represents the base command when called without any subcommands
+var rootCmd = &cobra.Command{
+	Use:   "service-grapher",
+	Short: "Converts a service graph expressed in YAML to various formats",
+}
+
+// Execute adds all child commands to the root command and sets flags
+// appropriately. This is called by main.main(). It only needs to happen once to
+// the rootCmd.
+func Execute() {
+	err := rootCmd.Execute()
+	exitIfError(err)
+}
+
+func exitIfError(err error) {
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}

--- a/isotope/convert/main.go
+++ b/isotope/convert/main.go
@@ -1,0 +1,21 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this currentFile except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import "istio.io/tools/isotope/convert/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/isotope/convert/pkg/graphviz/graphviz.go
+++ b/isotope/convert/pkg/graphviz/graphviz.go
@@ -1,0 +1,219 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this currentFile except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package graphviz converts service graphs into Graphviz DOT language.
+package graphviz
+
+import (
+	"bytes"
+	"fmt"
+	"text/template"
+
+	"istio.io/tools/isotope/convert/pkg/graph"
+	"istio.io/tools/isotope/convert/pkg/graph/script"
+	"istio.io/tools/isotope/convert/pkg/graph/svc"
+)
+
+// ServiceGraphToDotLanguage converts a ServiceGraph to a Graphviz DOT language
+// string.
+func ServiceGraphToDotLanguage(
+	serviceGraph graph.ServiceGraph) (string, error) {
+	graph, err := ServiceGraphToGraph(serviceGraph)
+	if err != nil {
+		return "", err
+	}
+	dotLang, err := GraphToDotLanguage(graph)
+	if err != nil {
+		return "", err
+	}
+	return dotLang, nil
+}
+
+// GraphToDotLanguage converts a graphviz graph to a Graphviz DOT language
+// string via a template.
+func GraphToDotLanguage(g Graph) (string, error) {
+	tmpl, err := template.New("digraph").Parse(graphvizTemplate)
+	if err != nil {
+		return "", err
+	}
+
+	var b bytes.Buffer
+	err = tmpl.Execute(&b, g)
+	if err != nil {
+		return "", err
+	}
+	return b.String(), nil
+}
+
+// ServiceGraphToGraph converts a service graph to a graphviz graph.
+func ServiceGraphToGraph(sg graph.ServiceGraph) (Graph, error) {
+	nodes := make([]Node, 0, len(sg.Services))
+	edges := make([]Edge, 0, len(sg.Services))
+	for _, service := range sg.Services {
+		node, connections, err := toGraphvizNode(service)
+		if err != nil {
+			return Graph{}, err
+		}
+		nodes = append(nodes, node)
+		for _, connection := range connections {
+			edges = append(edges, connection)
+		}
+	}
+	return Graph{
+		Nodes: nodes,
+		Edges: edges,
+	}, nil
+}
+
+// Graph represents a Graphviz graph.
+type Graph struct {
+	Nodes []Node
+	Edges []Edge
+}
+
+// Node represents a node in the Graphviz graph.
+type Node struct {
+	Name         string
+	Type         string
+	ErrorRate    string
+	ResponseSize string
+	Steps        [][]string
+}
+
+// Edge represents a directed edge in the Graphviz graph.
+type Edge struct {
+	From      string
+	To        string
+	StepIndex int
+}
+
+const graphvizTemplate = `digraph {
+  node [
+    fontsize = "16"
+    fontname = "courier"
+    shape = plaintext
+  ];
+
+  {{ range .Nodes -}}
+  {{ .Name }} [label=<
+<TABLE BORDER="0" CELLBORDER="1" CELLSPACING="0">
+  <TR><TD><B>{{ .Name }}</B><BR />Type: {{ .Type }}<BR />Err: {{ .ErrorRate }}</TD></TR>
+  {{- range $i, $cmds := .Steps }}
+  <TR><TD PORT="{{ $i }}">
+  {{- range $j, $cmd := $cmds -}}
+    {{- if $j -}}<BR />{{- end -}}
+    {{- $cmd -}}
+  {{- end -}}
+  </TD></TR>
+  {{- end }}
+</TABLE>>];
+
+  {{ end }}
+
+  {{- range .Edges }}
+  {{ .From -}}:{{- .StepIndex }} -> {{ .To }}
+  {{- end }}
+}
+`
+
+func getEdgesFromExe(
+	exe script.Command, idx int, fromServiceName string) (edges []Edge) {
+	switch cmd := exe.(type) {
+	case script.ConcurrentCommand:
+		for _, subCmd := range cmd {
+			subEdges := getEdgesFromExe(subCmd, idx, fromServiceName)
+			for _, e := range subEdges {
+				edges = append(edges, e)
+			}
+		}
+	case script.RequestCommand:
+		e := Edge{
+			From:      fromServiceName,
+			To:        cmd.ServiceName,
+			StepIndex: idx,
+		}
+		edges = append(edges, e)
+	}
+	return
+}
+
+func toGraphvizNode(service svc.Service) (Node, []Edge, error) {
+	steps := make([][]string, 0, len(service.Script))
+	edges := make([]Edge, 0, len(service.Script))
+	for idx, exe := range service.Script {
+		step, err := executableToStringSlice(exe)
+		if err != nil {
+			return Node{}, nil, err
+		}
+		steps = append(steps, step)
+
+		stepEdges := getEdgesFromExe(exe, idx, service.Name)
+		for _, e := range stepEdges {
+			edges = append(edges, e)
+		}
+	}
+	n := Node{
+		Name:         service.Name,
+		Type:         service.Type.String(),
+		ErrorRate:    service.ErrorRate.String(),
+		ResponseSize: service.ResponseSize.String(),
+		Steps:        steps,
+	}
+	return n, edges, nil
+}
+
+func nonConcurrentCommandToString(exe script.Command) (string, error) {
+	switch cmd := exe.(type) {
+	case script.SleepCommand:
+		return fmt.Sprintf("SLEEP %s", cmd), nil
+	case script.RequestCommand:
+		return fmt.Sprintf(
+			"CALL \"%s\" %s",
+			cmd.ServiceName, cmd.Size.String()), nil
+	default:
+		return "", fmt.Errorf("unexpected type of executable %T", exe)
+	}
+}
+
+func executableToStringSlice(exe script.Command) ([]string, error) {
+	slice := make([]string, 0, 1)
+	appendNonConcurrentExe := func(exe script.Command) error {
+		s, err := nonConcurrentCommandToString(exe)
+		if err != nil {
+			return err
+		}
+		slice = append(slice, s)
+		return nil
+	}
+
+	switch cmd := exe.(type) {
+	case script.SleepCommand:
+		if err := appendNonConcurrentExe(exe); err != nil {
+			return nil, err
+		}
+	case script.RequestCommand:
+		if err := appendNonConcurrentExe(exe); err != nil {
+			return nil, err
+		}
+	case script.ConcurrentCommand:
+		for _, exe := range cmd {
+			if err := appendNonConcurrentExe(exe); err != nil {
+				return nil, err
+			}
+		}
+	default:
+		return nil, fmt.Errorf("unexpected type of executable %T", exe)
+	}
+	return slice, nil
+}

--- a/isotope/convert/pkg/graphviz/graphviz_test.go
+++ b/isotope/convert/pkg/graphviz/graphviz_test.go
@@ -1,0 +1,211 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this currentFile except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package graphviz
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+	"time"
+
+	"istio.io/tools/isotope/convert/pkg/graph"
+	"istio.io/tools/isotope/convert/pkg/graph/script"
+	"istio.io/tools/isotope/convert/pkg/graph/svc"
+	"istio.io/tools/isotope/convert/pkg/graph/svctype"
+)
+
+func TestServiceGraphToGraph(t *testing.T) {
+	expected := Graph{
+		Nodes: []Node{
+			Node{
+				Name:         "a",
+				Type:         "HTTP",
+				ErrorRate:    "0.01%",
+				ResponseSize: "10KiB",
+				Steps: [][]string{
+					[]string{
+						"SLEEP 100ms",
+					},
+				},
+			},
+			Node{
+				Name:         "b",
+				Type:         "gRPC",
+				ErrorRate:    "0.00%",
+				ResponseSize: "10KiB",
+				Steps:        [][]string{},
+			},
+			Node{
+				Name:         "c",
+				Type:         "HTTP",
+				ErrorRate:    "0.00%",
+				ResponseSize: "10KiB",
+				Steps: [][]string{
+					[]string{
+						"CALL \"a\" 10KiB",
+					},
+					[]string{
+						"CALL \"b\" 1KiB",
+					},
+				},
+			},
+			Node{
+				Name:         "d",
+				Type:         "HTTP",
+				ErrorRate:    "0.00%",
+				ResponseSize: "10KiB",
+				Steps: [][]string{
+					[]string{
+						"CALL \"a\" 1KiB",
+						"CALL \"c\" 1KiB",
+					},
+					[]string{
+						"SLEEP 10ms",
+					},
+					[]string{
+						"CALL \"b\" 1KiB",
+					},
+				},
+			},
+		},
+		Edges: []Edge{
+			Edge{
+				From:      "c",
+				To:        "a",
+				StepIndex: 0,
+			},
+			Edge{
+				From:      "c",
+				To:        "b",
+				StepIndex: 1,
+			},
+			Edge{
+				From:      "d",
+				To:        "a",
+				StepIndex: 0,
+			},
+			Edge{
+				From:      "d",
+				To:        "c",
+				StepIndex: 0,
+			},
+			Edge{
+				From:      "d",
+				To:        "b",
+				StepIndex: 2,
+			},
+		},
+	}
+
+	serviceGraph := graph.ServiceGraph{
+		Services: []svc.Service{
+			{
+				Name:         "a",
+				Type:         svctype.ServiceHTTP,
+				ErrorRate:    0.0001,
+				ResponseSize: 10240,
+				Script: []script.Command{
+					script.SleepCommand(100 * time.Millisecond),
+				},
+			},
+			{
+				Name:         "b",
+				Type:         svctype.ServiceGRPC,
+				ErrorRate:    0,
+				ResponseSize: 10240,
+			},
+			{
+				Name:         "c",
+				Type:         svctype.ServiceHTTP,
+				ErrorRate:    0,
+				ResponseSize: 10240,
+				Script: []script.Command{
+					script.RequestCommand{
+						ServiceName: "a",
+						Size:        10240,
+					},
+					script.RequestCommand{
+						ServiceName: "b",
+						Size:        1024,
+					},
+				},
+			},
+			{
+				Name:         "d",
+				Type:         svctype.ServiceHTTP,
+				ErrorRate:    0,
+				ResponseSize: 10240,
+				Script: []script.Command{
+					script.ConcurrentCommand([]script.Command{
+						script.RequestCommand{
+							ServiceName: "a",
+							Size:        1024,
+						},
+						script.RequestCommand{
+							ServiceName: "c",
+							Size:        1024,
+						},
+					}),
+					script.SleepCommand(10 * time.Millisecond),
+					script.RequestCommand{
+						ServiceName: "b",
+						Size:        1024,
+					},
+				},
+			},
+		},
+	}
+	actual, err := ServiceGraphToGraph(serviceGraph)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !graphsAreEqual(expected, actual) {
+		t.Errorf("\nexpect: %+v, \nactual: %+v", expected, actual)
+	}
+}
+
+func graphsAreEqual(left Graph, right Graph) bool {
+	return reflect.DeepEqual(left, right)
+}
+
+func sortNodes(nodes []Node) {
+	sort.SliceStable(nodes, func(i int, j int) bool {
+		leftNode := nodes[i]
+		rightNode := nodes[j]
+		return leftNode.Name < rightNode.Name
+	})
+}
+
+// sortEdges sorts edges by From, StepIndex, To.
+func sortEdges(edges []Edge) {
+	sort.SliceStable(edges, func(i int, j int) bool {
+		leftEdge := edges[i]
+		rightEdge := edges[j]
+		return leftEdgeIsLessThanRightEdge(leftEdge, rightEdge)
+	})
+}
+
+func leftEdgeIsLessThanRightEdge(left Edge, right Edge) (isLess bool) {
+	if left.From == right.From {
+		if left.StepIndex == right.StepIndex {
+			isLess = left.To < right.To
+		} else {
+			isLess = left.StepIndex < right.StepIndex
+		}
+	} else {
+		isLess = left.From < right.From
+	}
+	return
+}

--- a/isotope/convert/pkg/kubernetes/fortio_client.go
+++ b/isotope/convert/pkg/kubernetes/fortio_client.go
@@ -1,0 +1,77 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this currentFile except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package kubernetes converts service graphs into Kubernetes manifests.
+package kubernetes
+
+import (
+	"istio.io/tools/isotope/convert/pkg/consts"
+	appsv1 "k8s.io/api/apps/v1"
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var fortioClientLabels = map[string]string{"app": "client"}
+
+func makeFortioDeployment(
+	nodeSelector map[string]string,
+	clientImage string) (deployment appsv1.Deployment) {
+	deployment.APIVersion = "apps/v1"
+	deployment.Kind = "Deployment"
+	deployment.ObjectMeta.Name = "client"
+	deployment.ObjectMeta.Labels = fortioClientLabels
+	timestamp(&deployment.ObjectMeta)
+	deployment.Spec = appsv1.DeploymentSpec{
+		Selector: &metav1.LabelSelector{
+			MatchLabels: fortioClientLabels,
+		},
+		Template: apiv1.PodTemplateSpec{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: fortioClientLabels,
+			},
+			Spec: apiv1.PodSpec{
+				NodeSelector: nodeSelector,
+				Containers: []apiv1.Container{
+					{
+						Name:  "fortio-client",
+						Image: clientImage,
+						Args:  []string{"server"},
+						Ports: []apiv1.ContainerPort{
+							{
+								ContainerPort: consts.ServicePort,
+							},
+							{
+								ContainerPort: consts.FortioMetricsPort,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	timestamp(&deployment.Spec.Template.ObjectMeta)
+	return
+}
+
+func makeFortioService() (service apiv1.Service) {
+	service.APIVersion = "v1"
+	service.Kind = "Service"
+	service.ObjectMeta.Name = "client"
+	service.ObjectMeta.Labels = fortioClientLabels
+	service.ObjectMeta.Annotations = prometheusScrapeAnnotations
+	timestamp(&service.ObjectMeta)
+	service.Spec.Ports = []apiv1.ServicePort{{Port: consts.ServicePort}}
+	service.Spec.Selector = fortioClientLabels
+	return
+}

--- a/isotope/convert/pkg/kubernetes/kubernetes.go
+++ b/isotope/convert/pkg/kubernetes/kubernetes.go
@@ -1,0 +1,254 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this currentFile except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package kubernetes converts service graphs into Kubernetes manifests.
+package kubernetes
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/ghodss/yaml"
+	"istio.io/tools/isotope/convert/pkg/consts"
+	"istio.io/tools/isotope/convert/pkg/graph"
+	"istio.io/tools/isotope/convert/pkg/graph/svc"
+	appsv1 "k8s.io/api/apps/v1"
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	// ServiceGraphNamespace is the namespace all service graph related resources
+	// (i.e. ConfigMap, Services, and Deployments) will reside in.
+	ServiceGraphNamespace = "service-graph"
+
+	numConfigMaps          = 1
+	numManifestsPerService = 2
+
+	configVolume           = "config-volume"
+	serviceGraphConfigName = "service-graph-config"
+)
+
+var (
+	serviceGraphAppLabels       = map[string]string{"app": "service-graph"}
+	serviceGraphNodeLabels      = map[string]string{"role": "service"}
+	prometheusScrapeAnnotations = map[string]string{
+		"prometheus.io/scrape": "true"}
+)
+
+// ServiceGraphToKubernetesManifests converts a ServiceGraph to Kubernetes
+// manifests.
+func ServiceGraphToKubernetesManifests(
+	serviceGraph graph.ServiceGraph,
+	serviceNodeSelector map[string]string,
+	serviceImage string,
+	serviceMaxIdleConnectionsPerHost int,
+	clientNodeSelector map[string]string,
+	clientImage string) ([]byte, error) {
+	numServices := len(serviceGraph.Services)
+	numManifests := numManifestsPerService*numServices + numConfigMaps
+	manifests := make([]string, 0, numManifests)
+
+	appendManifest := func(manifest interface{}) error {
+		yamlDoc, err := yaml.Marshal(manifest)
+		if err != nil {
+			return err
+		}
+		manifests = append(manifests, string(yamlDoc))
+		return nil
+	}
+
+	namespace := makeServiceGraphNamespace()
+	if err := appendManifest(namespace); err != nil {
+		return nil, err
+	}
+
+	configMap, err := makeConfigMap(serviceGraph)
+	if err != nil {
+		return nil, err
+	}
+	if err := appendManifest(configMap); err != nil {
+		return nil, err
+	}
+
+	for _, service := range serviceGraph.Services {
+		k8sDeployment, innerErr := makeDeployment(
+			service, serviceNodeSelector, serviceImage,
+			serviceMaxIdleConnectionsPerHost)
+		if innerErr != nil {
+			return nil, innerErr
+		}
+		innerErr = appendManifest(k8sDeployment)
+		if innerErr != nil {
+			return nil, innerErr
+		}
+
+		k8sService, innerErr := makeService(service)
+		if innerErr != nil {
+			return nil, innerErr
+		}
+		innerErr = appendManifest(k8sService)
+		if innerErr != nil {
+			return nil, innerErr
+		}
+	}
+
+	fortioDeployment := makeFortioDeployment(
+		clientNodeSelector, clientImage)
+	if err := appendManifest(fortioDeployment); err != nil {
+		return nil, err
+	}
+
+	fortioService := makeFortioService()
+	if err := appendManifest(fortioService); err != nil {
+		return nil, err
+	}
+
+	yamlDocString := strings.Join(manifests, "---\n")
+	return []byte(yamlDocString), nil
+}
+
+func combineLabels(a, b map[string]string) map[string]string {
+	c := make(map[string]string, len(a)+len(b))
+	for k, v := range a {
+		c[k] = v
+	}
+	for k, v := range b {
+		c[k] = v
+	}
+	return c
+}
+
+func makeServiceGraphNamespace() (namespace apiv1.Namespace) {
+	namespace.APIVersion = "v1"
+	namespace.Kind = "Namespace"
+	namespace.ObjectMeta.Name = consts.ServiceGraphNamespace
+	namespace.ObjectMeta.Labels = map[string]string{"istio-injection": "enabled"}
+	timestamp(&namespace.ObjectMeta)
+	return
+}
+
+func makeConfigMap(
+	graph graph.ServiceGraph) (configMap apiv1.ConfigMap, err error) {
+	graphYAMLBytes, err := yaml.Marshal(graph)
+	if err != nil {
+		return
+	}
+	configMap.APIVersion = "v1"
+	configMap.Kind = "ConfigMap"
+	configMap.ObjectMeta.Name = serviceGraphConfigName
+	configMap.ObjectMeta.Namespace = ServiceGraphNamespace
+	configMap.ObjectMeta.Labels = serviceGraphAppLabels
+	timestamp(&configMap.ObjectMeta)
+	configMap.Data = map[string]string{
+		consts.ServiceGraphConfigMapKey: string(graphYAMLBytes),
+	}
+	return
+}
+
+func makeService(service svc.Service) (k8sService apiv1.Service, err error) {
+	k8sService.APIVersion = "v1"
+	k8sService.Kind = "Service"
+	k8sService.ObjectMeta.Name = service.Name
+	k8sService.ObjectMeta.Namespace = ServiceGraphNamespace
+	k8sService.ObjectMeta.Labels = serviceGraphAppLabels
+	k8sService.ObjectMeta.Annotations = prometheusScrapeAnnotations
+	timestamp(&k8sService.ObjectMeta)
+	k8sService.Spec.Ports = []apiv1.ServicePort{{Port: consts.ServicePort}}
+	k8sService.Spec.Selector = map[string]string{"name": service.Name}
+	return
+}
+
+func makeDeployment(
+	service svc.Service, nodeSelector map[string]string,
+	serviceImage string, serviceMaxIdleConnectionsPerHost int) (
+	k8sDeployment appsv1.Deployment, err error) {
+	k8sDeployment.APIVersion = "apps/v1"
+	k8sDeployment.Kind = "Deployment"
+	k8sDeployment.ObjectMeta.Name = service.Name
+	k8sDeployment.ObjectMeta.Namespace = ServiceGraphNamespace
+	k8sDeployment.ObjectMeta.Labels = serviceGraphAppLabels
+	k8sDeployment.ObjectMeta.Annotations = prometheusScrapeAnnotations
+	timestamp(&k8sDeployment.ObjectMeta)
+	k8sDeployment.Spec = appsv1.DeploymentSpec{
+		Replicas: &service.NumReplicas,
+		Selector: &metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				"name": service.Name,
+			},
+		},
+		Template: apiv1.PodTemplateSpec{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: combineLabels(
+					serviceGraphNodeLabels,
+					map[string]string{
+						"name": service.Name,
+					}),
+			},
+			Spec: apiv1.PodSpec{
+				NodeSelector: nodeSelector,
+				Containers: []apiv1.Container{
+					apiv1.Container{
+						Name:  consts.ServiceContainerName,
+						Image: serviceImage,
+						Args: []string{
+							fmt.Sprintf(
+								"--max-idle-connections-per-host=%v",
+								serviceMaxIdleConnectionsPerHost),
+						},
+						Env: []apiv1.EnvVar{
+							{Name: consts.ServiceNameEnvKey, Value: service.Name},
+						},
+						VolumeMounts: []apiv1.VolumeMount{
+							{
+								Name:      configVolume,
+								MountPath: consts.ConfigPath,
+							},
+						},
+						Ports: []apiv1.ContainerPort{
+							{
+								ContainerPort: consts.ServicePort,
+							},
+						},
+					},
+				},
+				Volumes: []apiv1.Volume{
+					{
+						Name: configVolume,
+						VolumeSource: apiv1.VolumeSource{
+							ConfigMap: &apiv1.ConfigMapVolumeSource{
+								LocalObjectReference: apiv1.LocalObjectReference{
+									Name: serviceGraphConfigName,
+								},
+								Items: []apiv1.KeyToPath{
+									{
+										Key:  consts.ServiceGraphConfigMapKey,
+										Path: consts.ServiceGraphYAMLFileName,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	timestamp(&k8sDeployment.Spec.Template.ObjectMeta)
+	return
+}
+
+func timestamp(objectMeta *metav1.ObjectMeta) {
+	objectMeta.CreationTimestamp = metav1.Time{Time: time.Now()}
+}


### PR DESCRIPTION
#6 added the "library code" necessary for converting topology YAML to other formats.

This PR adds the "application code" to call those library functions, including a [cobra](https://github.com/spf13/cobra) CLI to run the application.

Through the CLI, you can convert topology YAML to either a [Graphviz DOT](https://www.graphviz.org/doc/info/lang.html) file Kubernetes manifests (including a ConfigMap and Deployments/Services for the [fortio](https://github.com/istio/fortio) client and topology services).

A subsequent PR will add the Python scripts to run the convert program.

Added dependencies:

- [spf13/cobra](https://github.com/spf13/cobra)
- [ghodss/yaml](https://github.com/ghodss/yaml)
- [k8s.io/api](https://github.com/kubernetes/api)
- [k8s.io/apimachinery](https://github.com/kubernetes/apimachinery)

[Isotope design doc](https://docs.google.com/document/d/1R0kM19mATEoSmX7ZGRN_LCeh7h-8f5bNmhLR1Y8hKuc/view)

/cc @mandarjog @costinm 
/assign @mandarjog @costinm 