### PR TITLE
Update service graph with standard pod labels

### DIFF
--- a/perf/istio-install/base/templates/istio-gateway.yaml
+++ b/perf/istio-install/base/templates/istio-gateway.yaml
@@ -80,7 +80,7 @@ spec:
   http:
   - route:
     - destination:
-        host: prometheus.istio-system.svc.cluster.local
+        host: istio-prometheus.istio-prometheus.svc.cluster.local
         port:
           number: 9090
 ---

--- a/perf/istio-install/setup_istio.sh
+++ b/perf/istio-install/setup_istio.sh
@@ -43,12 +43,15 @@ function install_prometheus() {
   helm fetch stable/prometheus-operator --untar --untardir "${PROMETHEUS_INSTALL}"
 
   kubectl create ns istio-prometheus || true
-
+  PROM_OP=tmp/prom-operator.yaml
   helm template "${PROMETHEUS_INSTALL}/prometheus-operator/" \
     --namespace istio-prometheus \
     --name prometheus \
-    -f "${PROMETHEUS_INSTALL}/values.yaml" \
-    | kubectl apply --namespace istio-prometheus -f -
+    -f "${PROMETHEUS_INSTALL}/values.yaml" > "${PROM_OP}"
+
+  echo "${PROM_OP}"
+
+  kubectl apply --namespace istio-prometheus -f "${PROM_OP}"
 
   # delete grafana pod so it redeploys with new config
   kubectl delete pod -l app=grafana
@@ -91,8 +94,9 @@ function install_istio() {
 
   # if release_url is not overridden then daily builds require
   # tag and hub overrides
+
   if [[ -z "${RELEASE_URL}" ]];then
-    opts="--set global.tag=${release}"
+    opts+=" --set global.tag=${release}"
     opts+=" --set global.hub=gcr.io/istio-release"
   fi
 

--- a/perf/load/templates/istio-ingress.gen.yaml
+++ b/perf/load/templates/istio-ingress.gen.yaml
@@ -26,10 +26,16 @@ spec:
   - route:
     - destination:
         host: {{ .Values.serviceNamePrefix }}0
-        subset: all
+        subset: v1
         port:
           number: 8080
-      weight: 100
+      weight: 30
+    - destination:
+        host: {{ .Values.serviceNamePrefix }}0
+        subset: v2
+        port:
+          number: 8080
+      weight: 70
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule

--- a/perf/load/templates/istio-ingress.gen.yaml
+++ b/perf/load/templates/istio-ingress.gen.yaml
@@ -43,12 +43,12 @@ spec:
   subsets:
   - name: all
     labels:
-      name: {{ .Values.serviceNamePrefix }}0
+      app: {{ .Values.serviceNamePrefix }}0
   - name: v1
     labels:
-      name: {{ .Values.serviceNamePrefix }}0
+      app: {{ .Values.serviceNamePrefix }}0
       version: v1
   - name: v2
     labels:
-      name: {{ .Values.serviceNamePrefix }}0
+      app: {{ .Values.serviceNamePrefix }}0
       version: v2

--- a/perf/load/templates/service-graph.gen.yaml
+++ b/perf/load/templates/service-graph.gen.yaml
@@ -167,7 +167,7 @@ spec:
   replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
-      name: {{ .Values.serviceNamePrefix }}0
+      app: {{ .Values.serviceNamePrefix }}0
   template:
     metadata:
       annotations:
@@ -175,7 +175,7 @@ spec:
         prometheus.io/scrape: "true"
 {{- end }}
       labels:
-        name: {{ .Values.serviceNamePrefix }}0
+        app: {{ .Values.serviceNamePrefix }}0
         role: service
         version: v1
     spec:
@@ -217,7 +217,7 @@ spec:
   replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
-      name: {{ .Values.serviceNamePrefix }}0
+      app: {{ .Values.serviceNamePrefix }}0
   template:
     metadata:
       annotations:
@@ -225,7 +225,7 @@ spec:
         prometheus.io/scrape: "true"
 {{- end }}
       labels:
-        name: {{ .Values.serviceNamePrefix }}0
+        app: {{ .Values.serviceNamePrefix }}0
         role: service
         version: v2
     spec:
@@ -268,7 +268,7 @@ spec:
   - name: http-web
     port: 8080
   selector:
-    name: {{ .Values.serviceNamePrefix }}0
+    app: {{ .Values.serviceNamePrefix }}0
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -280,7 +280,7 @@ spec:
   replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
-      name: {{ .Values.serviceNamePrefix }}0-0
+      app: {{ .Values.serviceNamePrefix }}0-0
   template:
     metadata:
       annotations:
@@ -288,7 +288,7 @@ spec:
         prometheus.io/scrape: "true"
 {{- end }}
       labels:
-        name: {{ .Values.serviceNamePrefix }}0-0
+        app: {{ .Values.serviceNamePrefix }}0-0
         role: service
         version: v1
     spec:
@@ -331,7 +331,7 @@ spec:
   - name: http-web
     port: 8080
   selector:
-    name: {{ .Values.serviceNamePrefix }}0-0
+    app: {{ .Values.serviceNamePrefix }}0-0
 status:
 ---
 apiVersion: apps/v1
@@ -344,7 +344,7 @@ spec:
   replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
-      name: {{ .Values.serviceNamePrefix }}0-1
+      app: {{ .Values.serviceNamePrefix }}0-1
   template:
     metadata:
       annotations:
@@ -352,7 +352,7 @@ spec:
         prometheus.io/scrape: "true"
 {{- end }}
       labels:
-        name: {{ .Values.serviceNamePrefix }}0-1
+        app: {{ .Values.serviceNamePrefix }}0-1
         role: service
         version: v1
     spec:
@@ -395,7 +395,7 @@ spec:
   - name: http-web
     port: 8080
   selector:
-    name: {{ .Values.serviceNamePrefix }}0-1
+    app: {{ .Values.serviceNamePrefix }}0-1
 status:
 ---
 apiVersion: apps/v1
@@ -408,7 +408,7 @@ spec:
   replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
-      name: {{ .Values.serviceNamePrefix }}0-2
+      app: {{ .Values.serviceNamePrefix }}0-2
   template:
     metadata:
       annotations:
@@ -416,7 +416,7 @@ spec:
         prometheus.io/scrape: "true"
 {{- end }}
       labels:
-        name: {{ .Values.serviceNamePrefix }}0-2
+        app: {{ .Values.serviceNamePrefix }}0-2
         role: service
         version: v1
     spec:
@@ -459,7 +459,7 @@ spec:
   - name: http-web
     port: 8080
   selector:
-    name: {{ .Values.serviceNamePrefix }}0-2
+    app: {{ .Values.serviceNamePrefix }}0-2
 status:
 ---
 apiVersion: apps/v1
@@ -472,7 +472,7 @@ spec:
   replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
-      name: {{ .Values.serviceNamePrefix }}0-3
+      app: {{ .Values.serviceNamePrefix }}0-3
   template:
     metadata:
       annotations:
@@ -480,7 +480,7 @@ spec:
         prometheus.io/scrape: "true"
 {{- end }}
       labels:
-        name: {{ .Values.serviceNamePrefix }}0-3
+        app: {{ .Values.serviceNamePrefix }}0-3
         role: service
         version: v1
     spec:
@@ -523,7 +523,7 @@ spec:
   - name: http-web
     port: 8080
   selector:
-    name: {{ .Values.serviceNamePrefix }}0-3
+    app: {{ .Values.serviceNamePrefix }}0-3
 status:
 ---
 apiVersion: apps/v1
@@ -536,7 +536,7 @@ spec:
   replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
-      name: {{ .Values.serviceNamePrefix }}0-4
+      app: {{ .Values.serviceNamePrefix }}0-4
   template:
     metadata:
       annotations:
@@ -544,7 +544,7 @@ spec:
         prometheus.io/scrape: "true"
 {{- end }}
       labels:
-        name: {{ .Values.serviceNamePrefix }}0-4
+        app: {{ .Values.serviceNamePrefix }}0-4
         role: service
         version: v1
     spec:
@@ -587,7 +587,7 @@ spec:
   - name: http-web
     port: 8080
   selector:
-    name: {{ .Values.serviceNamePrefix }}0-4
+    app: {{ .Values.serviceNamePrefix }}0-4
 status:
 ---
 apiVersion: apps/v1
@@ -600,7 +600,7 @@ spec:
   replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
-      name: {{ .Values.serviceNamePrefix }}0-5
+      app: {{ .Values.serviceNamePrefix }}0-5
   template:
     metadata:
       annotations:
@@ -608,7 +608,7 @@ spec:
         prometheus.io/scrape: "true"
 {{- end }}
       labels:
-        name: {{ .Values.serviceNamePrefix }}0-5
+        app: {{ .Values.serviceNamePrefix }}0-5
         role: service
         version: v1
     spec:
@@ -651,7 +651,7 @@ spec:
   - name: http-web
     port: 8080
   selector:
-    name: {{ .Values.serviceNamePrefix }}0-5
+    app: {{ .Values.serviceNamePrefix }}0-5
 status:
 ---
 apiVersion: apps/v1
@@ -664,7 +664,7 @@ spec:
   replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
-      name: {{ .Values.serviceNamePrefix }}0-6
+      app: {{ .Values.serviceNamePrefix }}0-6
   template:
     metadata:
       annotations:
@@ -672,7 +672,7 @@ spec:
         prometheus.io/scrape: "true"
 {{- end }}
       labels:
-        name: {{ .Values.serviceNamePrefix }}0-6
+        app: {{ .Values.serviceNamePrefix }}0-6
         role: service
         version: v1
     spec:
@@ -715,7 +715,7 @@ spec:
   - name: http-web
     port: 8080
   selector:
-    name: {{ .Values.serviceNamePrefix }}0-6
+    app: {{ .Values.serviceNamePrefix }}0-6
 status:
 ---
 apiVersion: apps/v1
@@ -728,7 +728,7 @@ spec:
   replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
-      name: {{ .Values.serviceNamePrefix }}0-7
+      app: {{ .Values.serviceNamePrefix }}0-7
   template:
     metadata:
       annotations:
@@ -736,7 +736,7 @@ spec:
         prometheus.io/scrape: "true"
 {{- end }}
       labels:
-        name: {{ .Values.serviceNamePrefix }}0-7
+        app: {{ .Values.serviceNamePrefix }}0-7
         role: service
         version: v1
     spec:
@@ -779,7 +779,7 @@ spec:
   - name: http-web
     port: 8080
   selector:
-    name: {{ .Values.serviceNamePrefix }}0-7
+    app: {{ .Values.serviceNamePrefix }}0-7
 status:
 ---
 apiVersion: apps/v1
@@ -792,7 +792,7 @@ spec:
   replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
-      name: {{ .Values.serviceNamePrefix }}0-8
+      app: {{ .Values.serviceNamePrefix }}0-8
   template:
     metadata:
       annotations:
@@ -800,7 +800,7 @@ spec:
         prometheus.io/scrape: "true"
 {{- end }}
       labels:
-        name: {{ .Values.serviceNamePrefix }}0-8
+        app: {{ .Values.serviceNamePrefix }}0-8
         role: service
         version: v1
     spec:
@@ -843,7 +843,7 @@ spec:
   - name: http-web
     port: 8080
   selector:
-    name: {{ .Values.serviceNamePrefix }}0-8
+    app: {{ .Values.serviceNamePrefix }}0-8
 status:
 ---
 apiVersion: apps/v1
@@ -856,7 +856,7 @@ spec:
   replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
-      name: {{ .Values.serviceNamePrefix }}0-0-0
+      app: {{ .Values.serviceNamePrefix }}0-0-0
   template:
     metadata:
       annotations:
@@ -864,7 +864,7 @@ spec:
         prometheus.io/scrape: "true"
 {{- end }}
       labels:
-        name: {{ .Values.serviceNamePrefix }}0-0-0
+        app: {{ .Values.serviceNamePrefix }}0-0-0
         role: service
         version: v1
     spec:
@@ -907,7 +907,7 @@ spec:
   - name: http-web
     port: 8080
   selector:
-    name: {{ .Values.serviceNamePrefix }}0-0-0
+    app: {{ .Values.serviceNamePrefix }}0-0-0
 status:
 ---
 apiVersion: apps/v1
@@ -920,7 +920,7 @@ spec:
   replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
-      name: {{ .Values.serviceNamePrefix }}0-1-0
+      app: {{ .Values.serviceNamePrefix }}0-1-0
   template:
     metadata:
       annotations:
@@ -928,7 +928,7 @@ spec:
         prometheus.io/scrape: "true"
 {{- end }}
       labels:
-        name: {{ .Values.serviceNamePrefix }}0-1-0
+        app: {{ .Values.serviceNamePrefix }}0-1-0
         role: service
         version: v1
     spec:
@@ -971,7 +971,7 @@ spec:
   - name: http-web
     port: 8080
   selector:
-    name: {{ .Values.serviceNamePrefix }}0-1-0
+    app: {{ .Values.serviceNamePrefix }}0-1-0
 status:
 ---
 apiVersion: apps/v1
@@ -984,7 +984,7 @@ spec:
   replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
-      name: {{ .Values.serviceNamePrefix }}0-2-0
+      app: {{ .Values.serviceNamePrefix }}0-2-0
   template:
     metadata:
       annotations:
@@ -992,7 +992,7 @@ spec:
         prometheus.io/scrape: "true"
 {{- end }}
       labels:
-        name: {{ .Values.serviceNamePrefix }}0-2-0
+        app: {{ .Values.serviceNamePrefix }}0-2-0
         role: service
         version: v1
     spec:
@@ -1035,7 +1035,7 @@ spec:
   - name: http-web
     port: 8080
   selector:
-    name: {{ .Values.serviceNamePrefix }}0-2-0
+    app: {{ .Values.serviceNamePrefix }}0-2-0
 status:
 ---
 apiVersion: apps/v1
@@ -1048,7 +1048,7 @@ spec:
   replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
-      name: {{ .Values.serviceNamePrefix }}0-3-0
+      app: {{ .Values.serviceNamePrefix }}0-3-0
   template:
     metadata:
       annotations:
@@ -1056,7 +1056,7 @@ spec:
         prometheus.io/scrape: "true"
 {{- end }}
       labels:
-        name: {{ .Values.serviceNamePrefix }}0-3-0
+        app: {{ .Values.serviceNamePrefix }}0-3-0
         role: service
         version: v1
     spec:
@@ -1099,7 +1099,7 @@ spec:
   - name: http-web
     port: 8080
   selector:
-    name: {{ .Values.serviceNamePrefix }}0-3-0
+    app: {{ .Values.serviceNamePrefix }}0-3-0
 status:
 ---
 apiVersion: apps/v1
@@ -1112,7 +1112,7 @@ spec:
   replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
-      name: {{ .Values.serviceNamePrefix }}0-4-0
+      app: {{ .Values.serviceNamePrefix }}0-4-0
   template:
     metadata:
       annotations:
@@ -1120,7 +1120,7 @@ spec:
         prometheus.io/scrape: "true"
 {{- end }}
       labels:
-        name: {{ .Values.serviceNamePrefix }}0-4-0
+        app: {{ .Values.serviceNamePrefix }}0-4-0
         role: service
         version: v1
     spec:
@@ -1163,7 +1163,7 @@ spec:
   - name: http-web
     port: 8080
   selector:
-    name: {{ .Values.serviceNamePrefix }}0-4-0
+    app: {{ .Values.serviceNamePrefix }}0-4-0
 status:
 ---
 apiVersion: apps/v1
@@ -1176,7 +1176,7 @@ spec:
   replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
-      name: {{ .Values.serviceNamePrefix }}0-5-0
+      app: {{ .Values.serviceNamePrefix }}0-5-0
   template:
     metadata:
       annotations:
@@ -1184,7 +1184,7 @@ spec:
         prometheus.io/scrape: "true"
 {{- end }}
       labels:
-        name: {{ .Values.serviceNamePrefix }}0-5-0
+        app: {{ .Values.serviceNamePrefix }}0-5-0
         role: service
         version: v1
     spec:
@@ -1227,7 +1227,7 @@ spec:
   - name: tcp-web
     port: 8080
   selector:
-    name: {{ .Values.serviceNamePrefix }}0-5-0
+    app: {{ .Values.serviceNamePrefix }}0-5-0
 status:
 ---
 apiVersion: apps/v1
@@ -1240,7 +1240,7 @@ spec:
   replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
-      name: {{ .Values.serviceNamePrefix }}0-6-0
+      app: {{ .Values.serviceNamePrefix }}0-6-0
   template:
     metadata:
       annotations:
@@ -1248,7 +1248,7 @@ spec:
         prometheus.io/scrape: "true"
 {{- end }}
       labels:
-        name: {{ .Values.serviceNamePrefix }}0-6-0
+        app: {{ .Values.serviceNamePrefix }}0-6-0
         role: service
         version: v1
     spec:
@@ -1291,7 +1291,7 @@ spec:
   - name: tcp-web
     port: 8080
   selector:
-    name: {{ .Values.serviceNamePrefix }}0-6-0
+    app: {{ .Values.serviceNamePrefix }}0-6-0
 status:
 ---
 apiVersion: apps/v1
@@ -1304,7 +1304,7 @@ spec:
   replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
-      name: {{ .Values.serviceNamePrefix }}0-7-0
+      app: {{ .Values.serviceNamePrefix }}0-7-0
   template:
     metadata:
       annotations:
@@ -1312,7 +1312,7 @@ spec:
         prometheus.io/scrape: "true"
 {{- end }}
       labels:
-        name: {{ .Values.serviceNamePrefix }}0-7-0
+        app: {{ .Values.serviceNamePrefix }}0-7-0
         role: service
         version: v1
     spec:
@@ -1355,7 +1355,7 @@ spec:
   - name: tcp-web
     port: 8080
   selector:
-    name: {{ .Values.serviceNamePrefix }}0-7-0
+    app: {{ .Values.serviceNamePrefix }}0-7-0
 status:
 ---
 apiVersion: apps/v1
@@ -1368,7 +1368,7 @@ spec:
   replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
-      name: {{ .Values.serviceNamePrefix }}0-8-0
+      app: {{ .Values.serviceNamePrefix }}0-8-0
   template:
     metadata:
       annotations:
@@ -1376,7 +1376,7 @@ spec:
         prometheus.io/scrape: "true"
 {{- end }}
       labels:
-        name: {{ .Values.serviceNamePrefix }}0-8-0
+        app: {{ .Values.serviceNamePrefix }}0-8-0
         role: service
         version: v1
     spec:
@@ -1419,5 +1419,5 @@ spec:
   - name: tcp-web
     port: 8080
   selector:
-    name: {{ .Values.serviceNamePrefix }}0-8-0
+    app: {{ .Values.serviceNamePrefix }}0-8-0
 status:


### PR DESCRIPTION
1. update service graph to use standard `app` label
2. fix prometheus virtual service with the new prometheus host 