### PR TITLE
Support non-https traffic

### DIFF
--- a/perf/load/common.sh
+++ b/perf/load/common.sh
@@ -4,6 +4,8 @@ SYSTEM_GATEWAY_URL=$(kubectl -n istio-system get service istio-ingressgateway -o
 INGRESS_GATEWAY_URL=$(kubectl -n istio-ingress get service istio-ingressgateway -o jsonpath='{.status.loadBalancer.ingress[0].ip}' || true)
 GATEWAY_URL=${SYSTEM_GATEWAY_URL:-$INGRESS_GATEWAY_URL}
 
+HTTPS=${HTTPS:-"false"}
+
 function run_test() {
   local ns=${1:?"namespaces"}
   local prefix=${2:?"prefix name for service. typically svc-"}
@@ -14,6 +16,7 @@ function run_test() {
           --set Namespace="${ns}" \
           --set domain="${DNS_DOMAIN}" \
           --set ingress="${GATEWAY_URL}" \
+          --set https="${HTTPS}" \
           . > "${YAML}"
   echo "Wrote ${YAML}"
 

--- a/perf/load/templates/istio-ingress.gen.yaml
+++ b/perf/load/templates/istio-ingress.gen.yaml
@@ -13,16 +13,18 @@ spec:
     hosts:
     - {{ .Values.serviceNamePrefix }}0.local
     - {{ .Values.serviceNamePrefix }}0.{{ .Values.domain }}
+{{- if .Values.https }}
   - port:
       name: https
       number: 443
       protocol: HTTPS
     tls:
       mode: SIMPLE
-      credentialName: {{ .Values.serviceNamePrefix }}0-cert 
+      credentialName: {{ .Values.serviceNamePrefix }}0-cert
     hosts:
     - {{ .Values.serviceNamePrefix }}0.local
     - {{ .Values.serviceNamePrefix }}0.{{ .Values.domain }}
+{{- end }}
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService

--- a/perf/load/values.yaml
+++ b/perf/load/values.yaml
@@ -23,3 +23,4 @@ configSleep: 120
 
 # ingress should be set correctly
 ingress: 127.0.0.1
+https: false


### PR DESCRIPTION
When we turned on SDS testing we went broke non-sds testing. Need this change to get load client working without sds