### PR TITLE
Add graceful shutdown test

### DIFF
--- a/perf/istio/gracefulShutdown/Chart.yaml
+++ b/perf/istio/gracefulShutdown/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+name: gracefulShutdown
+version: 1.0
+description: Helm chart for istio gracefulShutdown
+keywords:
+  - istio
+  - performance
+sources:
+  - http://github.com/istio/istio
+engine: gotpl

--- a/perf/istio/gracefulShutdown/README.md
+++ b/perf/istio/gracefulShutdown/README.md
@@ -1,0 +1,7 @@
+# Graceful Shutdown Test
+
+This test ensures that proxies will be shutdown gracefully.
+
+This is measured by sending many long lasting requests.
+
+When the server is redeployed, traffic should gracefully transition to the new deployment - connections should not be dropped.

--- a/perf/istio/gracefulShutdown/setup.sh
+++ b/perf/istio/gracefulShutdown/setup.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -ex
+
+function install_all_config() {
+  local DIRNAME="${1:?"output dir"}"
+  local OUTFILE="${DIRNAME}/all_config.yaml"
+
+  kubectl create ns graceful-shutdown || true
+
+  kubectl label namespace graceful-shutdown istio-injection=enabled || true
+
+  helm -n graceful-shutdown template . > "${OUTFILE}"
+
+  if [[ -z "${DRY_RUN}" ]]; then
+      kubectl -n graceful-shutdown apply -f "${OUTFILE}"
+  fi
+}
+
+WD=$(dirname $0)
+WD=$(cd $WD; pwd)
+mkdir -p "${WD}/tmp"
+
+install_all_config "${WD}/tmp" $*

--- a/perf/istio/gracefulShutdown/templates/client.yaml
+++ b/perf/istio/gracefulShutdown/templates/client.yaml
@@ -1,0 +1,26 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: client
+  labels:
+    app: client
+spec:
+  selector:
+    matchLabels:
+      app: client
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        app: client
+    spec:
+      containers:
+      - name: client
+        image: {{ .Values.fortioImage }}
+        args:
+        - load
+        - -qps
+        - "{{ .Values.qps }}"
+        - -t
+        - "0"
+        - http://httpbin:8000/delay/{{ .Values.connectionDuration }}

--- a/perf/istio/gracefulShutdown/templates/redeployer-cron.yaml
+++ b/perf/istio/gracefulShutdown/templates/redeployer-cron.yaml
@@ -1,0 +1,68 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: redeployer-httpbin
+  labels:
+    app: redeployer-httpbin
+spec:
+  schedule: "*/{{ .Values.httpbinRedployMinutes }} * * * *" # Every x minutes
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          annotations:
+            sidecar.istio.io/inject: "false"
+          labels:
+            app: redeployer-httpbin
+        spec:
+          containers:
+            - name: redeployer-httpbin
+              image: gcr.io/istio-release/kubectl:release-1.1-latest-daily
+              command:
+                - bash
+                - -c
+                - |-
+                  #!/bin/bash
+                  function force_redeploy() {
+                      kubectl patch deployment "${1:?"deployment"}" \
+                          -p "{\"spec\":{\"template\":{\"metadata\":{\"labels\":{\"date\":\"`date +'%s'`\"}}}}}" \
+                          "${@:2}"
+                  }
+                  echo "`date`: redeploying httpbin"
+                  force_redeploy httpbin
+          restartPolicy: OnFailure
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: redeployer-pilot
+  labels:
+    app: redeployer-pilot
+spec:
+  schedule: "*/{{ .Values.pilotRedployMinutes }} * * * *" # Every x minutes
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          annotations:
+            sidecar.istio.io/inject: "false"
+          labels:
+            app: redeployer-pilot
+        spec:
+          containers:
+            - name: redeployer-pilot
+              image: gcr.io/istio-release/kubectl:release-1.1-latest-daily
+              command:
+                - bash
+                - -c
+                - |-
+                  #!/bin/bash
+                  function force_redeploy() {
+                      kubectl patch deployment "${1:?"deployment"}" \
+                          -p "{\"spec\":{\"template\":{\"metadata\":{\"labels\":{\"date\":\"`date +'%s'`\"}}}}}" \
+                          "${@:2}"
+                  }
+                  echo "`date`: redeploying istio-pilot"
+                  force_redeploy istio-pilot -n istio-system
+          restartPolicy: OnFailure
+

--- a/perf/istio/gracefulShutdown/templates/server.yaml
+++ b/perf/istio/gracefulShutdown/templates/server.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: httpbin
+  labels:
+    app: httpbin
+spec:
+  ports:
+  - name: http
+    port: 8000
+    targetPort: 80
+  selector:
+    app: httpbin
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: httpbin
+spec:
+  selector:
+    matchLabels:
+      app: httpbin
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        app: httpbin
+    spec:
+      containers:
+      - image: docker.io/kennethreitz/httpbin
+        imagePullPolicy: IfNotPresent
+        name: httpbin
+        ports:
+        - containerPort: 80

--- a/perf/istio/gracefulShutdown/values.yaml
+++ b/perf/istio/gracefulShutdown/values.yaml
@@ -1,0 +1,5 @@
+connectionDuration: 10 # maximum supported by httpbin is 10s
+qps: 10
+fortioImage: fortio/fortio:latest
+httpbinRedployMinutes: 1
+pilotRedployMinutes: 30


### PR DESCRIPTION
This test sends long lasting requests to a server that is restarted
repeatedly. This is used to test that traffic will be dropped gracefully
rather than connections dropped.

@liamawhite 