### PR TITLE
Skip prometheus for weekly upgrades

### DIFF
--- a/perf/auto-qual-test/base/deploy_latest_daily.sh
+++ b/perf/auto-qual-test/base/deploy_latest_daily.sh
@@ -12,7 +12,7 @@ if [[ ! -z "${TARGET_VERSION}" ]];then
   RELEASE_MAJOR_MINOR="${TARGET_VERSION}"
 fi
 LATEST_BUILD=$(curl -L https://gcsweb.istio.io/gcs/istio-prerelease/daily-build/$RELEASE_MAJOR_MINOR-latest.txt)
-HELMREPO_URL=https://gcsweb.istio.io/gcs/istio-prerelease/daily-build/$LATEST_BUILD/charts/ RELEASE_URL=https://gcsweb.istio.io/gcs/istio-prerelease/daily-build/$LATEST_BUILD/istio-$LATEST_BUILD-linux.tar.gz ./setup_istio.sh $RELEASE_MAJOR_MINOR
+SKIP_PROMETHEUS=true HELMREPO_URL=https://gcsweb.istio.io/gcs/istio-prerelease/daily-build/$LATEST_BUILD/charts/ RELEASE_URL=https://gcsweb.istio.io/gcs/istio-prerelease/daily-build/$LATEST_BUILD/istio-$LATEST_BUILD-linux.tar.gz ./setup_istio.sh $RELEASE_MAJOR_MINOR
 
 # trigger redeploy on services to get new sidecars
 /etc/scripts/redeploy.sh ALL


### PR DESCRIPTION
Prometheus will need to be tuned to the test for retention parameters, etc.  Redeploying it wipes out the tuning.  This does mean that test clusters will need to run the setup_istio script once manually without the skip_prometheus flag before running the automated upgrade job.

Prerequisite: #164 