### PR TITLE
Add "SDS + CertManager" test scenario to the perf tests suite

### DIFF
--- a/perf/istio/gateway-bouncer/setup.sh
+++ b/perf/istio/gateway-bouncer/setup.sh
@@ -34,8 +34,8 @@ function install_gateway_bouncer() {
     kubectl -n $NAMESPACE delete configmap fortio-client-config
     kubectl -n $NAMESPACE create configmap fortio-client-config \
       --from-literal=external_addr=$INGRESS_IP
-    kubectl -n $NAMESPACE patch deployment istio-ingress-$NAMESPACE \
-      -p "{\"spec\":{\"template\":{\"metadata\":{\"labels\":{\"date\":\"`date +'%s'`\"}}}}}"
+    kubectl -n $NAMESPACE patch deployment fortio-client \
+      -p "{\"spec\":{\"template\":{\"metadata\":{\"annotations\":{\"date\":\"`date +'%s'`\"}}}}}"
   fi
 }
 

--- a/perf/istio/gateway-bouncer/templates/bouncer.yaml
+++ b/perf/istio/gateway-bouncer/templates/bouncer.yaml
@@ -68,7 +68,7 @@ spec:
                   kubectl \
                     -n {{ .Values.namespace }} \
                     patch deployment istio-ingress-{{ .Values.namespace }} \
-                    -p "{\"spec\":{\"template\":{\"metadata\":{\"labels\":{\"date\":\"`date +'%s'`\"}}}}}"
+                    -p "{\"spec\":{\"template\":{\"metadata\":{\"annotations\":{\"date\":\"`date +'%s'`\"}}}}}"
 
                   sleep {{ .Values.pilotDowntimeDurationSec }}
 

--- a/perf/istio/sds-certmanager/Chart.yaml
+++ b/perf/istio/sds-certmanager/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+name: istio
+version: 1.1.0
+description: Helm chart of the 'K8S Ingress + SDS + CertManager' scenario.
+keywords:
+  - istio
+  - ingressgateway
+  - certmanager
+  - sds
+sources:
+  - http://github.com/istio/istio
+engine: gotpl
+icon: https://istio.io/favicons/android-192x192.png

--- a/perf/istio/sds-certmanager/README.md
+++ b/perf/istio/sds-certmanager/README.md
@@ -1,0 +1,33 @@
+# SDS + CertManager
+
+This scenario verifies the use of Istio IngressGateway as standard K8S Ingress
+backend with SDS enabled and real TLS certificates managed by the CertManager.
+CertManager uses 'http01' mode and configures an Ingress (backed by Istio) in
+order to pass ACME challenge.
+
+This configuration requires a real GCloud DNS Zone setup in the current GCloud
+project. The setup script will use specified zone to create a subdomain based
+on the specified namespace pointing to the external IP of the Ingress Gateway.
+A TLS certificate will be issued for the subdomain and a Fortio Client will
+simulate external HTTPS traffic hitting internal Fortio Server to verify the
+connectivity.
+
+Use the following command to (re)install the scenario into a new/existing
+namespace (set `DRY_RUN=1` for a dry run):
+```
+NAMESPACE=sds-certmanager DNS_ZONE=myzone ./setup.sh
+```
+
+Assuming "myzone" has an "example.com" domain associated with it, the following
+subdomain will be configured and used in this scenario:
+
+```
+ingress.sds-certmanager.ns.example.com
+```
+
+Certificates are periodically rotated to verify that SDS is able to detect
+the renewed certificate and hot-swap the cert used by Ingress Gateway. The
+Fortio client is configured to abort on connectivity errors, so in order to
+verify the behavior check that the certificate was issued within last 30 min
+and 'fortio-client' pod hasn't been restarted (i.e. ensure that pod restarts
+do not correlate with certificate rotations).

--- a/perf/istio/sds-certmanager/setup.sh
+++ b/perf/istio/sds-certmanager/setup.sh
@@ -1,0 +1,111 @@
+#/bin/bash
+set -e
+
+command -v gcloud >/dev/null 2>&1 || {
+  echo >&2 "This scenario automatically creates necessary DNS-records in order"
+  echo >&2 "to get a obtain a TLS certificate from an ACME-compatible issuer."
+  echo >&2 "At the moment the DNS manipulation logic is implemented for Google"
+  echo >&2 "Cloud only and requires presence of GCloud SDK and a Google Cloud"
+  echo >&2 "project with at least one DNS Zone configured."
+  echo >&2
+  echo >&2 "Looks like GCloud SDK is not present in the PATH. Aborting..."
+
+  exit 1
+}
+
+NAMESPACE=${NAMESPACE:?"New/existing NAMESPACE to install this scenario into"}
+DNS_ZONE=${DNS_ZONE:?"Name of GCloud DNS zone to use for a new domain record"}
+
+function install_sds_certmanager() {
+  local DIRNAME="${1:?"output dir"}"
+  local OUTFILE="${DIRNAME}/sds_certmanager.yaml"
+  local INGRESS_IP=""
+  local INGRESS_DOMAIN=""
+
+  # Extracting the DNS name of the specified zone, so that the right domain
+  # can be configured during installation phase.
+  local DNS_NAME=$(gcloud dns managed-zones \
+    describe $DNS_ZONE --format='value(dnsName)')
+
+  if [[ -z "${DNS_NAME}" ]]; then
+    echo "Failed to resolve DNS_NAME of the proveded DNS_ZONE: ${DNS_ZONE}" 1>&2
+    exit 1
+  else
+    INGRESS_DOMAIN="ingress.${NAMESPACE}.ns.${DNS_NAME::-1}"
+    echo "The following ingress domain will be configured: ${INGRESS_DOMAIN}"
+  fi
+
+  # Preparing the installation template.
+  helm -n $NAMESPACE template \
+    --set namespace=$NAMESPACE \
+    --set ingressDomain=$INGRESS_DOMAIN \
+    . > "${OUTFILE}"
+
+  if [[ -z "${DRY_RUN}" ]]; then
+    kubectl -n $NAMESPACE apply -f "${OUTFILE}"
+
+    # Waiting until LoadBalancer is created and retrieving the assigned
+    # external IP address.
+    echo "Awaiting LoadBalancer creation and fetching assigned external IP..."
+
+    while : ; do
+      INGRESS_IP=$(kubectl -n $NAMESPACE \
+        get service istio-ingress-$NAMESPACE \
+        -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+
+      if [[ -z "${INGRESS_IP}" ]]; then
+        echo "Looks like LoadBalancer creation is still pending, waiting..."
+        sleep 5s
+      else
+        echo "Discovered external IP of the LoadBalancer: ${INGRESS_IP}"
+        break
+      fi
+    done
+
+    echo "Configuring the specified GCloud DNS Zone..."
+
+    if [ -f "./transaction.yaml" ]; then
+      gcloud dns record-sets transaction abort --zone "$DNS_ZONE"
+    fi
+
+    gcloud dns record-sets transaction start \
+      --zone "$DNS_ZONE"
+
+    local OLD_IP=$(gcloud dns record-sets list \
+      --zone "$DNS_ZONE" \
+      --name "${INGRESS_DOMAIN}." \
+      --format "value(rrdatas)")
+
+    if [[ ! -z "${OLD_IP}" ]]; then
+      local OLD_TTL=$(gcloud dns record-sets list \
+        --zone "$DNS_ZONE" \
+        --name "${INGRESS_DOMAIN}." \
+        --format "value(ttl)")
+      local OLD_TYPE=$(gcloud dns record-sets list \
+        --zone "$DNS_ZONE" \
+        --name "${INGRESS_DOMAIN}." \
+        --format "value(type)")
+
+      gcloud dns record-sets transaction remove \
+        --zone "$DNS_ZONE" \
+        --name "${INGRESS_DOMAIN}." \
+        --type "${OLD_TYPE}" \
+        --ttl "${OLD_TTL}" \
+        "${OLD_IP}"
+    fi
+
+    gcloud dns record-sets transaction add $INGRESS_IP \
+      --zone "$DNS_ZONE" \
+      --name "${INGRESS_DOMAIN}." \
+      --ttl "60" \
+      --type "A"
+    gcloud dns record-sets transaction execute \
+      --zone $DNS_ZONE
+  fi
+}
+
+WD=$(dirname $0)
+WD=$(cd $WD; pwd)
+mkdir -p "${WD}/tmp"
+
+install_sds_certmanager "${WD}/tmp" $*

--- a/perf/istio/sds-certmanager/templates/certmanager.yaml
+++ b/perf/istio/sds-certmanager/templates/certmanager.yaml
@@ -1,0 +1,280 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: clusterissuers.certmanager.k8s.io
+  annotations:
+    "helm.sh/hook": crd-install
+  labels:
+    app: certmanager
+    chart: certmanager
+    heritage: Tiller
+    release: istio
+spec:
+  group: certmanager.k8s.io
+  version: v1alpha1
+  names:
+    kind: ClusterIssuer
+    plural: clusterissuers
+  scope: Cluster
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: issuers.certmanager.k8s.io
+  annotations:
+    "helm.sh/hook": crd-install
+  labels:
+    app: certmanager
+    chart: certmanager
+    heritage: Tiller
+    release: istio
+spec:
+  group: certmanager.k8s.io
+  version: v1alpha1
+  names:
+    kind: Issuer
+    plural: issuers
+  scope: Namespaced
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: certificates.certmanager.k8s.io
+  annotations:
+    "helm.sh/hook": crd-install
+  labels:
+    app: certmanager
+    chart: certmanager
+    heritage: Tiller
+    release: istio
+spec:
+  additionalPrinterColumns:
+    - JSONPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - JSONPath: .spec.secretName
+      name: Secret
+      type: string
+    - JSONPath: .spec.issuerRef.name
+      name: Issuer
+      type: string
+      priority: 1
+    - JSONPath: .status.conditions[?(@.type=="Ready")].message
+      name: Status
+      type: string
+      priority: 1
+    - JSONPath: .metadata.creationTimestamp
+      description: |-
+        CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+
+        Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
+      name: Age
+      type: date
+  group: certmanager.k8s.io
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    kind: Certificate
+    plural: certificates
+    shortNames:
+      - cert
+      - certs
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: orders.certmanager.k8s.io
+  annotations:
+    "helm.sh/hook": crd-install
+  labels:
+    app: certmanager
+    chart: certmanager
+    heritage: Tiller
+    release: istio
+spec:
+  additionalPrinterColumns:
+    - JSONPath: .status.state
+      name: State
+      type: string
+    - JSONPath: .spec.issuerRef.name
+      name: Issuer
+      type: string
+      priority: 1
+    - JSONPath: .status.reason
+      name: Reason
+      type: string
+      priority: 1
+    - JSONPath: .metadata.creationTimestamp
+      description: |-
+        CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+
+        Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
+      name: Age
+      type: date
+  group: certmanager.k8s.io
+  version: v1alpha1
+  names:
+    kind: Order
+    plural: orders
+  scope: Namespaced
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: challenges.certmanager.k8s.io
+  annotations:
+    "helm.sh/hook": crd-install
+  labels:
+    app: certmanager
+    chart: certmanager
+    heritage: Tiller
+    release: istio
+spec:
+  additionalPrinterColumns:
+    - JSONPath: .status.state
+      name: State
+      type: string
+    - JSONPath: .spec.dnsName
+      name: Domain
+      type: string
+    - JSONPath: .status.reason
+      name: Reason
+      type: string
+    - JSONPath: .metadata.creationTimestamp
+      description: |-
+        CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+
+        Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
+      name: Age
+      type: date
+  group: certmanager.k8s.io
+  version: v1alpha1
+  names:
+    kind: Challenge
+    plural: challenges
+  scope: Namespaced
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: certmanager
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: certmanager
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: certmanager-{{ .Values.namespace }}
+  labels:
+    app: certmanager
+rules:
+  - apiGroups: ["certmanager.k8s.io"]
+    resources: ["certificates", "certificates/finalizers", "issuers", "clusterissuers", "orders", "orders/finalizers", "challenges"]
+    verbs: ["*"]
+  - apiGroups: [""]
+    resources: ["configmaps", "secrets", "events", "services", "pods"]
+    verbs: ["*"]
+  - apiGroups: ["extensions"]
+    resources: ["ingresses"]
+    verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: certmanager-{{ .Values.namespace }}
+  labels:
+    app: certmanager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: certmanager-{{ .Values.namespace }}
+subjects:
+  - name: certmanager
+    namespace: {{ .Values.namespace }}
+    kind: ServiceAccount
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: certmanager
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: certmanager
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: certmanager
+  template:
+    metadata:
+      labels:
+        app: certmanager
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ""
+    spec:
+      serviceAccountName: certmanager
+      containers:
+      - name: certmanager
+        image: "{{ .Values.certManagerImage }}"
+        imagePullPolicy: Always
+        args:
+        - --cluster-resource-namespace=$(POD_NAMESPACE)
+        - --leader-election-namespace=$(POD_NAMESPACE)
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+---
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: Issuer
+metadata:
+  name: letsencrypt-staging
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: certmanager
+spec:
+  acme:
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    email: mailbox@{{ .Values.ingressDomain }}
+    privateKeySecretRef:
+      name: letsencrypt-staging
+    http01: {}
+---
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: Issuer
+metadata:
+  name: letsencrypt
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: certmanager
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: mailbox@{{ .Values.ingressDomain }}
+    privateKeySecretRef:
+      name: letsencrypt
+    http01: {}
+---
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: Certificate
+metadata:
+  name: cert-staging
+  namespace: {{ .Values.namespace }}
+spec:
+  secretName: cert-staging-tls
+  # A newly issued "Let's Encrypt" cert is valid for 90 days since 1 hour ago.
+  # The following directive will trigger renewal every 30 mins.
+  renewBefore: 129510m # (90 days) minus (1 hour) minus (30 mins)
+  issuerRef:
+    name: letsencrypt-staging
+  commonName: {{ .Values.ingressDomain }}
+  dnsNames:
+  - {{ .Values.ingressDomain }}
+  acme:
+    config:
+    - http01:
+        ingressClass: istio-ingress-{{ .Values.namespace }}
+      domains:
+      - {{ .Values.ingressDomain }}

--- a/perf/istio/sds-certmanager/templates/fortio-client.yaml
+++ b/perf/istio/sds-certmanager/templates/fortio-client.yaml
@@ -1,0 +1,41 @@
+# Fortio load generator that simulates external traffic. Communicates with the
+# internal service via external LoadBalancer which IP address is supposed to be
+# passed via a config map.
+# Expects real DNS name and attempts to connect over https (allowing
+# non-trusted certificates so we can use "staging" version of "Let's Encrypt").
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: fortio-client
+spec:
+  template:
+    metadata:
+      labels:
+        app: fortio-cli-raw
+        version: v1
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      containers:
+      - name: fortio-client
+        image: {{ .Values.fortioImage }}
+        imagePullPolicy: Always
+        args:
+          - load
+          - -t
+          - "0"
+          - -abort-on
+          - "-1"
+          - -timeout
+          - "{{ .Values.clientConnTimeoutDuration }}"
+          - -c
+          - "{{ .Values.numOfClientConns }}"
+          - -qps
+          - "{{ .Values.numOfClientQps }}"
+          - -https-insecure
+          - "https://{{ .Values.ingressDomain }}/echo?size=1024"
+        resources:
+          requests:
+            cpu: 250m
+            memory: "256m"

--- a/perf/istio/sds-certmanager/templates/fortio-server.yaml
+++ b/perf/istio/sds-certmanager/templates/fortio-server.yaml
@@ -1,0 +1,57 @@
+# A simple 'Hello World' style service running behind the IngressGateway that
+# is configured using standard K8S Ingress with a custom Ingress class defined
+# in Pilot mesh config.
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: fortio-server
+spec:
+  ports:
+  - port: 8080
+    name: http-echo
+  - port: 8079
+    name: grpc-ping
+  selector:
+    app: fortio-server
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: fortio-server
+spec:
+  template:
+    metadata:
+      labels:
+        app: fortio-server
+        version: v1
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      containers:
+      - name: fortio-server
+        image: {{ .Values.fortioImage }}
+        imagePullPolicy: Always
+        ports:
+         - containerPort: 8080
+         - containerPort: 8079
+        args:
+          - server
+        resources:
+          requests:
+            cpu: 250m
+            memory: "256m"
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: fortio-server
+spec:
+  rules:
+    - host: {{ .Values.ingressDomain }}
+      http:
+        paths:
+          - path: /echo.*
+            backend:
+              serviceName: fortio-server
+              servicePort: 8080

--- a/perf/istio/sds-certmanager/templates/ingress.yaml
+++ b/perf/istio/sds-certmanager/templates/ingress.yaml
@@ -1,6 +1,36 @@
 # IngressGateway setup that is configured to support standard K8S Ingress. The
 # deployment also features a readiness check that should prevent it from
 # receiving traffic until a configuration is delivered from Pilot.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: istio-ingress-{{ .Values.namespace }}-service-account
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: ingressgateway
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: istio-ingress-{{ .Values.namespace }}-sds
+  namespace: {{ .Values.namespace }}
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "watch", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: istio-ingress-{{ .Values.namespace }}-sds
+  namespace: {{ .Values.namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: istio-ingress-{{ .Values.namespace }}-sds
+subjects:
+- kind: ServiceAccount
+  name: istio-ingress-{{ .Values.namespace }}-service-account
 ---
 apiVersion: v1
 kind: Service
@@ -48,8 +78,24 @@ spec:
         sidecar.istio.io/inject: "false"
         scheduler.alpha.kubernetes.io/critical-pod: ""
     spec:
-      terminationGracePeriodSeconds: 120
+      serviceAccountName: istio-ingress-{{ .Values.namespace }}-service-account
       containers:
+        - name: ingress-sds
+          image: "{{ .Values.nodeAgentImage }}"
+          imagePullPolicy: Always
+          env:
+          - name: "ENABLE_WORKLOAD_SDS"
+            value: "false"
+          - name: "ENABLE_INGRESS_GATEWAY_SDS"
+            value: "true"
+          - name: "INGRESS_GATEWAY_NAMESPACE"
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.namespace
+          volumeMounts:
+          - name: ingressgatewaysdsudspath
+            mountPath: /var/run/ingress_gateway
         - name: ingress
           image: {{ .Values.proxyImage }}
           imagePullPolicy: Always
@@ -94,7 +140,7 @@ spec:
             timeoutSeconds: 1
           resources:
             requests:
-              cpu: 10m
+              cpu: 250m
           env:
           - name: POD_NAME
             valueFrom:
@@ -111,13 +157,19 @@ spec:
               fieldRef:
                 apiVersion: v1
                 fieldPath: status.podIP
+          - name: ISTIO_META_USER_SDS
+            value: "true"
           volumeMounts:
+          - name: sdsudspath
+            mountPath: /var/run/sds
           - name: istio-certs
             mountPath: /etc/certs
             readOnly: true
           - name: ingress-certs
             mountPath: /etc/istio/ingress-certs
             readOnly: true
+          - name: ingressgatewaysdsudspath
+            mountPath: /var/run/ingress_gateway
       volumes:
       - name: istio-certs
         secret:
@@ -127,6 +179,11 @@ spec:
         secret:
           secretName: istio-ingress-certs
           optional: true
+      - name: ingressgatewaysdsudspath
+        emptyDir: {}
+      - name: sdsudspath
+        hostPath:
+          path: /var/run/sds
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -175,3 +232,14 @@ spec:
         name: http
       hosts:
         - "*"
+    - port:
+        number: 443
+        name: https
+        protocol: HTTPS
+      tls:
+        mode: SIMPLE
+        serverCertificate: "sds"
+        privateKey: "sds"
+        credentialName: "cert-staging-tls" # must be the same as secret
+      hosts:
+      - "{{ .Values.ingressDomain }}"

--- a/perf/istio/sds-certmanager/templates/namespace.yaml
+++ b/perf/istio/sds-certmanager/templates/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Values.namespace }}
+  labels:
+    istio-injection: disabled

--- a/perf/istio/sds-certmanager/templates/pilot.yaml
+++ b/perf/istio/sds-certmanager/templates/pilot.yaml
@@ -1,0 +1,326 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: istio-pilot-service-account
+  labels:
+    app: istio-pilot
+    release: istio
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: istio-pilot-{{ .Values.namespace }}
+  labels:
+    app: istio-pilot
+    release: istio
+rules:
+  - apiGroups: ["config.istio.io"]
+    resources: ["*"]
+    verbs: ["*"]
+  - apiGroups: ["rbac.istio.io"]
+    resources: ["*"]
+    verbs: ["get", "watch", "list"]
+  - apiGroups: ["networking.istio.io"]
+    resources: ["*"]
+    verbs: ["*"]
+  - apiGroups: ["authentication.istio.io"]
+    resources: ["*"]
+    verbs: ["*"]
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["*"]
+  - apiGroups: ["extensions"]
+    resources: ["thirdpartyresources", "thirdpartyresources.extensions", "ingresses", "ingresses/status"]
+    verbs: ["*"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["create", "get", "list", "watch", "update"]
+  - apiGroups: [""]
+    resources: ["endpoints", "pods", "services"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["namespaces", "nodes", "secrets"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: istio-pilot-{{ .Values.namespace }}
+  labels:
+    app: istio-pilot
+    release: istio
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: istio-pilot-{{ .Values.namespace }}
+subjects:
+  - kind: ServiceAccount
+    name: istio-pilot-service-account
+    namespace: {{ .Values.namespace }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: istio
+  labels:
+    app: istio
+    chart: istio-1.1.0
+    heritage: Tiller
+    release: istio
+data:
+  mesh: |-
+    # Set the following variable to true to disable policy checks by the Mixer.
+    # Note that metrics will still be reported to the Mixer.
+    disablePolicyChecks: false
+
+    # Set enableTracing to false to disable request tracing.
+    enableTracing: true
+
+    # Set accessLogFile to empty string to disable access log.
+    accessLogFile: "/dev/stdout"
+
+    # If accessLogEncoding is TEXT, value will be used directly as the log format
+    # example: "[%START_TIME%] %REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\n"
+    # If AccessLogEncoding is JSON, value will be parsed as map[string]string
+    # example: '{"start_time": "%START_TIME%", "req_method": "%REQ(:METHOD)%"}'
+    # Leave empty to use default log format
+    accessLogFormat: ''
+
+    # Set accessLogEncoding to JSON or TEXT to configure sidecar access log
+    accessLogEncoding: 'TEXT'
+
+    #
+    # Deprecated: mixer is using EDS
+    #mixerCheckServer: istio-policy.istio-micro-ingress.svc.cluster.local:9091
+    #mixerReportServer: istio-telemetry.istio-micro-ingress.svc.cluster.local:9091
+
+    # policyCheckFailOpen allows traffic in cases when the mixer policy service cannot be reached.
+    # Default is false which means the traffic is denied when the client is unable to connect to Mixer.
+    policyCheckFailOpen: false
+
+    # Set if using LoadBalancer Service. For NodePort, blank. Note that nodeport requires app:ingressgateway label.
+    ingressService: istio-ingress-{{ .Values.namespace }}
+    ingressControllerMode: "DEFAULT"
+    ingressClass: istio-ingress-{{ .Values.namespace }}
+
+    # Unix Domain Socket through which envoy communicates with NodeAgent SDS to get
+    # key/cert for mTLS. Use secret-mount files instead of SDS if set to empty.
+    sdsUdsPath:
+
+    # This flag is used by secret discovery service(SDS).
+    # If set to true(prerequisite: https://kubernetes.io/docs/concepts/storage/volumes/#projected), Istio will inject volumes mount
+    # for k8s service account JWT, so that K8s API server mounts k8s service account JWT to envoy container, which
+    # will be used to generate key/cert eventually. This isn't supported for non-k8s case.
+    enableSdsTokenMount: false
+
+    # This flag is used by secret discovery service(SDS).
+    # If set to true, envoy will fetch normal k8s service account JWT from '/var/run/secrets/kubernetes.io/serviceaccount/token'
+    # (https://kubernetes.io/docs/tasks/access-application-cluster/access-cluster/#accessing-the-api-from-a-pod)
+    # and pass to sds server, which will be used to request key/cert eventually.
+    # this flag is ignored if enableSdsTokenMount is set.
+    # This isn't supported for non-k8s case.
+    sdsUseK8sSaJwt: false
+
+    # The trust domain corresponds to the trust root of a system.
+    # Refer to https://github.com/spiffe/spiffe/blob/master/standards/SPIFFE-ID.md#21-trust-domain
+    trustDomain:
+
+    # Set the default behavior of the sidecar for handling outbound traffic from the application:
+    # REGISTRY_ONLY - restrict outbound traffic to services defined in the service registry as well
+    #   as those defined through ServiceEntries
+    # ALLOW_ANY - outbound traffic to unknown destinations will be allowed, in case there are no
+    #   services or ServiceEntries for the destination port
+    outboundTrafficPolicy:
+      mode: REGISTRY_ONLY
+
+    defaultConfig:
+      #
+      # TCP connection timeout between Envoy & the application, and between Envoys.
+      connectTimeout: 10s
+      #
+      ### ADVANCED SETTINGS #############
+      # Where should envoy's configuration be stored in the istio-proxy container
+      configPath: "/etc/istio/proxy"
+      binaryPath: "/usr/local/bin/envoy"
+      # The pseudo service name used for Envoy.
+      serviceCluster: istio-proxy
+      # These settings that determine how long an old Envoy
+      # process should be kept alive after an occasional reload.
+      drainDuration: 45s
+      parentShutdownDuration: 1m0s
+      #
+      # The mode used to redirect inbound connections to Envoy. This setting
+      # has no effect on outbound traffic: iptables REDIRECT is always used for
+      # outbound connections.
+      # If "REDIRECT", use iptables REDIRECT to NAT and redirect to Envoy.
+      # The "REDIRECT" mode loses source addresses during redirection.
+      # If "TPROXY", use iptables TPROXY to redirect to Envoy.
+      # The "TPROXY" mode preserves both the source and destination IP
+      # addresses and ports, so that they can be used for advanced filtering
+      # and manipulation.
+      # The "TPROXY" mode also configures the sidecar to run with the
+      # CAP_NET_ADMIN capability, which is required to use TPROXY.
+      #interceptionMode: REDIRECT
+      #
+      # Port where Envoy listens (on local host) for admin commands
+      # You can exec into the istio-proxy container in a pod and
+      # curl the admin port (curl http://localhost:15000/) to obtain
+      # diagnostic information from Envoy. See
+      # https://lyft.github.io/envoy/docs/operations/admin.html
+      # for more details
+      proxyAdminPort: 15000
+      #
+      # Set concurrency to a specific number to control the number of Proxy worker threads.
+      # If set to 0 (default), then start worker thread for each CPU thread/core.
+      concurrency: 0
+      #
+      tracing:
+        zipkin:
+          # Address of the Zipkin collector
+          address: zipkin.istio-system:9411
+      #
+      # Mutual TLS authentication between sidecars and istio control plane.
+      controlPlaneAuthPolicy: NONE
+      #
+      # Address where istio Pilot service is running
+      discoveryAddress: istio-pilot.{{ .Values.namespace }}:15010
+
+  # Configuration file for the mesh networks to be used by the Split Horizon EDS.
+  meshNetworks: |-
+    networks: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: istio-pilot
+  labels:
+    app: istio-pilot
+    release: istio
+spec:
+  ports:
+    - port: 15010
+      name: grpc-xds # direct
+    - port: 8080
+      name: http-legacy-discovery # direct
+    - port: 9093
+      name: http-monitoring
+  selector:
+    istio: pilot
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: istio-pilot
+  labels:
+    app: istio-pilot
+    release: istio
+    istio: pilot
+  annotations:
+    checksum/config-volume: f8da08b6b8c170dde721efd680270b2901e750d4aa186ebb6c22bef5b78a43f9
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        istio: pilot
+        app: pilot
+      annotations:
+        sidecar.istio.io/inject: "false"
+        scheduler.alpha.kubernetes.io/critical-pod: ""
+    spec:
+      serviceAccountName: istio-pilot-service-account
+      containers:
+        - name: discovery
+          image: {{ .Values.pilotImage }}
+          imagePullPolicy: Always
+          args:
+            - "discovery"
+            - --monitoringAddr=:9093
+            - --domain
+            - cluster.local
+            - --secureGrpcAddr
+            - ""
+          ports:
+            - containerPort: 8080
+            - containerPort: 15010
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 30
+            timeoutSeconds: 5
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            - name: PILOT_CACHE_SQUASH
+              value: "5"
+            - name: GODEBUG
+              value: "gctrace=2"
+            - name: PILOT_PUSH_THROTTLE_COUNT
+              value: "100"
+            - name: PILOT_TRACE_SAMPLING
+              value: "100"
+            - name: K8S_INGRESS_NS
+              value: {{ .Values.namespace }}
+          resources:
+            requests:
+              cpu: 500m
+              memory: 2048Mi
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/istio/config
+            - name: istio-certs
+              mountPath: /etc/certs
+              readOnly: true
+      volumes:
+        - name: config-volume
+          configMap:
+            name: istio
+        - name: istio-certs
+          secret:
+            secretName: istio.istio-pilot-service-account
+            optional: true
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: beta.kubernetes.io/arch
+                    operator: In
+                    values:
+                      - amd64
+                      - ppc64le
+                      - s390x
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 2
+              preference:
+                matchExpressions:
+                  - key: beta.kubernetes.io/arch
+                    operator: In
+                    values:
+                      - amd64
+            - weight: 2
+              preference:
+                matchExpressions:
+                  - key: beta.kubernetes.io/arch
+                    operator: In
+                    values:
+                      - ppc64le
+            - weight: 2
+              preference:
+                matchExpressions:
+                  - key: beta.kubernetes.io/arch
+                    operator: In
+                    values:
+                      - s390x
+      imagePullSecrets:
+        - name: private-registry-creds

--- a/perf/istio/sds-certmanager/values.yaml
+++ b/perf/istio/sds-certmanager/values.yaml
@@ -1,0 +1,10 @@
+fortioImage: fortio/fortio:latest
+pilotImage: gcr.io/istio-release/pilot:release-1.1-latest-daily
+kubectlImage: gcr.io/istio-release/kubectl:release-1.1-latest-daily
+proxyImage: gcr.io/istio-release/proxyv2:release-1.1-latest-daily
+nodeAgentImage: gcr.io/istio-release/node-agent-k8s:release-1.1-latest-daily
+certManagerImage: quay.io/jetstack/cert-manager-controller:v0.6.2
+
+numOfClientConns: 10
+numOfClientQps: 100
+clientConnTimeoutDuration: 15s


### PR DESCRIPTION
* Refer to the README.md for details.

* Similarly to the "gateway-bouncer" scenario this one attempts to
maintain all the components isolated within a dedicated namespace.

* Component definitions are currently hardcoded. This should be
addressed once the new installer is ready.

* Fixed the way restarts are being triggered for both this scenario
and 'gateway-bouncer' -- patching 'annotations' instead of labels.

* 'gateway-bouncer' bugfix related to the 'bounce' sequence.