### PR TITLE
Use print() function in both Python 2 and Python 3

### DIFF
--- a/isotope/runner/istio.py
+++ b/isotope/runner/istio.py
@@ -1,4 +1,5 @@
 """Functions for manipulating the Istio environment."""
+from __future__ import print_function
 
 import contextlib
 import logging
@@ -36,7 +37,7 @@ def set_up(entrypoint_service_name: str, entrypoint_service_namespace: str,
     """
     archive_url = convert_archive(archive_url)
 
-    print ("Using archive_url", archive_url)
+    print(("Using archive_url", archive_url))
 
     with tempfile.TemporaryDirectory() as tmp_dir_path:
         archive_path = os.path.join(tmp_dir_path, 'istio.tar.gz')

--- a/isotope/runner/mesh.py
+++ b/isotope/runner/mesh.py
@@ -9,6 +9,7 @@ and define three functions:
 
 These three functions make it simple for use in a with-statement.
 """
+from __future__ import print_function
 
 import contextlib
 from typing import Callable, Generator

--- a/perf/twoPodTest/runner/fortio.py
+++ b/perf/twoPodTest/runner/fortio.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import json
 import os
 import tempfile
@@ -122,33 +123,33 @@ def syncFortio(url, table, selector=None):
                 continue
 
         sd = datetime.strptime(st[:19], "%Y-%m-%dT%H:%M:%S")
-        print "Fetching prometheus metrics for", sd,
+        print("Fetching prometheus metrics for", sd, end=' ')
 
         if gd['errorPercent'] > 10:
-            print "... Run resulted in", gd['errorPercent'], "% errors"
+            print("... Run resulted in", gd['errorPercent'], "% errors")
             continue
         # give 30s after start of test
         prom_start = calendar.timegm(sd.utctimetuple()) + 30
         p = prom.Prom("http://prometheus.local", 120, start=prom_start)
         prom_metrics = p.fetch_cpu_and_mem()
         if len(prom_metrics) == 0:
-            print "... Not found"
+            print("... Not found")
             continue
         else:
-            print ""
+            print("")
 
         gd.update(prom_metrics)
         out.write(json.dumps(gd) + "\n")
         cnt += 1
 
     out.close()
-    print "Wrote {} records to {}".format(cnt, datafile)
+    print("Wrote {} records to {}".format(cnt, datafile))
 
     p = subprocess.Popen("bq insert {table} {datafile}".format(
         table=table, datafile=datafile).split())
     ret = p.wait()
-    print p.stdout
-    print p.stderr
+    print(p.stdout)
+    print(p.stderr)
     return ret
 
 

--- a/perf/twoPodTest/runner/prom.py
+++ b/perf/twoPodTest/runner/prom.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import datetime
 import calendar
 import requests
@@ -382,7 +383,7 @@ def main(argv):
     if args.indent is not None:
         indent = int(args.indent)
 
-    print json.dumps(out, indent=indent)
+    print(json.dumps(out, indent=indent))
 
 
 def getParser():

--- a/perf/twoPodTest/runner/runner.py
+++ b/perf/twoPodTest/runner/runner.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import datetime
 import calendar
 import requests
@@ -144,9 +145,9 @@ def perf(pod, labels, duration=20, runfn=run_command_sync):
                                                              filename=filename, duration=duration),
                    runfn=run_command_sync, container="istio-proxy")
 
-    print perf
+    print(perf)
 
-    print kubecp(pod + ":" + filepath + ".perf", filename + ".perf")
+    print(kubecp(pod + ":" + filepath + ".perf", filename + ".perf"))
 
     run_command_sync("./flame.sh " + filename + ".perf")
     return perf
@@ -156,7 +157,7 @@ def kubecp(from_file, to_file):
     namespace = os.environ.get("NAMESPACE", "service-graph")
     cmd = "kubectl --namespace {namespace} cp {from_file} {to_file} -c istio-proxy".format(
         from_file=from_file, to_file=to_file, namespace=namespace)
-    print cmd
+    print(cmd)
     return run_command_sync(cmd)
 
 
@@ -167,7 +168,7 @@ def kubectl(pod, remote_cmd, runfn=run_command, container=None):
         c = "-c " + container
     cmd = "kubectl --namespace {namespace} exec -i -t {pod} {c} -- {remote_cmd}".format(
         pod=pod, remote_cmd=remote_cmd, c=c, namespace=namespace)
-    print cmd
+    print(cmd)
     return runfn(cmd)
 
 
@@ -178,7 +179,7 @@ def rc(command):
         if output == '' and process.poll() is not None:
             break
         if output:
-            print output.strip() + "\n"
+            print(output.strip() + "\n")
     return process.poll()
 
 
@@ -222,7 +223,7 @@ def getParser():
 
 def main(argv):
     args = getParser().parse_args(argv)
-    print args
+    print(args)
     return run(args)
 
 if __name__ == "__main__":


### PR DESCRIPTION
Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.