### PR TITLE
Add http 1.0 test

### DIFF
--- a/perf/istio/http10/Chart.yaml
+++ b/perf/istio/http10/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+name: gracefulShutdown
+version: 1.0
+description: Helm chart for istio http 1.0 testing
+keywords:
+  - istio
+  - performance
+sources:
+  - http://github.com/istio/istio
+engine: gotpl

--- a/perf/istio/http10/README.md
+++ b/perf/istio/http10/README.md
@@ -1,0 +1,7 @@
+# HTTP 1.0 Testing
+
+This test the Envoy proxies will accept.
+
+This is tested by sending http 1.0 requests repeatedly.
+
+HTTP 1.0 needs to be enabled in pilot for this to work. This can be done by setting `pilot.env.PILOT_HTTP10=1`.

--- a/perf/istio/http10/setup.sh
+++ b/perf/istio/http10/setup.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -ex
+
+function install_all_config() {
+  local DIRNAME="${1:?"output dir"}"
+  local OUTFILE="${DIRNAME}/all_config.yaml"
+
+  kubectl create ns http10 || true
+
+  kubectl label namespace http10 istio-injection=enabled || true
+
+  helm -n http10 template . > "${OUTFILE}"
+
+  if [[ -z "${DRY_RUN}" ]]; then
+      kubectl -n http10 apply -f "${OUTFILE}"
+  fi
+}
+
+WD=$(dirname $0)
+WD=$(cd $WD; pwd)
+mkdir -p "${WD}/tmp"
+
+install_all_config "${WD}/tmp" $*

--- a/perf/istio/http10/templates/client.yaml
+++ b/perf/istio/http10/templates/client.yaml
@@ -1,24 +1,26 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: shell
+  name: http10-client
 spec:
   selector:
     matchLabels:
-      app: shell
+      app: http10-client
   template:
     metadata:
+      annotations:
+        HTTP10: "1"
       labels:
-        app: shell
+        app: http10-client
     spec:
       containers:
-        - name: shell
+        - name: http10-client
           image: {{ .Values.curlImage }}
           args:
             - bash
             - -c
             - |-
               while true; do
-                curl -v fortio-server:8080/echo --http1.0
+                curl -sS  -o /dev/null -w "%{http_code}\n" fortio-server:8080/echo --http1.0
                 sleep .1
               done

--- a/perf/istio/http10/templates/client.yaml
+++ b/perf/istio/http10/templates/client.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: shell
+spec:
+  selector:
+    matchLabels:
+      app: shell
+  template:
+    metadata:
+      labels:
+        app: shell
+    spec:
+      containers:
+        - name: shell
+          image: {{ .Values.curlImage }}
+          args:
+            - bash
+            - -c
+            - |-
+              while true; do
+                curl -v fortio-server:8080/echo --http1.0
+                sleep .1
+              done

--- a/perf/istio/http10/templates/server.yaml
+++ b/perf/istio/http10/templates/server.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: fortio-server
+  labels:
+    app: fortio-server
+spec:
+  ports:
+  - name: http
+    port: 8080
+  selector:
+    app: fortio-server
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fortio-server
+spec:
+  selector:
+    matchLabels:
+      app: fortio-server
+  template:
+    metadata:
+      labels:
+        app: fortio-server
+    spec:
+      containers:
+      - image: {{ .Values.fortioImage }}
+        imagePullPolicy: IfNotPresent
+        name: fortio-server
+        ports:
+          - containerPort: 8080

--- a/perf/istio/http10/values.yaml
+++ b/perf/istio/http10/values.yaml
@@ -1,0 +1,2 @@
+fortioImage: fortio/fortio:latest
+curlImage: tutum/curl:trusty

--- a/perf/istio/values-istio-test.yaml
+++ b/perf/istio/values-istio-test.yaml
@@ -88,6 +88,7 @@ pilot:
   autoscaleMax: 10
   env:
     PILOT_PUSH_THROTTLE: 50
+    PILOT_HTTP10: 1
     GODEBUG: gctrace=2
   resources:
     requests:

--- a/perf/istio/values-istio-test.yaml
+++ b/perf/istio/values-istio-test.yaml
@@ -88,7 +88,6 @@ pilot:
   autoscaleMax: 10
   env:
     PILOT_PUSH_THROTTLE: 50
-    PILOT_HTTP10: 1
     GODEBUG: gctrace=2
   resources:
     requests:


### PR DESCRIPTION
This adds testing for https://github.com/istio/istio/pull/11511. The test is simple, and just sends a lot of http 1.0 requests to fortio. The client does not use fortio due to https://github.com/fortio/fortio/issues/324. If/when that is figured out we can switch curl out, but for now it does the job. 
