### PR TITLE
Add control plane chaos orchestration cron

### DIFF
--- a/perf/stability/graceful-shutdown/README.md
+++ b/perf/stability/graceful-shutdown/README.md
@@ -6,4 +6,4 @@ This is measured by sending many long lasting requests.
 
 When the server is redeployed, traffic should gracefully transition to the new deployment - connections should not be dropped.
 
-It is recommended to also run the `istio-upgrader` test, to ensure connections shutdown gracefully for Istio upgrades.
+It is recommended to also run the `istio-upgrader` test or the `istio-chaos`, to ensure connections are able to handle Istio control plane upgrades and downtime.

--- a/perf/stability/istio-chaos/Chart.yaml
+++ b/perf/stability/istio-chaos/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+name: istioChaos
+version: 1.0
+description: Helm chart for istio chaos test
+keywords:
+  - istio
+  - performance
+sources:
+  - http://github.com/istio/istio
+engine: gotpl

--- a/perf/stability/istio-chaos/README.md
+++ b/perf/stability/istio-chaos/README.md
@@ -1,0 +1,8 @@
+# Istio Chaos Test
+
+This test creates a cronjob that runs every `chaosIntervalMinutes` and does the following:
+
+1. Selects a number (between 1 and `chaosLevel`) of components to simultaneously scale to zero.
+2. Scales those components to zero
+3. Sleeps for `chaosDurationMinutes`
+4. Scales those components to one

--- a/perf/stability/istio-chaos/templates/chaos-cron.yaml
+++ b/perf/stability/istio-chaos/templates/chaos-cron.yaml
@@ -1,0 +1,89 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.namespace }}-account
+  namespace: istio-stability-{{ .Values.namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: {{ .Values.namespace }}-role
+rules:
+  - apiGroups: ["extensions"]
+    resources: ["deployments", "deployments/scale"]
+    verbs: ["get", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Values.namespace }}-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Values.namespace }}-role
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.namespace }}-account
+    namespace: istio-stability-{{ .Values.namespace }}
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: istio-chaos
+  namespace: istio-stability-{{ .Values.namespace }}
+  labels:
+    app: istio-chaos
+spec:
+  schedule: "*/{{ .Values.chaosIntervalMinutes }} * * * *" # Every x minutes
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          annotations:
+            sidecar.istio.io/inject: "false"
+          labels:
+            app: istio-chaos
+        spec:
+          serviceAccountName: {{ .Values.namespace }}-account
+          containers:
+            - name: istio-chaos
+              image: {{ .Values.kubectlImage }}
+              command:
+                - bash
+                - -c
+                - |-
+                  #!/bin/bash
+                  CHAOS_LEVEL={{ .Values.chaosDurationMinutes }}
+                  CHAOS_DURATION={{ .Values.chaosDurationMinutes }}
+                  COMPONENTS=({{ .Values.components }})
+
+                  function log () {
+                      echo "`date`: $1"
+                  }
+
+                  function scale () {
+                      IFS=' ' read -r -a TO_SCALE <<< "$1"
+                      for COMPONENT in ${TO_SCALE[@]}
+                      do
+                          log "Scaling $COMPONENT to $2..."
+                          kubectl scale deployment/$COMPONENT --replicas $2 -n istio-system
+                      done
+                  }
+
+                  # Randomise component array
+                  IFS=$'\n' COMPONENTS=($(sort -R <<<"${COMPONENTS[*]}"))
+
+                  # Select components for chaos
+                  COMPONENT_COUNT=$(( ( RANDOM % $CHAOS_LEVEL )  + 1 ))
+                  SELECTED_COMPONENTS=${COMPONENTS[@]::$COMPONENT_COUNT}
+                  log "The following components have been selected for chaos: $SELECTED_COMPONENTS"
+
+                  # Cause some chaos
+                  scale $SELECTED_COMPONENTS 0
+                  log "Sleeping for chaos duration (${CHAOS_DURATION}m)"
+                  sleep $((CHAOS_DURATION*60))
+                  scale $SELECTED_COMPONENTS 1
+                  log "Chaos managed."
+
+          restartPolicy: OnFailure
+

--- a/perf/stability/istio-chaos/templates/chaos-cron.yaml
+++ b/perf/stability/istio-chaos/templates/chaos-cron.yaml
@@ -53,7 +53,7 @@ spec:
                 - -c
                 - |-
                   #!/bin/bash
-                  CHAOS_LEVEL={{ .Values.chaosDurationMinutes }}
+                  CHAOS_LEVEL={{ .Values.chaosLevel }}
                   CHAOS_DURATION={{ .Values.chaosDurationMinutes }}
                   COMPONENTS=({{ .Values.components }})
 

--- a/perf/stability/istio-chaos/values.yaml
+++ b/perf/stability/istio-chaos/values.yaml
@@ -1,0 +1,6 @@
+namespace: istio-chaos
+chaosIntervalMinutes: 2 # Must be greater than duration to avoid race conditions... Unless you want chaos^2!
+chaosDurationMinutes: 1
+chaosLevel: 3 # The maximum number of components to kill simultaneously, selected at random.
+components: istio-pilot istio-citadel istio-galley istio-policy istio-telemetry istio-tracing
+kubectlImage: gcr.io/istio-release/kubectl:master-latest-daily

--- a/perf/stability/stability.mk
+++ b/perf/stability/stability.mk
@@ -5,7 +5,7 @@ STABILITY = $(WD)/setup_test.sh
 stable_tests = http10 graceful-shutdown gateway-bouncer mysql redis rabbitmq
 
 # Tests that need no special setup
-standard_tests = http10 graceful-shutdown redis rabbitmq
+standard_tests = http10 graceful-shutdown redis rabbitmq istio-chaos
 
 # Tests that have a special ./setup script in their folder
 extra_setup_tests = mysql sds-certmanager gateway-bouncer allconfig
@@ -19,7 +19,7 @@ $(extra_setup_tests):
 stability: $(stable_tests)
 
 # Extra tests that may be unstable or require additional configuration
-stability_all: stability sds-certmanager allconfig
+stability_all: stability sds-certmanager allconfig istio-chaos
 
 clean-stability:
 	kubectl get namespaces -oname | grep "istio-stability-" | xargs kubectl delete


### PR DESCRIPTION
This test creates a cronjob that runs every `chaosIntervalMinutes` and does the following:

 1. Selects a number (between 1 and `chaosLevel`) of components to simultaneously scale to zero.
2. Scales those components to zero
3. Sleeps for `chaosDurationMinutes`
4. Scales those components to one

Signed-off-by: Liam White <liam@tetrate.io>