### PR TITLE
Update connection duration for graceful shutdown

### DIFF
--- a/perf/stability/graceful-shutdown/values.yaml
+++ b/perf/stability/graceful-shutdown/values.yaml
@@ -1,4 +1,7 @@
-connectionDuration: 10 # maximum supported by httpbin is 10s
+# Should be set slightly below TERMINATION_DRAIN_DURATION_SECONDS
+# maximum supported by httpbin is 10s
+connectionDuration: 4 #
+
 qps: 10
 fortioImage: fortio/fortio:latest
 httpbinRedployMinutes: 1


### PR DESCRIPTION
Pilot changed by default to have a 5s termination period, so we need to
lower the connection duration default to match this