### PR TITLE
Fix memory limits on telemetry

### DIFF
--- a/perf/istio/values-istio-test.yaml
+++ b/perf/istio/values-istio-test.yaml
@@ -15,6 +15,8 @@ global:
     concurrency: 2
     accessLogFile: ""
     resources:
+      limits:
+        memory: 256Mi
       requests:
         #cpu: 50m
         #memory: 56Mi


### PR DESCRIPTION
Previously this was set below the requests, which made the installation
fail.