### PR TITLE
Allow skipping prometheus deployments

### DIFF
--- a/perf/istio-install/setup_istio.sh
+++ b/perf/istio-install/setup_istio.sh
@@ -90,8 +90,9 @@ function install_istio() {
 
   if [[ -z "${DRY_RUN}" ]];then
       kubectl apply -f "${FILENAME}"
-
-      "$WD/setup_prometheus.sh" ${DIRNAME}
+      if [[ -z "${SKIP_PROMETHEUS}" ]];then
+          "$WD/setup_prometheus.sh" ${DIRNAME}
+      fi
   fi
 
   echo "Wrote file ${FILENAME}"


### PR DESCRIPTION
This is useful for update runs, where we really just want istio updated, and don't want to nuke any tuning in Prometheus or elsewhere...