### PR TITLE
Update setup.sh to new location for Istio CRDS

### DIFF
--- a/perf/istio/setup.sh
+++ b/perf/istio/setup.sh
@@ -33,7 +33,11 @@ function install_istio() {
   kubectl create ns istio-system || true
 
   if [[ -z "${DRY_RUN}" ]];then
-      kubectl apply -f "${DIRNAME}/${release}/istio/templates/crds.yaml"
+      # apply CRD files for istio kinds
+      if [[ -f "${DIRNAME}/${release}/istio/templates/crds.yaml" ]];then
+         kubectl apply -f "${DIRNAME}/${release}/istio/templates/crds.yaml"
+      else
+         kubectl apply -f "${DIRNAME}/${release}/istio-init/files/"
   fi
 
   local FILENAME="${DIRNAME}/${release}.yml"


### PR DESCRIPTION
https://github.com/istio/istio/pull/10562 moved CRD.yaml files from ./istio/templates to ./istio-init/files.  This change works with both the old and new paths for backwards compatibility.