### PR TITLE
Don't use helm repo for install

### DIFF
--- a/perf/istio-install/setup_istio.sh
+++ b/perf/istio-install/setup_istio.sh
@@ -63,22 +63,6 @@ function install_istio() {
 
   local outfile="$(download ${DIRNAME} ${release})"
 
-  if [[ ! -d "${DIRNAME}/${release}" ]];then
-      DN=$(mktemp -d)
-      tar -xzf "${outfile}" -C "${DN}" --strip-components 1
-      mv "${DN}/install/kubernetes/helm" "${DIRNAME}/${release}"
-      rm -Rf ${DN}
-      helm init -c
-      if [[ ! ${release} =~ release-1.0-* ]];then
-        local helmrepo="https://gcsweb.istio.io/gcs/istio-prerelease/daily-build/${release}/charts"
-        if [[ ! -z "${HELMREPO_URL}" ]];then
-          helmrepo="${HELMREPO_URL}"
-        fi
-        helm repo add istio.io "${helmrepo}"
-      fi
-      helm dep update "${DIRNAME}/${release}/istio" || true
-  fi
-
   kubectl create ns istio-system || true
 
   if [[ -z "${DRY_RUN}" ]];then


### PR DESCRIPTION
This isn't used anyways and breaks installing releases that don't have a helm repo (at least 1.0.6)