### PR TITLE
Add sds ingress test with cert rotations

### DIFF
--- a/perf/istio-install/base/templates/istio-gateway.yaml
+++ b/perf/istio-install/base/templates/istio-gateway.yaml
@@ -50,6 +50,16 @@ spec:
         port:
           number: 3000
 ---
+apiVersion: "networking.istio.io/v1alpha3"
+kind: "DestinationRule"
+metadata:
+  name: "grafana"
+spec:
+  host: grafana.istio-system.svc.cluster.local
+  trafficPolicy:
+    tls:
+      mode: DISABLE
+---
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
@@ -83,6 +93,16 @@ spec:
         host: istio-prometheus.istio-prometheus.svc.cluster.local
         port:
           number: 9090
+---
+apiVersion: "networking.istio.io/v1alpha3"
+kind: "DestinationRule"
+metadata:
+  name: "prom"
+spec:
+  host: istio-prometheus.istio-prometheus.svc.cluster.local
+  trafficPolicy:
+    tls:
+      mode: DISABLE
 ---
 {{- if $.Values.certManager }}
 apiVersion: certmanager.k8s.io/v1alpha1

--- a/perf/istio-install/values.yaml
+++ b/perf/istio-install/values.yaml
@@ -10,7 +10,6 @@ global:
   imagePullPolicy: Always
   k8sIngressSelector: ingressgateway
 
-  controlPlaneSecurityEnabled: true
 
   proxy:
     enableCoreDump: true
@@ -23,6 +22,19 @@ global:
       limits:
         memory: 256Mi
 
+  mtls:
+    # Default setting for service-to-service mtls. Can be set explicitly using
+    # destination rules or service annotations.
+    enabled: true
+
+  # 1.1.5 sds.enabled requires controlPlaneSecurity to be disabled.
+  controlPlaneSecurityEnabled: false
+  sds:
+    enabled: true
+    udsPath: "unix:/var/run/sds/uds_path"
+    useNormalJwt: true
+
+
 ingress:
   enabled: false
 
@@ -32,6 +44,8 @@ gateways:
 
   istio-ingressgateway:
     meshExpansion: true
+    sds:
+      enabled: true
     enabled: true
     secretVolumes:
     - name: istio-ingressgateway-certs
@@ -169,12 +183,12 @@ certmanager:
 
 
 nodeagent:
-  enabled: false
+  enabled: true
   image: node-agent-k8s
   env:
     CA_PROVIDER: "Citadel"
     CA_ADDR: "istio-citadel:8060"
     VALID_TOKEN: true
-    SECRET_GRACE_DURATION: "30m"
+    SECRET_GRACE_DURATION: "10m"
     SECRET_JOB_RUN_INTERVAL: "30s"
-    SECRET_TTL: "1h"
+    SECRET_TTL: "20m"

--- a/perf/load/common.sh
+++ b/perf/load/common.sh
@@ -8,6 +8,7 @@ function run_test() {
   helm -n ${ns} template \
           --set serviceNamePrefix="${prefix}" \
           --set Namespace="${ns}" \
+          --set domain="${DNS_DOMAIN}" \
           . > "${YAML}"
   echo "Wrote ${YAML}"
 
@@ -40,8 +41,6 @@ function start_servicegraphs() {
       ${CMD} "${WD}/loadclient/setup_test.sh" "${ns}" "${prefix}"
       ${CMD} run_test "${ns}" "${prefix}"
     fi
-
-    sleep 30
   }
 }
 

--- a/perf/load/common.sh
+++ b/perf/load/common.sh
@@ -41,6 +41,8 @@ function start_servicegraphs() {
       ${CMD} "${WD}/loadclient/setup_test.sh" "${ns}" "${prefix}"
       ${CMD} run_test "${ns}" "${prefix}"
     fi
+
+    sleep 30
   }
 }
 

--- a/perf/load/common.sh
+++ b/perf/load/common.sh
@@ -45,7 +45,7 @@ function start_servicegraphs() {
       ${CMD} run_test "${ns}" "${prefix}"
     fi
 
-    sleep 3
+    sleep 30
   }
 }
 

--- a/perf/load/common.sh
+++ b/perf/load/common.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+GATEWAY_URL=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+
 function run_test() {
   local ns=${1:?"namespaces"}
   local prefix=${2:?"prefix name for service. typically svc-"}
@@ -9,6 +11,7 @@ function run_test() {
           --set serviceNamePrefix="${prefix}" \
           --set Namespace="${ns}" \
           --set domain="${DNS_DOMAIN}" \
+          --set ingress="${GATEWAY_URL}" \
           . > "${YAML}"
   echo "Wrote ${YAML}"
 
@@ -42,7 +45,7 @@ function start_servicegraphs() {
       ${CMD} run_test "${ns}" "${prefix}"
     fi
 
-    sleep 30
+    sleep 3
   }
 }
 

--- a/perf/load/loadclient/setup_test.sh
+++ b/perf/load/loadclient/setup_test.sh
@@ -8,6 +8,8 @@ set -ex
 NAMESPACE=${1:?"namespace"}
 NAMEPREFIX=${2:?"prefix name for service. typically svc-"}
 
+HTTPS=${HTTPS:-"false"}
+
 GATEWAY_URL=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
 SERVICEHOST="${NAMEPREFIX}0.local"
 
@@ -17,6 +19,8 @@ function run_test() {
 	  --set serviceHost="${SERVICEHOST}" \
     --set Namespace="${NAMESPACE}" \
     --set ingress="${GATEWAY_URL}" \
+    --set domain="${DNS_DOMAIN}" \
+    --set https="${HTTPS}" \
           . > "${YAML}"
   echo "Wrote ${YAML}"
 

--- a/perf/load/loadclient/templates/load_gen.yaml
+++ b/perf/load/loadclient/templates/load_gen.yaml
@@ -30,7 +30,14 @@ spec:
         - "0.0001"
         - -H
         - "Host: {{ .Values.serviceHost }}"
+{{- if .Values.https }}
+        - -resolve
+        - {{ .Values.ingress }}
+        - -k
+        - "https://{{ .Values.serviceHost }}/{{ .Values.serviceURL  }}"
+{{- else }}
         - "http://{{ .Values.ingress }}/{{ .Values.serviceURL  }}"
+{{- end }}
         image: {{ .Values.image }}
         name: fortio
         ports:

--- a/perf/load/loadclient/templates/load_gen.yaml
+++ b/perf/load/loadclient/templates/load_gen.yaml
@@ -25,7 +25,7 @@ spec:
         - -qps
         - "{{ .Values.qps }}"
         - -t
-        - "0"
+        - "{{ .Values.runDuration }}"
         - -r
         - "0.0001"
         - -H

--- a/perf/load/loadclient/values.yaml
+++ b/perf/load/loadclient/values.yaml
@@ -5,7 +5,7 @@ connections: 8
 qps: 50
 size: 1024
 serviceHost: svc-0.local
-runDuration: 500  # 0 means run forever
+runDuration: 0  # 0 means run forever
 #serviceURL: productpage
 #image: tahler/fortio:prometheus
 image: fortio/fortio

--- a/perf/load/loadclient/values.yaml
+++ b/perf/load/loadclient/values.yaml
@@ -5,6 +5,7 @@ connections: 8
 qps: 50
 size: 1024
 serviceHost: svc-0.local
+runDuration: 500  # 0 means run forever
 #serviceURL: productpage
 #image: tahler/fortio:prometheus
 image: fortio/fortio

--- a/perf/load/loadclient/values.yaml
+++ b/perf/load/loadclient/values.yaml
@@ -6,5 +6,7 @@ qps: 50
 size: 1024
 serviceHost: svc-0.local
 #serviceURL: productpage
-image: tahler/fortio:prometheus
+#image: tahler/fortio:prometheus
+image: fortio/fortio
 replicas: 2
+https: false

--- a/perf/load/rotate/Dockerfile
+++ b/perf/load/rotate/Dockerfile
@@ -1,0 +1,3 @@
+FROM gcr.io/google-containers/hyperkube:v1.12.1
+# istio.io/istio$ bin/gobuild.sh ./generate_cert ./security/tools/generate_cert
+ADD generate_cert /usr/local/bin/

--- a/perf/load/rotate/README
+++ b/perf/load/rotate/README
@@ -1,0 +1,8 @@
+Config-changer has a rotate script that does the following
+
+1. Fetch cert and key from citadel
+2. Generate short lived certificate
+3. Rotate cert
+
+The script requires `generate_cert` tool from the security repository.
+The Dockerfile contained here builds the image.

--- a/perf/load/templates/config-changer.yaml
+++ b/perf/load/templates/config-changer.yaml
@@ -31,7 +31,7 @@ rules:
   verbs: ["*"]
 - apiGroups: [""]
   resources: ["configmaps", "endpoints", "pods", "services", "namespaces", "secrets", "replicationcontrollers"]
-  verbs: ["create", "get", "list", "watch", "update"]
+  verbs: ["create", "get", "list", "watch", "update", "patch"]
 - apiGroups: [""]
   resources: ["endpoints", "pods", "services"]
   verbs: ["get", "list", "watch"]
@@ -82,7 +82,7 @@ spec:
         - /script/run.sh
         - /bin/sleep
         - infinity
-        image: gcr.io/google-containers/hyperkube:v1.12.1
+        image: gcr.io/mixologist-142215/hyperkube:v1.12.1
         imagePullPolicy: IfNotPresent
         name: config-change
         volumeMounts:

--- a/perf/load/templates/config-map.yaml
+++ b/perf/load/templates/config-map.yaml
@@ -15,6 +15,7 @@ data:
       - entrypoint-gateway
       hosts:
       - {{ .Values.serviceNamePrefix }}0.local
+      - {{ .Values.serviceNamePrefix }}0.{{ .Values.domain }}
       http:
       - route:
         - destination:
@@ -38,6 +39,15 @@ metadata:
 data:
   run.sh: |
     #!/bin/bash
+    set -ex
+    WD=$(dirname $0)
+    WD=$(cd $WD;pwd)
+
+    ${WD}/rollout.sh &
+    ${WD}/rotate.sh {{ .Values.serviceNamePrefix }}0 {{ .Values.domain }} 60m &
+    wait
+  rollout.sh: |
+    #!/bin/bash
     # Canary rollout of v2
     while [[ true ]];do
       for v1 in 100 70 40 20;do
@@ -46,3 +56,28 @@ data:
         sleep {{ .Values.configSleep }}
       done
     done
+  rotate.sh: |
+    set -ex
+    # 1. Issues a new cert using citadel's key
+    # 2. Replaces the cert in the secret 
+    # 3. The secret is known as "${host}-cert"
+    function rotate_cert() {
+      local host=${1:?"hostname"}
+      local domain=${2:?"domain"}
+      local duration=${3:?"valid duration of the cert"}
+      local genNo=${4:?"generation number"}
+      local ns=${5:-"istio-system"}
+
+      gen=$(printf 'gen%.5d' ${genNo})
+      generate_cert -mode citadel -host "${host}.local,${host}.${domain},${host}-${gen}.local" -duration 30m
+
+      kubectl -n "${ns}" create secret generic "${host}-cert" --from-file=key=priv.pem --from-file=cert=cert.pem  --dry-run -o yaml | kubectl -n "${ns}" apply -f -
+    }
+
+    while [[ true ]];do
+      for ((ii=0; ii<65535; ii++)) {
+        rotate_cert $* ${ii}
+        sleep {{ .Values.configSleep }}
+      }
+    done
+

--- a/perf/load/templates/config-map.yaml
+++ b/perf/load/templates/config-map.yaml
@@ -54,6 +54,8 @@ data:
         v2=$((100-$v1))
         sed -e "s/V1_WEIGHT/$v1/" -e "s/V2_WEIGHT/$v2/" /data/cfg.yaml | kubectl -n {{ .Values.Namespace }} apply -f -
         sleep {{ .Values.configSleep }}
+        # add jitter
+        sleep $[ ( $RANDOM % {{ .Values.configSleep }} )  + 1 ]s
       done
     done
   rotate.sh: |
@@ -78,6 +80,6 @@ data:
       for ((ii=0; ii<65535; ii++)) {
         rotate_cert $* ${ii}
         sleep {{ .Values.configSleep }}
+        sleep $[ ( $RANDOM % {{ .Values.configSleep }} )  + 1 ]s
       }
     done
-

--- a/perf/load/templates/config-map.yaml
+++ b/perf/load/templates/config-map.yaml
@@ -43,6 +43,8 @@ data:
     WD=$(dirname $0)
     WD=$(cd $WD;pwd)
 
+    export INGRESS_IP={{ .Values.ingress }}
+
     ${WD}/rollout.sh &
     ${WD}/rotate.sh {{ .Values.serviceNamePrefix }}0 {{ .Values.domain }} 60m &
     wait
@@ -72,7 +74,7 @@ data:
       local ns=${5:-"istio-system"}
 
       gen=$(printf 'gen%.5d' ${genNo})
-      generate_cert -mode citadel -host "${host}.local,${host}.${domain},${host}-${gen}.local" -duration 30m
+      generate_cert -mode signer -signer-priv=ca.key -signer-cert=ca.cert -host "${host}.local,${host}.${domain},${host}-${gen}.local" -duration 30m
       if [[ $? -ne 0 ]];then
         errs=$((errs+1))
         return
@@ -82,7 +84,27 @@ data:
       if [[ $? -ne 0 ]];then
         errs=$((errs+1))
       fi
+
+      # check if the new certificate is visible
+      # We add generation number in the cert for verification.
+      for ((jj=0; jj<5; j++)) {
+        echo | openssl s_client -connect "${INGRESS_IP}:443" -servername "${host}.local" -CAfile ca.cert | openssl x509 -noout -text  > /tmp/aa
+        grep DNS /tmp/aa
+        if [[ $(grep "${host}-${gen}.local" /tmp/aa) ]];then
+          echo "Found ${host}-${gen}.local"
+          break
+        fi
+
+        echo "Did not find ${host}-${gen}.local"
+        sleep 10
+      }
     }
+
+    # fetch signer cert and key
+    # This is used to sign certificate for rotation.
+    kubectl get secret -n istio-system istio-ca-secret -o yaml > ca.yaml
+    awk '/ca-cert/ {print $2}' ca.yaml | base64 --decode > ca.cert
+    awk '/ca-key/ {print $2}' ca.yaml | base64 --decode > ca.key
 
     while [[ true ]];do
       for ((ii=0; ii<65535; ii++)) {

--- a/perf/load/templates/config-map.yaml
+++ b/perf/load/templates/config-map.yaml
@@ -59,7 +59,8 @@ data:
       done
     done
   rotate.sh: |
-    set -ex
+    set -x
+    errs=0
     # 1. Issues a new cert using citadel's key
     # 2. Replaces the cert in the secret 
     # 3. The secret is known as "${host}-cert"
@@ -72,8 +73,15 @@ data:
 
       gen=$(printf 'gen%.5d' ${genNo})
       generate_cert -mode citadel -host "${host}.local,${host}.${domain},${host}-${gen}.local" -duration 30m
+      if [[ $? -ne 0 ]];then
+        errs=$((errs+1))
+        return
+      fi
 
       kubectl -n "${ns}" create secret generic "${host}-cert" --from-file=key=priv.pem --from-file=cert=cert.pem  --dry-run -o yaml | kubectl -n "${ns}" apply -f -
+      if [[ $? -ne 0 ]];then
+        errs=$((errs+1))
+      fi
     }
 
     while [[ true ]];do

--- a/perf/load/templates/istio-ingress.gen.yaml
+++ b/perf/load/templates/istio-ingress.gen.yaml
@@ -6,12 +6,23 @@ spec:
   selector:
     istio: ingressgateway
   servers:
-  - hosts:
-    - {{ .Values.serviceNamePrefix }}0.local
-    port:
+  - port:
       name: http
       number: 80
       protocol: HTTP
+    hosts:
+    - {{ .Values.serviceNamePrefix }}0.local
+    - {{ .Values.serviceNamePrefix }}0.{{ .Values.domain }}
+  - port:
+      name: https
+      number: 443
+      protocol: HTTPS
+    tls:
+      mode: SIMPLE
+      credentialName: {{ .Values.serviceNamePrefix }}0-cert 
+    hosts:
+    - {{ .Values.serviceNamePrefix }}0.local
+    - {{ .Values.serviceNamePrefix }}0.{{ .Values.domain }}
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
@@ -22,6 +33,7 @@ spec:
   - entrypoint-gateway
   hosts:
   - {{ .Values.serviceNamePrefix }}0.local
+  - {{ .Values.serviceNamePrefix }}0.{{ .Values.domain }}
   http:
   - route:
     - destination:

--- a/perf/load/values.yaml
+++ b/perf/load/values.yaml
@@ -16,7 +16,7 @@ readinessProbe:
 prometheus_scrape: false
 
 # time between config changes
-configSleep: 60
+configSleep: 120
 # tcp does not support permissive mode
 # so readinessProbe
 #tcpReadinessProbe:

--- a/perf/load/values.yaml
+++ b/perf/load/values.yaml
@@ -16,7 +16,7 @@ readinessProbe:
 prometheus_scrape: false
 
 # time between config changes
-configSleep: 360
+configSleep: 60
 # tcp does not support permissive mode
 # so readinessProbe
 #tcpReadinessProbe:

--- a/perf/load/values.yaml
+++ b/perf/load/values.yaml
@@ -20,3 +20,6 @@ configSleep: 120
 # tcp does not support permissive mode
 # so readinessProbe
 #tcpReadinessProbe:
+
+# ingress should be set correctly
+ingress: 127.0.0.1


### PR DESCRIPTION
1. Add TLS options to load test
2. Update config changer to issue short lived certificates that will be sent to proxy by SDS
3. Add code to verify that the newly pushed certificate is actually presented.