### PR TITLE
Istio Perf: periodically trigger rolling restart of the ingressgateway

### DIFF
--- a/perf/istio/allconfig/setup.sh
+++ b/perf/istio/allconfig/setup.sh
@@ -9,12 +9,14 @@ function install_all_config() {
   local DIRNAME="${1:?"output dir"}"
   local domain=${DNS_DOMAIN:-qualistio.org}
   local OUTFILE="${DIRNAME}/all_config.yaml"
+  local NAMESPACE=test
 
-  kubectl create ns test || true
+  kubectl create ns $NAMESPACE || true
 
-  kubectl label namespace test istio-injection=enabled || true
+  kubectl label namespace $NAMESPACE istio-injection=enabled || true
 
-  helm -n test template \
+  helm -n $NAMESPACE template \
+    --set namespace=$NAMESPACE \
     --set fortioImage=fortio/fortio:latest \
     --set ingress="${GATEWAY_URL}" \
     --set domain="${domain}" . > "${OUTFILE}"

--- a/perf/istio/allconfig/templates/gateway-bouncer.yaml
+++ b/perf/istio/allconfig/templates/gateway-bouncer.yaml
@@ -1,0 +1,64 @@
+# CronJob that periodically triggers rolling restart of ingressgateway.
+# Used to test graceful shutdown of ingressgateway instances, graceful draining
+# of inflight connections, correctness of readiness checks, etc.
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: gateway-bouncer
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: gateway-bouncer
+rules:
+  - apiGroups: ["extensions"]
+    resources: ["deployments"]
+    verbs: ["get", "list", "patch", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: gateway-bouncer
+subjects:
+  - kind: ServiceAccount
+    namespace: {{ .Values.namespace }}
+    name: gateway-bouncer
+roleRef:
+  kind: ClusterRole
+  name: gateway-bouncer
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: gateway-bouncer
+  labels:
+    app: gateway-bouncer
+spec:
+  schedule: "*/{{ .Values.gatewayBounceFreqMins }} * * * *" # Every x minutes
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          annotations:
+            sidecar.istio.io/inject: "false"
+          labels:
+            app: gateway-bouncer
+        spec:
+          serviceAccountName: gateway-bouncer
+          containers:
+            - name: gateway-bouncer
+              image: gcr.io/istio-release/kubectl:release-1.1-latest-daily
+              command:
+                - bash
+                - -c
+                - |-
+                  #!/bin/bash
+                  echo "Bouncing istio-ingressgateway..."
+                  kubectl \
+                    -n {{ .Values.istioNamespace }} \
+                    patch deployment istio-ingressgateway \
+                    -p "{\"spec\":{\"template\":{\"metadata\":{\"labels\":{\"date\":\"`date +'%s'`\"}}}}}"
+          restartPolicy: OnFailure
+---

--- a/perf/istio/allconfig/values.yaml
+++ b/perf/istio/allconfig/values.yaml
@@ -4,6 +4,10 @@ testTag: nightly-release-1.0
 
 domain: v10.qualistio.org
 
+# Release.Namespace isn't being correctly populated when pre-rendering Helm
+# template, so passing the namespace explicitly.
+namespace: test
+
 # Namespace where istio control plane is installed.
 istioNamespace: istio-system
 
@@ -28,3 +32,7 @@ healthCheck: true
 
 certManager: false
 ingress: ingressIP
+
+# Frequency of how often a rolling restart of Ingress Gateway should be
+# triggered.
+gatewayBounceFreqMins: 15


### PR DESCRIPTION
While exploring ways to test the newly introduced readiness check for the ingressgateway and chatting with @costinm and @mandarjog I realized that there's more generic scenario that we might want to exercise on continuous basis. How about we try triggering rolling restart of the ingressgateway every so often (every 15 mins in this case), so that we not only validate readiness checks but also make sure that upgrades/casual restarts are smooth, connections are being drained gracefully during the shutdown, observe the impact of a restart under the load, etc.

Let me know if this is a bad idea or if there are reasons not to introduce such test at this point.