### PR TITLE
Skip longer period before and after twopod

### DIFF
--- a/perf/benchmark/runner/prom.py
+++ b/perf/benchmark/runner/prom.py
@@ -55,7 +55,7 @@ class Prom(object):
 
     def fetch_cpu_by_container(self):
         return self.fetch(
-            'rate(container_cpu_usage_seconds_total{container_name=~"mixer|policy|discovery|istio-proxy|captured|uncaptured"}[1m])',
+            'irate(container_cpu_usage_seconds_total{container_name=~"mixer|policy|discovery|istio-proxy|captured|uncaptured"}[1m])',
             metric_by_deployment_by_container,
             to_miliCpus)
 


### PR DESCRIPTION
By doing this we can ensure that adjacent tests are less likely to impact each other, and that components have enough time to warm up/cooldown