### PR TITLE
support generating RBAC rules for two pods test.

### DIFF
--- a/perf/twoPodTest/runner/runner.py
+++ b/perf/twoPodTest/runner/runner.py
@@ -152,7 +152,8 @@ def perf(pod, labels, duration=20, runfn=run_command_sync):
     return perf
 
 
-def kubecp(from_file, to_file, namespace="service-graph"):
+def kubecp(from_file, to_file):
+    namespace = os.environ.get("NAMESPACE", "service-graph")
     cmd = "kubectl --namespace {namespace} cp {from_file} {to_file} -c istio-proxy".format(
         from_file=from_file, to_file=to_file, namespace=namespace)
     print cmd

--- a/perf/twoPodTest/templates/bad.yaml
+++ b/perf/twoPodTest/templates/bad.yaml
@@ -11,6 +11,28 @@ spec:
     app: badhealth
   type: ClusterIP
 ---
+{{- if $.Values.rbac.enabled }}
+apiVersion: "rbac.istio.io/v1alpha1"
+kind: ServiceRole
+metadata:
+  name: badhealth
+spec:
+  rules:
+  - services: ["badhealth.*"]
+    methods: ["*"]
+---
+apiVersion: "rbac.istio.io/v1alpha1"
+kind: ServiceRoleBinding
+metadata:
+  name: badhealth
+spec:
+  subjects:
+  - user: "*"
+  roleRef:
+    kind: ServiceRole
+    name: "badhealth"
+---
+{{- end }}
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:

--- a/perf/twoPodTest/templates/fortio.yaml
+++ b/perf/twoPodTest/templates/fortio.yaml
@@ -1,3 +1,26 @@
+{{- define "rbac" }}
+{{- $ruleName := (randAlpha 16) | lower }}
+apiVersion: "rbac.istio.io/v1alpha1"
+kind: ServiceRole
+metadata:
+  name: {{ $ruleName }}
+spec:
+  rules:
+  - services: ["{{ $.name }}.*"]
+    methods: ["*"]
+---
+apiVersion: "rbac.istio.io/v1alpha1"
+kind: ServiceRoleBinding
+metadata:
+  name: {{ $ruleName }}
+spec:
+  subjects:
+  - user: "{{ $.userName }}"
+  roleRef:
+    kind: ServiceRole
+    name: "{{ $ruleName }}"
+{{- end }}
+
 {{- define "fortio" }}
 ---
 apiVersion: v1
@@ -22,6 +45,23 @@ spec:
     app: {{ $.name }}
   type: ClusterIP
 ---
+{{- if $.Values.rbac.enabled }}
+{{- range $i, $e := until ($.Values.rbac.numPolicies|int) }}
+{{- $data := dict "name" $.name "Values" $.Values "userName" (randAlpha 16) }}
+{{- template "rbac" $data }}
+---
+{{- end }}
+{{- $data := dict "name" .name "Values" .Values "ruleName" (randAlphaNum 16) "userName" "*" }}
+  {{- template "rbac" $data }}
+---
+apiVersion: "rbac.istio.io/v1alpha1"
+kind: RbacConfig
+metadata:
+  name: default
+spec:
+  mode: 'ON'
+---
+{{- end }}
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -150,4 +190,4 @@ spec:
         ingressClass: istio
       domains:
       - fortiotls.{{ .Values.domain }}
--
+---

--- a/perf/twoPodTest/values.yaml
+++ b/perf/twoPodTest/values.yaml
@@ -14,3 +14,10 @@ fortioImage: istio/fortio:latest_release
 tlsmode: ISTIO_MUTUAL
 domain: local
 gateway: fortio-gateway
+rbac:
+  # If true, generates random RBAC policies for the fortio service.
+  enabled: false
+  # Number of RBAC policies generated.
+  # Note: The generated policies will have a random name. One of the policies allows everyone to access fortioserver and
+  # the other policies allow a random non exist user to access it.
+  numPolicies: 3


### PR DESCRIPTION
Ref: https://github.com/istio/istio/issues/8477

How to use
- Generate config without RBAC rules: `$ NAMESPACE=perf-without-rbac DNS_DOMAIN=local TMPDIR=.  ./setup_test.sh`
- Generate config with RBAC rules: `$ NAMESPACE=perf-with-rbac DNS_DOMAIN=local TMPDIR=.  ./setup_test.sh --rbac`

A quick run in my local environment (Istio 1.1. Perf running with 3 connections, 100 qps, 60 seconds):
- Result without RBAC rules (1.730 ms avg):
```bash
Fortio 1.0.1 running at 100 queries per second, 16->16 procs, for 1m0s: http://fortioserver:8080/echo?size=1024
10:04:50 I httprunner.go:82> Starting http test for http://fortioserver:8080/echo?size=1024 with 3 threads at 100.0 qps
Starting at 100 qps with 3 thread(s) [gomax 16] for 1m0s : 2000 calls each (total 6000)
kubectl --namespace perf-test exec -i -t fortioclient-77ccf555b8-5k8n7  -- fortio load -c 3 -qps 100 -t 60s -a -r 0.00005 -httpbufferkb=128 -labels 83462e0e_qps_100_c_3_mixer_mixercache_1024_bothsidecars http://fortioserver:8080/echo?size=1024
kubectl --namespace perf-test cp ./get_perfdata.sh fortioserver-79ff59bdd4-kdfpf:/etc/istio/proxy/get_perfdata.sh -c istio-proxy
Defaulting container name to captured.
Use 'kubectl describe pod/fortioclient-77ccf555b8-5k8n7 -n perf-test' to see all of the containers in this pod.
Fortio 1.0.1 running at 100 queries per second, 16->16 procs, for 1m0s: http://fortioserver:8080/echo?size=1024
10:04:50 I httprunner.go:82> Starting http test for http://fortioserver:8080/echo?size=1024 with 3 threads at 100.0 qps
Starting at 100 qps with 3 thread(s) [gomax 16] for 1m0s : 2000 calls each (total 6000)
kubectl --namespace perf-test exec -i -t fortioserver-79ff59bdd4-kdfpf -c istio-proxy -- /etc/istio/proxy/get_perfdata.sh 83462e0e_qps_100_c_3_mixer_mixercache_1024_srv_bothsidecars_perf.data 40
                     perf_event_paranoid=1
[ perf record: Woken up 1 times to write data ]
[ perf record: Captured and wrote 0.091 MB /etc/istio/proxy/83462e0e_qps_100_c_3_mixer_mixercache_1024_srv_bothsidecars_perf.data (253 samples) ]
Wrote /etc/istio/proxy/83462e0e_qps_100_c_3_mixer_mixercache_1024_srv_bothsidecars_perf.data.perf
                                                                                                 kubectl --namespace perf-test cp fortioserver-79ff59bdd4-kdfpf:/etc/istio/proxy/83462e0e_qps_100_c_3_mixer_mixercache_1024_srv_bothsidecars_perf.data.perf 83462e0e_qps_100_c_3_mixer_mixercache_1024_srv_bothsidecars_perf.data.perf -c istio-proxy
                                                                                                                                                                        tar: Removing leading `/' from member names
                                      10:05:50 I periodic.go:533> T002 ended after 1m0.003634044s : 2000 calls. qps=33.33131454227293
10:05:50 I periodic.go:533> T000 ended after 1m0.003764s : 2000 calls. qps=33.33124235339636
10:05:50 I periodic.go:533> T001 ended after 1m0.003801887s : 2000 calls. qps=33.33122130771693
Ended after 1m0.00394127s : 6000 calls. qps=99.993
Sleep times : count 5997 avg 0.028074924 +/- 0.0002577 min 0.024019452 max 0.028620626 sum 168.36532
Aggregated Function Time : count 6000 avg 0.0017297801 +/- 0.0002535 min 0.001120183 max 0.005876564 sum 10.3786808
# range, mid point, percentile, count
>= 0.00112018 <= 0.00125 , 0.00118509 , 0.23, 14
> 0.00125 <= 0.0015 , 0.001375 , 12.72, 749
> 0.0015 <= 0.00175 , 0.001625 , 61.35, 2918
> 0.00175 <= 0.002 , 0.001875 , 89.55, 1692
> 0.002 <= 0.00225 , 0.002125 , 96.85, 438
> 0.00225 <= 0.0025 , 0.002375 , 98.73, 113
> 0.0025 <= 0.003 , 0.00275 , 99.57, 50
> 0.003 <= 0.0035 , 0.00325 , 99.87, 18
> 0.0035 <= 0.004 , 0.00375 , 99.97, 6
> 0.004 <= 0.0045 , 0.00425 , 99.98, 1
> 0.005 <= 0.00587656 , 0.00543828 , 100.00, 1
# target 50% 0.00169166
# target 75% 0.00187101
# target 90% 0.00201541
# target 99% 0.00266
# target 99.9% 0.00366667
Sockets used: 3 (for perfect keepalive, would be 3)
Code 200 : 6000 (100.0 %)
Response Header Sizes : count 6000 avg 167 +/- 0 min 167 max 167 sum 1002000
Response Body/Total Sizes : count 6000 avg 1191 +/- 0 min 1191 max 1191 sum 7146000
All done 6000 calls (plus 3 warmup) 1.730 ms avg, 100.0 qps
Successfully wrote 3019 bytes of Json data to /var/lib/istio/fortio/2018-12-04-100450_83462e0e_qps_100_c_3_mixer_mixercache_1024_bot.json

```
- Result with 3 RBAC rules per service (1.871 ms avg):
```bash
Fortio 1.0.1 running at 100 queries per second, 16->16 procs, for 1m0s: http://fortioserver:8080/echo?size=1024
11:31:03 I httprunner.go:82> Starting http test for http://fortioserver:8080/echo?size=1024 with 3 threads at 100.0 qps
Starting at 100 qps with 3 thread(s) [gomax 16] for 1m0s : 2000 calls each (total 6000)
kubectl --namespace perf-rbac exec -i -t fortioserver-79ff59bdd4-87wv8 -c istio-proxy -- /etc/istio/proxy/get_perfdata.sh 6a2316dc_qps_100_c_3_mixer_mixercache_1024_srv_bothsidecars_perf.data 40
                     perf_event_paranoid=1
[ perf record: Woken up 1 times to write data ]
[ perf record: Captured and wrote 0.096 MB /etc/istio/proxy/6a2316dc_qps_100_c_3_mixer_mixercache_1024_srv_bothsidecars_perf.data (269 samples) ]
Wrote /etc/istio/proxy/6a2316dc_qps_100_c_3_mixer_mixercache_1024_srv_bothsidecars_perf.data.perf
                                                                                                 kubectl --namespace perf-rbac cp fortioserver-79ff59bdd4-87wv8:/etc/istio/proxy/6a2316dc_qps_100_c_3_mixer_mixercache_1024_srv_bothsidecars_perf.data.perf 6a2316dc_qps_100_c_3_mixer_mixercache_1024_srv_bothsidecars_perf.data.perf -c istio-proxy
                                                                                                                                                                        tar: Removing leading `/' from member names
                                      11:32:03 I periodic.go:533> T002 ended after 1m0.003437326s : 2000 calls. qps=33.331423817171604
11:32:03 I periodic.go:533> T001 ended after 1m0.003515349s : 2000 calls. qps=33.33138047608291
11:32:03 I periodic.go:533> T000 ended after 1m0.003715232s : 2000 calls. qps=33.331269443352724
Ended after 1m0.003771855s : 6000 calls. qps=99.994
Sleep times : count 5997 avg 0.027900186 +/- 0.0002981 min 0.022940522 max 0.028551523 sum 167.317413
Aggregated Function Time : count 6000 avg 0.0018712657 +/- 0.0002965 min 0.001141756 max 0.006802798 sum 11.2275942
# range, mid point, percentile, count
>= 0.00114176 <= 0.00125 , 0.00119588 , 0.12, 7
> 0.00125 <= 0.0015 , 0.001375 , 5.38, 316
> 0.0015 <= 0.00175 , 0.001625 , 34.00, 1717
> 0.00175 <= 0.002 , 0.001875 , 75.68, 2501
> 0.002 <= 0.00225 , 0.002125 , 92.38, 1002
> 0.00225 <= 0.0025 , 0.002375 , 96.90, 271
> 0.0025 <= 0.003 , 0.00275 , 99.17, 136
> 0.003 <= 0.0035 , 0.00325 , 99.80, 38
> 0.0035 <= 0.004 , 0.00375 , 99.92, 7
> 0.004 <= 0.0045 , 0.00425 , 99.97, 3
> 0.005 <= 0.006 , 0.0055 , 99.98, 1
> 0.006 <= 0.0068028 , 0.0064014 , 100.00, 1
# target 50% 0.00184596
# target 75% 0.0019959
# target 90% 0.00221432
# target 99% 0.00296324
# target 99.9% 0.00392857
Sockets used: 3 (for perfect keepalive, would be 3)
Code 200 : 6000 (100.0 %)
Response Header Sizes : count 6000 avg 167 +/- 0 min 167 max 167 sum 1002000
Response Body/Total Sizes : count 6000 avg 1191 +/- 0 min 1191 max 1191 sum 7146000
All done 6000 calls (plus 3 warmup) 1.871 ms avg, 100.0 qps
Successfully wrote 3135 bytes of Json data to /var/lib/istio/fortio/2018-12-04-113103_6a2316dc_qps_100_c_3_mixer_mixercache_1024_bot.json
```

Will run the tests with more RBAC rules and larger qps later.

/cc @mandarjog @liminw

Signed-off-by: Yangmin Zhu <ymzhu@google.com>