### PR TITLE
remove duplicate prometheus values

### DIFF
--- a/perf/istio/values-istio-test.yaml
+++ b/perf/istio/values-istio-test.yaml
@@ -100,9 +100,6 @@ pilot:
 ingress:
   enabled: false
 
-prometheus:
-  enabled: true
-
 sidecar-injector:
   enabled: true
 


### PR DESCRIPTION
As the file is, setting this line to enabled: false has no effect.