### PR TITLE
Isotope: Add containerized service application

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,10 +2,22 @@
 
 
 [[projects]]
+  branch = "master"
+  name = "github.com/beorn7/perks"
+  packages = ["quantile"]
+  revision = "3a771d992973f24aa725d07868b467d1ddfceafb"
+
+[[projects]]
   name = "github.com/docker/go-units"
   packages = ["."]
   revision = "47565b4f722fb6ceae66b95f853feed578a4a51c"
   version = "v0.3.3"
+
+[[projects]]
+  name = "github.com/ghodss/yaml"
+  packages = ["."]
+  revision = "0ca9ea5df5451ffdf184b4428c902747c2c11cd7"
+  version = "v1.0.0"
 
 [[projects]]
   name = "github.com/golang/protobuf"
@@ -19,6 +31,60 @@
 
 [[projects]]
   branch = "master"
+  name = "github.com/hashicorp/errwrap"
+  packages = ["."]
+  revision = "d6c0cd88035724dd42e0f335ae30161c20575ecc"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/hashicorp/go-multierror"
+  packages = ["."]
+  revision = "3d5d8f294aa03d8e98859feac328afbdf1ae0703"
+
+[[projects]]
+  name = "github.com/matttproud/golang_protobuf_extensions"
+  packages = ["pbutil"]
+  revision = "c12348ce28de40eed0136aa2b644d0ee0650e56c"
+  version = "v1.0.1"
+
+[[projects]]
+  name = "github.com/prometheus/client_golang"
+  packages = [
+    "prometheus",
+    "prometheus/promhttp"
+  ]
+  revision = "c5b7fccd204277076155f10851dad72b76a49317"
+  version = "v0.8.0"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/prometheus/client_model"
+  packages = ["go"]
+  revision = "5c3871d89910bfb32f5fcab2aa4b9ec68e65a99f"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/prometheus/common"
+  packages = [
+    "expfmt",
+    "internal/bitbucket.org/ww/goautoneg",
+    "model"
+  ]
+  revision = "c7de2306084e37d54b8be01f3541a8464345e9a5"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/prometheus/procfs"
+  packages = [
+    ".",
+    "internal/util",
+    "nfs",
+    "xfs"
+  ]
+  revision = "05ee40e3a273f7245e8777337fc7b46e533a9a92"
+
+[[projects]]
+  branch = "master"
   name = "github.com/shurcooL/sanitized_anchor_name"
   packages = ["."]
   revision = "86672fcb3f950f35f2e675df2240550f2a50762f"
@@ -29,9 +95,21 @@
   revision = "cadec560ec52d93835bf2f15bd794700d3a2473b"
   version = "v2.0.0"
 
+[[projects]]
+  name = "gopkg.in/yaml.v2"
+  packages = ["."]
+  revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
+  version = "v2.2.1"
+
+[[projects]]
+  name = "istio.io/fortio"
+  packages = ["log"]
+  revision = "1e338e499d8ae134dcc32ad63825e7b972158687"
+  version = "v1.0.1"
+
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "89badf1e30b594f2cdf52d38471be8934c77d367b65df45f437170a6d3bcff31"
+  inputs-digest = "becb0a3d1da55c890cfe361ace75b3ae81d9bc1f5d3f7acc28b49df5fbaad2ef"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -104,8 +104,8 @@
 [[projects]]
   name = "istio.io/fortio"
   packages = ["log"]
-  revision = "1e338e499d8ae134dcc32ad63825e7b972158687"
-  version = "v1.0.1"
+  revision = "d13f3b92c63db22136bac4e0896562404bd4ef6e"
+  version = "v1.1.0"
 
 [solve-meta]
   analyzer-name = "dep"

--- a/isotope/service/Dockerfile
+++ b/isotope/service/Dockerfile
@@ -17,7 +17,7 @@ RUN CGO_ENABLED=0 GOOS=linux \
 
 FROM scratch
 COPY --from=builder \
-    /go/src/istio.io/tools/isotope/service/main /usr/local/bin/service
+    /go/src/istio.io/tools/isotope/service/main /usr/local/bin/isotope_service
 
 EXPOSE 8080
-ENTRYPOINT ["/usr/local/bin/service"]
+ENTRYPOINT ["/usr/local/bin/isotope_service"]

--- a/isotope/service/Dockerfile
+++ b/isotope/service/Dockerfile
@@ -1,0 +1,23 @@
+# Note: this image must be built from the root of the repository for access to
+# the vendor folder.
+
+FROM golang:1.10.2 AS builder
+
+RUN go get -u github.com/golang/dep/cmd/dep
+
+WORKDIR /go/src/istio.io/tools
+
+COPY . .
+RUN dep ensure -vendor-only
+
+WORKDIR /go/src/istio.io/tools/isotope/service
+
+RUN CGO_ENABLED=0 GOOS=linux \
+    go build -a -installsuffix cgo -o ./main ./main.go
+
+FROM scratch
+COPY --from=builder \
+    /go/src/istio.io/tools/isotope/service/main /usr/local/bin/service
+
+EXPOSE 8080
+ENTRYPOINT ["/usr/local/bin/service"]

--- a/isotope/service/README.md
+++ b/isotope/service/README.md
@@ -1,0 +1,31 @@
+# Service
+
+This directory holds the "mock-service" component for isotope. It is a
+relatively simple HTTP server which follows instructions from a YAML file and
+exposes Prometheus metrics.
+
+## Usage
+
+1. Include the entire topology YAML in `/etc/config/service-graph.yaml`
+1. Set the environment variable, `SERVICE_NAME`, to the name of the service
+   from the topology YAML that this service should emulate
+
+## Metrics
+
+Captures the following metrics for a Prometheus endpoint:
+
+- `service_incoming_requests_total` - a counter of requests received by this
+  service
+- `service_outgoing_requests_total` - a counter of requests sent to other
+  services
+- `service_outgoing_request_size` - a histogram of sizes of requests sent to
+  other services
+- `service_request_duration_seconds` - a histogram of durations from "request
+  received" to "response sent"
+- `service_response_size` - a histogram of sizes of responses sent from this
+  service
+
+## Performance
+
+Running on a GKE cluster with a limit of 1 vCPU and 3.75 gigabytes of memory,
+and logging set to INFO, this service can reach a maximum QPS of 12,000.

--- a/isotope/service/README.md
+++ b/isotope/service/README.md
@@ -27,5 +27,8 @@ Captures the following metrics for a Prometheus endpoint:
 
 ## Performance
 
-Running on a GKE cluster with a limit of 1 vCPU and 3.75 gigabytes of memory,
-and logging set to INFO, this service can reach a maximum QPS of 12,000.
+With both a Fortio 1.1.0 client and a single isotope service running in a GKE
+cluster, the client on a n1-highcpu-96 machine sending 96 concurrent requests
+as fast as possible, the service on a n1-standard-4 machine with a limit of 1
+vCPU and 3.75GB RAM, and logging set to INFO, the service reaches a maximum
+QPS of 12,000 - 14,000 before maxing out CPU.

--- a/isotope/service/main.go
+++ b/isotope/service/main.go
@@ -68,7 +68,7 @@ func main() {
 	}
 }
 
-func serveWithPrometheus(defaultHandler http.Handler) (err error) {
+func serveWithPrometheus(defaultHandler http.Handler) error {
 	log.Infof(`exposing Prometheus endpoint "%s"`, promEndpoint)
 	http.Handle(promEndpoint, prometheus.Handler())
 
@@ -77,11 +77,10 @@ func serveWithPrometheus(defaultHandler http.Handler) (err error) {
 
 	addr := fmt.Sprintf(":%d", consts.ServicePort)
 	log.Infof("listening on port %v\n", consts.ServicePort)
-	err = http.ListenAndServe(addr, nil)
-	if err != nil {
-		return
+	if err := http.ListenAndServe(addr, nil); err != nil {
+		return err
 	}
-	return
+	return nil
 }
 
 func setMaxProcs() {

--- a/isotope/service/main.go
+++ b/isotope/service/main.go
@@ -22,10 +22,10 @@ import (
 	"path"
 	"runtime"
 
+	"istio.io/fortio/log"
 	"istio.io/tools/isotope/convert/pkg/consts"
 	"istio.io/tools/isotope/service/pkg/srv"
 	"istio.io/tools/isotope/service/pkg/srv/prometheus"
-	"istio.io/fortio/log"
 )
 
 const (

--- a/isotope/service/main.go
+++ b/isotope/service/main.go
@@ -46,8 +46,6 @@ var (
 func main() {
 	flag.Parse()
 
-	log.SetLogLevel(log.Info)
-
 	setMaxProcs()
 	setMaxIdleConnectionsPerHost(*maxIdleConnectionsPerHostFlag)
 

--- a/isotope/service/main.go
+++ b/isotope/service/main.go
@@ -1,0 +1,98 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this currentFile except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"net/http"
+	"os"
+	"path"
+	"runtime"
+
+	"istio.io/tools/isotope/convert/pkg/consts"
+	"istio.io/tools/isotope/service/pkg/srv"
+	"istio.io/tools/isotope/service/pkg/srv/prometheus"
+	"istio.io/fortio/log"
+)
+
+const (
+	promEndpoint    = "/metrics"
+	defaultEndpoint = "/"
+)
+
+var (
+	serviceGraphYAMLFilePath = path.Join(
+		consts.ConfigPath, consts.ServiceGraphYAMLFileName)
+
+	// Set by the Python script when running this through Docker.
+	maxIdleConnectionsPerHostFlag = flag.Int(
+		"max-idle-connections-per-host", 0,
+		"maximum number of TCP connections to keep open per host")
+)
+
+func main() {
+	flag.Parse()
+
+	log.SetLogLevel(log.Info)
+
+	setMaxProcs()
+	setMaxIdleConnectionsPerHost(*maxIdleConnectionsPerHostFlag)
+
+	serviceName, ok := os.LookupEnv(consts.ServiceNameEnvKey)
+	if !ok {
+		log.Fatalf(`env var "%s" is not set`, consts.ServiceNameEnvKey)
+	}
+
+	defaultHandler, err := srv.HandlerFromServiceGraphYAML(
+		serviceGraphYAMLFilePath, serviceName)
+	if err != nil {
+		log.Fatalf("%s", err)
+	}
+
+	err = serveWithPrometheus(defaultHandler)
+	if err != nil {
+		log.Fatalf("%s", err)
+	}
+}
+
+func serveWithPrometheus(defaultHandler http.Handler) (err error) {
+	log.Infof(`exposing Prometheus endpoint "%s"`, promEndpoint)
+	http.Handle(promEndpoint, prometheus.Handler())
+
+	log.Infof(`exposing default endpoint "%s"`, defaultEndpoint)
+	http.Handle(defaultEndpoint, defaultHandler)
+
+	addr := fmt.Sprintf(":%d", consts.ServicePort)
+	log.Infof("listening on port %v\n", consts.ServicePort)
+	err = http.ListenAndServe(addr, nil)
+	if err != nil {
+		return
+	}
+	return
+}
+
+func setMaxProcs() {
+	numCPU := runtime.NumCPU()
+	maxProcs := runtime.GOMAXPROCS(0)
+	if maxProcs < numCPU {
+		log.Infof("setting GOMAXPROCS to %v (previously %v)", numCPU, maxProcs)
+		runtime.GOMAXPROCS(numCPU)
+	}
+}
+
+func setMaxIdleConnectionsPerHost(n int) {
+	http.DefaultTransport.(*http.Transport).MaxIdleConnsPerHost = n
+}

--- a/isotope/service/pkg/srv/graph.go
+++ b/isotope/service/pkg/srv/graph.go
@@ -1,0 +1,103 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this currentFile except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package srv
+
+import (
+	"fmt"
+	"io/ioutil"
+
+	"github.com/ghodss/yaml"
+	"istio.io/fortio/log"
+	"istio.io/tools/isotope/convert/pkg/graph"
+	"istio.io/tools/isotope/convert/pkg/graph/svc"
+	"istio.io/tools/isotope/convert/pkg/graph/svctype"
+)
+
+// HandlerFromServiceGraphYAML makes a handler to emulate the service with name
+// serviceName in the service graph represented by the YAML file at path.
+func HandlerFromServiceGraphYAML(
+	path string, serviceName string) (handler Handler, err error) {
+
+	serviceGraph, err := serviceGraphFromYAMLFile(path)
+	if err != nil {
+		return
+	}
+
+	service, err := extractService(serviceGraph, serviceName)
+	if err != nil {
+		return
+	}
+	logService(service)
+
+	serviceTypes := extractServiceTypes(serviceGraph)
+
+	handler = Handler{
+		Service:      service,
+		ServiceTypes: serviceTypes,
+	}
+	return
+}
+
+func logService(service svc.Service) error {
+	if log.Log(log.Info) {
+		serviceYAML, err := yaml.Marshal(service)
+		if err != nil {
+			return err
+		}
+		log.Infof("acting as service %s:\n%s", service.Name, serviceYAML)
+	}
+	return nil
+}
+
+// serviceGraphFromYAMLFile unmarshals the ServiceGraph from the YAML at path.
+func serviceGraphFromYAMLFile(
+	path string) (serviceGraph graph.ServiceGraph, err error) {
+	graphYAML, err := ioutil.ReadFile(path)
+	if err != nil {
+		return
+	}
+	log.Debugf("unmarshalling\n%s", graphYAML)
+	err = yaml.Unmarshal(graphYAML, &serviceGraph)
+	if err != nil {
+		return
+	}
+	return
+}
+
+// extractService finds the service in serviceGraph with the specified name.
+func extractService(
+	serviceGraph graph.ServiceGraph, name string) (
+	service svc.Service, err error) {
+	for _, svc := range serviceGraph.Services {
+		if svc.Name == name {
+			service = svc
+			return
+		}
+	}
+	err = fmt.Errorf(
+		"service with name %s does not exist in %v", name, serviceGraph)
+	return
+}
+
+// extractServiceTypes builds a map from service name to its type
+// (i.e. HTTP or gRPC).
+func extractServiceTypes(
+	serviceGraph graph.ServiceGraph) map[string]svctype.ServiceType {
+	types := make(map[string]svctype.ServiceType, len(serviceGraph.Services))
+	for _, service := range serviceGraph.Services {
+		types[service.Name] = service.Type
+	}
+	return types
+}

--- a/isotope/service/pkg/srv/handler.go
+++ b/isotope/service/pkg/srv/handler.go
@@ -1,0 +1,69 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this currentFile except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package srv
+
+import (
+	"net/http"
+	"os"
+	"time"
+
+	"istio.io/fortio/log"
+	"istio.io/tools/isotope/convert/pkg/graph/svc"
+	"istio.io/tools/isotope/convert/pkg/graph/svctype"
+	"istio.io/tools/isotope/service/pkg/srv/prometheus"
+)
+
+// pathTracesHeaderKey is the HTTP header key for path tracing. It must be in
+// Train-Case.
+const pathTracesHeaderKey = "Path-Traces"
+
+var hostname = os.Getenv("HOSTNAME")
+
+// Handler handles the default endpoint by emulating its Service.
+type Handler struct {
+	Service      svc.Service
+	ServiceTypes map[string]svctype.ServiceType
+}
+
+func (h Handler) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
+	startTime := time.Now()
+
+	prometheus.RecordRequestReceived()
+
+	respond := func(status int) {
+		writer.WriteHeader(status)
+		err := request.Write(writer)
+		if err != nil {
+			log.Errf("%s", err)
+		}
+
+		stopTime := time.Now()
+		duration := stopTime.Sub(startTime)
+		// TODO: Record size of response payload.
+		prometheus.RecordResponseSent(duration, 0, status)
+	}
+
+	for _, step := range h.Service.Script {
+		forwardableHeader := extractForwardableHeader(request.Header)
+		err := execute(step, forwardableHeader, h.ServiceTypes)
+		if err != nil {
+			log.Errf("%s", err)
+			respond(http.StatusInternalServerError)
+			return
+		}
+	}
+
+	respond(http.StatusOK)
+}

--- a/isotope/service/pkg/srv/header.go
+++ b/isotope/service/pkg/srv/header.go
@@ -1,0 +1,48 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this currentFile except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package srv
+
+import (
+	"net/http"
+)
+
+var (
+	forwardableHeaders = []string{
+		"X-Request-Id",
+		"X-B3-Traceid",
+		"X-B3-Spanid",
+		"X-B3-Parentspanid",
+		"X-B3-Sampled",
+		"X-B3-Flags",
+		"X-Ot-Span-Context",
+	}
+	forwardableHeadersSet = make(map[string]bool, len(forwardableHeaders))
+)
+
+func init() {
+	for _, key := range forwardableHeaders {
+		forwardableHeadersSet[key] = true
+	}
+}
+
+func extractForwardableHeader(header http.Header) http.Header {
+	forwardableHeader := make(http.Header, len(forwardableHeaders))
+	for key := range forwardableHeadersSet {
+		if values, ok := header[key]; ok {
+			forwardableHeader[key] = values
+		}
+	}
+	return forwardableHeader
+}

--- a/isotope/service/pkg/srv/prometheus/handler.go
+++ b/isotope/service/pkg/srv/prometheus/handler.go
@@ -1,0 +1,104 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this currentFile except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package prometheus
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+
+	prom "github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+var (
+	durationBuckets = []float64{
+		0.007, 0.008, 0.009, 0.01, 0.011, 0.012, 0.014, 0.016, 0.018, 0.02, 0.025,
+		0.03, 0.035, 0.04, 0.045, 0.05, 0.06, 0.07, 0.08, 0.09, 0.1, 0.12, 0.14,
+		0.16, 0.18, 0.2, 0.25, 0.3, 0.35, 0.4, 0.45, 0.5}
+	sizeBuckets = []float64{
+		// 1, 10, 100, 1,000, ..., 1,000,000,000
+		1e+00, 1e+01, 1e+02, 1e+03, 1e+04, 1e+05, 1e+06, 1e+07, 1e+08, 1e+09}
+
+	serviceIncomingRequestsTotal = prom.NewCounter(
+		prom.CounterOpts{
+			Name: "service_incoming_requests_total",
+			Help: "Number of requests sent to this service.",
+		})
+
+	serviceOutgoingRequestsTotal = prom.NewCounterVec(
+		prom.CounterOpts{
+			Name: "service_outgoing_requests_total",
+			Help: "Number of requests sent from this service.",
+		}, []string{"destination_service"})
+
+	serviceOutgoingRequestSize = prom.NewHistogramVec(
+		prom.HistogramOpts{
+			Name:    "service_outgoing_request_size",
+			Help:    "Size in bytes of requests sent from this service.",
+			Buckets: sizeBuckets,
+		}, []string{"destination_service"})
+
+	serviceRequestDurationSeconds = prom.NewHistogramVec(
+		prom.HistogramOpts{
+			Name:    "service_request_duration_seconds",
+			Help:    "Duration in seconds it took to serve requests to this service.",
+			Buckets: durationBuckets,
+		}, []string{"code"})
+
+	serviceResponseSize = prom.NewHistogramVec(
+		prom.HistogramOpts{
+			Name:    "service_response_size",
+			Help:    "Size in bytes of responses sent from this service.",
+			Buckets: sizeBuckets,
+		}, []string{"code"})
+)
+
+// Handler returns an http.Handler which should be attached to a "/metrics"
+// endpoint for Prometheus to ingest.
+func Handler() http.Handler {
+	prom.MustRegister(serviceIncomingRequestsTotal)
+
+	prom.MustRegister(serviceOutgoingRequestsTotal)
+	prom.MustRegister(serviceOutgoingRequestSize)
+
+	prom.MustRegister(serviceRequestDurationSeconds)
+	prom.MustRegister(serviceResponseSize)
+
+	return promhttp.Handler()
+}
+
+// RecordRequestReceived increments the Prometheus counter for incoming
+// requests.
+func RecordRequestReceived() {
+	serviceIncomingRequestsTotal.Inc()
+}
+
+// RecordRequestSent increments the Prometheus counter for outgoing requests
+// and records an outgoing request size.
+func RecordRequestSent(destinationService string, size uint64) {
+	serviceOutgoingRequestsTotal.WithLabelValues(destinationService).Inc()
+	serviceOutgoingRequestSize.WithLabelValues(destinationService).Observe(
+		float64(size))
+}
+
+// RecordResponseSent observes the time-to-response duration and size for the
+// HTTP status code.
+func RecordResponseSent(duration time.Duration, size uint64, code int) {
+	strCode := strconv.Itoa(code)
+	serviceRequestDurationSeconds.WithLabelValues(strCode).Observe(
+		duration.Seconds())
+	serviceResponseSize.WithLabelValues(strCode).Observe(float64(size))
+}

--- a/isotope/service/pkg/srv/request.go
+++ b/isotope/service/pkg/srv/request.go
@@ -1,0 +1,58 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this currentFile except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package srv
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+
+	"istio.io/fortio/log"
+	"istio.io/tools/isotope/convert/pkg/consts"
+	"istio.io/tools/isotope/convert/pkg/graph/size"
+	"istio.io/tools/isotope/convert/pkg/graph/svctype"
+)
+
+func sendRequest(
+	destName string,
+	destType svctype.ServiceType,
+	size size.ByteSize,
+	requestHeader http.Header) (*http.Response, error) {
+	url := fmt.Sprintf("http://%s:%v", destName, consts.ServicePort)
+	request, err := buildRequest(url, size, requestHeader)
+	if err != nil {
+		return nil, err
+	}
+	log.Debugf("sending request to %s (%s)", destName, url)
+	return http.DefaultClient.Do(request)
+}
+
+func buildRequest(
+	url string, size size.ByteSize, requestHeader http.Header) (
+	*http.Request, error) {
+	payload := make([]byte, size)
+	request, err := http.NewRequest("GET", url, bytes.NewBuffer(payload))
+	if err != nil {
+		return nil, err
+	}
+	copyHeader(request, requestHeader)
+	return request, nil
+}
+
+func copyHeader(request *http.Request, header http.Header) {
+	for key, values := range header {
+		request.Header[key] = values
+	}
+}


### PR DESCRIPTION
This PR adds the mock HTTP server to function as a service in a topology. It acts out the script from the topology YAML when an HTTP request is sent to "/" and serves Prometheus metrics on "/metrics".

[Isotope design doc](https://docs.google.com/document/d/1R0kM19mATEoSmX7ZGRN_LCeh7h-8f5bNmhLR1Y8hKuc/view)

/cc @mandarjog @costinm 
/assign @mandarjog @costinm 