### PR TITLE
Add client reconnection stress test for galley

### DIFF
--- a/perf/galley-load-tests/mcp-client-scaling-stress-test.sh
+++ b/perf/galley-load-tests/mcp-client-scaling-stress-test.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+set -e
+
+MAX_REPLICAS=${MAX_REPLICAS:-100}
+MIN_REPLICAS=${MIN_REPLICAS:-10}
+
+# setup port forwarding to galley to query memory and cpu profiles
+GALLEY_POD=$(kubectl -n istio-system get pod -listio=galley --field-selector=status.phase=Running -o jsonpath='{.items[0].metadata.name}')
+echo "Profiling "${GALLEY_POD}
+
+kubectl -n istio-system port-forward ${GALLEY_POD} 9094 >/dev/null &
+GALLEY_PID=$!
+on_exit() {
+    kill ${GALLEY_PID}
+}
+trap on_exit EXIT
+
+sleep 1 # give port forwarding a chance to start
+
+num_goroutines() {
+    echo $(curl -s http://localhost:9094/debug/pprof/goroutine?debug=1 | grep ^"goroutine profile"|cut -f4 -d' ')
+}
+
+while true; do
+    # scale up
+    for replicas in $(seq ${MIN_REPLICAS} 1 ${MAX_REPLICAS}); do
+        kubectl -n istio-system scale deployment istio-pilot --replicas ${replicas}
+        kubectl -n istio-system rollout status deployment istio-pilot
+
+        echo "[up]" $(num_goroutines) goroutines for ${REPLICAS} replicas
+    done
+
+    # scale down
+    for replicas in $(seq ${MAX_REPLICAS} -1 ${MIN_REPLICAS}); do
+        kubectl -n istio-system scale deployment istio-pilot --replicas ${replicas}
+        kubectl -n istio-system rollout status deployment istio-pilot
+
+        echo "[down]" $(num_goroutines) goroutines for ${REPLICAS} replicas
+    done
+done

--- a/perf/galley-load-tests/mcp-client-scaling-stress-test.sh
+++ b/perf/galley-load-tests/mcp-client-scaling-stress-test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -o errexit
 
 MAX_REPLICAS=${MAX_REPLICAS:-100}
 MIN_REPLICAS=${MIN_REPLICAS:-10}


### PR DESCRIPTION
This script can be in a standalone cluster or in one of the large scale testing clusters if HPA is disabled for Pilot. 

Sample out:
```
deployment "istio-pilot" scaled
Waiting for rollout to finish: 21 of 22 updated replicas are available...
deployment "istio-pilot" successfully rolled out
[up] 677 goroutines for replicas
deployment "istio-pilot" scaled
Waiting for rollout to finish: 22 of 23 updated replicas are available...
deployment "istio-pilot" successfully rolled out
[up] 682 goroutines for replicas
deployment "istio-pilot" scaled
Waiting for rollout to finish: 23 of 24 updated replicas are available...
deployment "istio-pilot" successfully rolled out
[up] 687 goroutines for replicas
deployment "istio-pilot" scaled
Waiting for rollout to finish: 24 of 25 updated replicas are available...
deployment "istio-pilot" successfully rolled out
[up] 692 goroutines for replicas
deployment "istio-pilot" scaled
Waiting for rollout to finish: 25 of 26 updated replicas are available...
deployment "istio-pilot" successfully rolled out
[up] 697 goroutines for replicas
deployment "istio-pilot" scaled
Waiting for rollout to finish: 26 of 27 updated replicas are available...
deployment "istio-pilot" successfully rolled out
[up] 702 goroutines for replicas
deployment "istio-pilot" scaled
Waiting for rollout to finish: 27 of 28 updated replicas are available...
```