### PR TITLE
Use irate for CPU usage

### DIFF
--- a/perf/benchmark/runner/prom.py
+++ b/perf/benchmark/runner/prom.py
@@ -55,7 +55,7 @@ class Prom(object):
 
     def fetch_cpu_by_container(self):
         return self.fetch(
-            'rate(container_cpu_usage_seconds_total{container_name=~"mixer|policy|discovery|istio-proxy|captured|uncaptured"}[1m])',
+            'irate(container_cpu_usage_seconds_total{container_name=~"mixer|policy|discovery|istio-proxy|captured|uncaptured"}[1m])',
             metric_by_deployment_by_container,
             to_miliCpus)
 


### PR DESCRIPTION
Because rate uses the 1m rolling window, we see too low average CPU
because the first/last minutes include time before the test has started,
and we don't see the correct max/min values, and other tests data
impacts each other. irate fixes these issues.