### PR TITLE
Extend Sleep Command

### DIFF
--- a/isotope/README.md
+++ b/isotope/README.md
@@ -99,6 +99,27 @@ Each step in the script includes a command.
 ###### Sleep
 
 `sleep`: Pauses for a duration. Useful for simulating processing time.
+One needs to provide a probability distribution for this command.
+
+#### Examples
+
+Pause all requests by 100 ms:
+
+```yaml
+script:
+  - sleep: {100ms: 100}
+```
+
+Pause 50\% of the request by 1sec and 50\% of the request by 50ms:
+
+```yaml
+script:
+  - sleep: {1s: 50, 50ms: 50}
+```
+
+The percentages should sum upto 100 otherwise
+the program would generate an error and crash.
+
 
 ```yaml
 sleep: {{ Duration }}

--- a/isotope/convert/pkg/graph/script/concurrent_command_test.go
+++ b/isotope/convert/pkg/graph/script/concurrent_command_test.go
@@ -16,10 +16,11 @@ package script
 
 import (
 	"encoding/json"
-	"github.com/jmcvetta/randutil"
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/jmcvetta/randutil"
 )
 
 func TestConcurrentCommand_UnmarshalJSON(t *testing.T) {

--- a/isotope/convert/pkg/graph/script/concurrent_command_test.go
+++ b/isotope/convert/pkg/graph/script/concurrent_command_test.go
@@ -16,10 +16,10 @@ package script
 
 import (
 	"encoding/json"
+	"github.com/jmcvetta/randutil"
 	"reflect"
 	"testing"
 	"time"
-	"github.com/jmcvetta/randutil"
 )
 
 func TestConcurrentCommand_UnmarshalJSON(t *testing.T) {
@@ -36,7 +36,7 @@ func TestConcurrentCommand_UnmarshalJSON(t *testing.T) {
 		{
 			[]byte(`[{"sleep": {"1s": 100}}]`),
 			ConcurrentCommand{
-				SleepCommand([]randutil.Choice{randutil.Choice{100, 1 * time.Second}}),
+				SleepCommand([]randutil.Choice{{100, 1 * time.Second}}),
 			},
 			nil,
 		},
@@ -44,7 +44,7 @@ func TestConcurrentCommand_UnmarshalJSON(t *testing.T) {
 			[]byte(`[{"call": "A"}, {"sleep": {"10ms": 100}}]`),
 			ConcurrentCommand{
 				RequestCommand{ServiceName: "A"},
-				SleepCommand([]randutil.Choice{randutil.Choice{100, 10 * time.Millisecond}}),
+				SleepCommand([]randutil.Choice{{100, 10 * time.Millisecond}}),
 			},
 			nil,
 		},

--- a/isotope/convert/pkg/graph/script/concurrent_command_test.go
+++ b/isotope/convert/pkg/graph/script/concurrent_command_test.go
@@ -19,6 +19,7 @@ import (
 	"reflect"
 	"testing"
 	"time"
+	"github.com/jmcvetta/randutil"
 )
 
 func TestConcurrentCommand_UnmarshalJSON(t *testing.T) {
@@ -33,17 +34,17 @@ func TestConcurrentCommand_UnmarshalJSON(t *testing.T) {
 			nil,
 		},
 		{
-			[]byte(`[{"sleep": "1s"}]`),
+			[]byte(`[{"sleep": {"1s": 100}}]`),
 			ConcurrentCommand{
-				SleepCommand(1 * time.Second),
+				SleepCommand([]randutil.Choice{randutil.Choice{100, 1 * time.Second}}),
 			},
 			nil,
 		},
 		{
-			[]byte(`[{"call": "A"}, {"sleep": "10ms"}]`),
+			[]byte(`[{"call": "A"}, {"sleep": {"10ms": 100}}]`),
 			ConcurrentCommand{
 				RequestCommand{ServiceName: "A"},
-				SleepCommand(10 * time.Millisecond),
+				SleepCommand([]randutil.Choice{randutil.Choice{100, 10 * time.Millisecond}}),
 			},
 			nil,
 		},

--- a/isotope/convert/pkg/graph/script/script_test.go
+++ b/isotope/convert/pkg/graph/script/script_test.go
@@ -19,6 +19,7 @@ import (
 	"reflect"
 	"testing"
 	"time"
+	"github.com/jmcvetta/randutil"
 )
 
 func TestScript_UnmarshalJSON(t *testing.T) {
@@ -35,28 +36,28 @@ func TestScript_UnmarshalJSON(t *testing.T) {
 			nil,
 		},
 		{
-			[]byte(`[{"sleep": "1s"}]`),
+			[]byte(`[{"sleep": {"1s": 100}}]`),
 			Script{
-				SleepCommand(1 * time.Second),
+				SleepCommand([]randutil.Choice{randutil.Choice{100, 1 * time.Second}}),
 			},
 			nil,
 		},
 		{
-			[]byte(`[{"call": "A"}, {"sleep": "10ms"}]`),
+			[]byte(`[{"call": "A"}, {"sleep": {"10ms": 100}}]`),
 			Script{
 				RequestCommand{ServiceName: "A"},
-				SleepCommand(10 * time.Millisecond),
+				SleepCommand([]randutil.Choice{randutil.Choice{100, 10 * time.Millisecond}}),
 			},
 			nil,
 		},
 		{
-			[]byte(`[[{"call": "A"}, {"call": "B"}], {"sleep": "10ms"}]`),
+			[]byte(`[[{"call": "A"}, {"call": "B"}], {"sleep": {"10ms": 100}}]`),
 			Script{
 				ConcurrentCommand{
 					RequestCommand{ServiceName: "A"},
 					RequestCommand{ServiceName: "B"},
 				},
-				SleepCommand(10 * time.Millisecond),
+				SleepCommand([]randutil.Choice{randutil.Choice{100, 10 * time.Millisecond}}),
 			},
 			nil,
 		},

--- a/isotope/convert/pkg/graph/script/script_test.go
+++ b/isotope/convert/pkg/graph/script/script_test.go
@@ -16,10 +16,11 @@ package script
 
 import (
 	"encoding/json"
-	"github.com/jmcvetta/randutil"
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/jmcvetta/randutil"
 )
 
 func TestScript_UnmarshalJSON(t *testing.T) {

--- a/isotope/convert/pkg/graph/script/script_test.go
+++ b/isotope/convert/pkg/graph/script/script_test.go
@@ -16,10 +16,10 @@ package script
 
 import (
 	"encoding/json"
+	"github.com/jmcvetta/randutil"
 	"reflect"
 	"testing"
 	"time"
-	"github.com/jmcvetta/randutil"
 )
 
 func TestScript_UnmarshalJSON(t *testing.T) {
@@ -38,7 +38,7 @@ func TestScript_UnmarshalJSON(t *testing.T) {
 		{
 			[]byte(`[{"sleep": {"1s": 100}}]`),
 			Script{
-				SleepCommand([]randutil.Choice{randutil.Choice{100, 1 * time.Second}}),
+				SleepCommand([]randutil.Choice{{100, 1 * time.Second}}),
 			},
 			nil,
 		},
@@ -46,7 +46,7 @@ func TestScript_UnmarshalJSON(t *testing.T) {
 			[]byte(`[{"call": "A"}, {"sleep": {"10ms": 100}}]`),
 			Script{
 				RequestCommand{ServiceName: "A"},
-				SleepCommand([]randutil.Choice{randutil.Choice{100, 10 * time.Millisecond}}),
+				SleepCommand([]randutil.Choice{{100, 10 * time.Millisecond}}),
 			},
 			nil,
 		},
@@ -57,7 +57,7 @@ func TestScript_UnmarshalJSON(t *testing.T) {
 					RequestCommand{ServiceName: "A"},
 					RequestCommand{ServiceName: "B"},
 				},
-				SleepCommand([]randutil.Choice{randutil.Choice{100, 10 * time.Millisecond}}),
+				SleepCommand([]randutil.Choice{{100, 10 * time.Millisecond}}),
 			},
 			nil,
 		},

--- a/isotope/convert/pkg/graph/script/sleep_command.go
+++ b/isotope/convert/pkg/graph/script/sleep_command.go
@@ -16,10 +16,10 @@ package script
 
 import (
 	"encoding/json"
-	"time"
 	"github.com/jmcvetta/randutil"
 	"istio.io/fortio/log"
 	"strconv"
+	"time"
 )
 
 // SleepCommand describes a command to pause for a duration.
@@ -44,7 +44,6 @@ func (c *SleepCommand) UnmarshalJSON(b []byte) (err error) {
 			return err
 		}
 
-		
 		ret = append(ret, randutil.Choice{percentage, duration})
 		totalPercentage += percentage
 	}
@@ -73,7 +72,6 @@ func (c SleepCommand) String() string {
 			ret += "}"
 		}
 
-		
 	}
 
 	return ret

--- a/isotope/convert/pkg/graph/script/sleep_command.go
+++ b/isotope/convert/pkg/graph/script/sleep_command.go
@@ -58,13 +58,13 @@ func (c *SleepCommand) UnmarshalJSON(b []byte) (err error) {
 }
 
 func (c SleepCommand) String() string {
-	ret := ": "
+	ret := ""
 	for idx, item := range c {
 		if idx == 0 {
 			ret += "{"
 		}
 
-		ret += "'" + item.Item.(time.Duration).String() + "': "
+		ret += "" + item.Item.(time.Duration).String() + ": "
 		ret += (strconv.Itoa(item.Weight))
 
 		if (idx + 1) < len(c) {

--- a/isotope/convert/pkg/graph/script/sleep_command.go
+++ b/isotope/convert/pkg/graph/script/sleep_command.go
@@ -16,10 +16,11 @@ package script
 
 import (
 	"encoding/json"
-	"github.com/jmcvetta/randutil"
-	"istio.io/fortio/log"
 	"strconv"
 	"time"
+
+	"github.com/jmcvetta/randutil"
+	"istio.io/fortio/log"
 )
 
 // SleepCommand describes a command to pause for a duration.

--- a/isotope/convert/pkg/graph/script/sleep_command_test.go
+++ b/isotope/convert/pkg/graph/script/sleep_command_test.go
@@ -16,10 +16,11 @@ package script
 
 import (
 	"encoding/json"
-	"github.com/jmcvetta/randutil"
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/jmcvetta/randutil"
 )
 
 func TestSleepCommand_UnmarshalJSON(t *testing.T) {

--- a/isotope/convert/pkg/graph/script/sleep_command_test.go
+++ b/isotope/convert/pkg/graph/script/sleep_command_test.go
@@ -16,10 +16,10 @@ package script
 
 import (
 	"encoding/json"
-	"testing"
-	"time"
 	"github.com/jmcvetta/randutil"
 	"reflect"
+	"testing"
+	"time"
 )
 
 func TestSleepCommand_UnmarshalJSON(t *testing.T) {
@@ -30,7 +30,7 @@ func TestSleepCommand_UnmarshalJSON(t *testing.T) {
 	}{
 		{
 			[]byte(`{"100ms": 100}`),
-			SleepCommand([]randutil.Choice{randutil.Choice{100, 100 * time.Millisecond}}),
+			SleepCommand([]randutil.Choice{{100, 100 * time.Millisecond}}),
 			nil,
 		},
 	}
@@ -50,7 +50,7 @@ func TestSleepCommand_UnmarshalJSON(t *testing.T) {
 
 			for timeString, percentage := range probDistribution {
 				duration, _ := time.ParseDuration(timeString)
-				
+
 				command = append(command, randutil.Choice{percentage, duration})
 			}
 

--- a/isotope/convert/pkg/graph/unmarshal_test.go
+++ b/isotope/convert/pkg/graph/unmarshal_test.go
@@ -20,6 +20,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jmcvetta/randutil"
+
 	"istio.io/tools/isotope/convert/pkg/graph/script"
 	"istio.io/tools/isotope/convert/pkg/graph/svc"
 
@@ -87,7 +89,7 @@ var (
 				"requestSize": 516,
 				"responseSize": 128,
 				"script": [
-					{ "sleep": "100ms" }
+					{ "sleep": {"100ms": 100} }
 				]
 			},
 			"services": [
@@ -104,7 +106,7 @@ var (
 								"size": "1KiB"
 							}
 						},
-						{ "sleep": "10ms" }
+						{ "sleep": {"10ms": 100} }
 					]
 				},
 				{
@@ -118,7 +120,7 @@ var (
 							{ "call": "a" },
 							{ "call": "b" }
 						],
-						{ "sleep": "10ms" }
+						{ "sleep": {"10ms": 100} }
 					]
 				}
 			]
@@ -132,7 +134,7 @@ var (
 			ErrorRate:    0.1,
 			ResponseSize: 128,
 			Script: script.Script([]script.Command{
-				script.SleepCommand(100 * time.Millisecond),
+				script.SleepCommand([]randutil.Choice{randutil.Choice{100, 100 * time.Millisecond}}),
 			}),
 		},
 		{
@@ -143,7 +145,7 @@ var (
 			ResponseSize: 128,
 			Script: script.Script([]script.Command{
 				script.RequestCommand{ServiceName: "a", Size: 1024},
-				script.SleepCommand(10 * time.Millisecond),
+				script.SleepCommand([]randutil.Choice{randutil.Choice{100, 10 * time.Millisecond}}),
 			}),
 		},
 		{
@@ -157,7 +159,7 @@ var (
 					script.RequestCommand{ServiceName: "a", Size: 516},
 					script.RequestCommand{ServiceName: "b", Size: 516},
 				},
-				script.SleepCommand(10 * time.Millisecond),
+				script.SleepCommand([]randutil.Choice{randutil.Choice{100, 10 * time.Millisecond}}),
 			}),
 		},
 	}}
@@ -182,7 +184,7 @@ var (
 					"script": [
 						[
 							[{ "call": "a" }, { "call": "a" }],
-							{ "sleep": "10ms" }
+							{ "sleep": {"10ms": 100} }
 						]
 					]
 				}

--- a/isotope/convert/pkg/graph/unmarshal_test.go
+++ b/isotope/convert/pkg/graph/unmarshal_test.go
@@ -134,7 +134,7 @@ var (
 			ErrorRate:    0.1,
 			ResponseSize: 128,
 			Script: script.Script([]script.Command{
-				script.SleepCommand([]randutil.Choice{randutil.Choice{100, 100 * time.Millisecond}}),
+				script.SleepCommand([]randutil.Choice{{100, 100 * time.Millisecond}}),
 			}),
 		},
 		{
@@ -145,7 +145,7 @@ var (
 			ResponseSize: 128,
 			Script: script.Script([]script.Command{
 				script.RequestCommand{ServiceName: "a", Size: 1024},
-				script.SleepCommand([]randutil.Choice{randutil.Choice{100, 10 * time.Millisecond}}),
+				script.SleepCommand([]randutil.Choice{{100, 10 * time.Millisecond}}),
 			}),
 		},
 		{
@@ -159,7 +159,7 @@ var (
 					script.RequestCommand{ServiceName: "a", Size: 516},
 					script.RequestCommand{ServiceName: "b", Size: 516},
 				},
-				script.SleepCommand([]randutil.Choice{randutil.Choice{100, 10 * time.Millisecond}}),
+				script.SleepCommand([]randutil.Choice{{100, 10 * time.Millisecond}}),
 			}),
 		},
 	}}

--- a/isotope/convert/pkg/graphviz/graphviz_test.go
+++ b/isotope/convert/pkg/graphviz/graphviz_test.go
@@ -19,6 +19,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jmcvetta/randutil"
+
 	"istio.io/tools/isotope/convert/pkg/graph"
 	"istio.io/tools/isotope/convert/pkg/graph/script"
 	"istio.io/tools/isotope/convert/pkg/graph/svc"
@@ -35,7 +37,7 @@ func TestServiceGraphToGraph(t *testing.T) {
 				ResponseSize: "10KiB",
 				Steps: [][]string{
 					{
-						"SLEEP 100ms",
+						"SLEEP : {'100ms': 100}",
 					},
 				},
 			},
@@ -71,7 +73,7 @@ func TestServiceGraphToGraph(t *testing.T) {
 						"CALL \"c\" 1KiB",
 					},
 					{
-						"SLEEP 10ms",
+						"SLEEP : {'100ms': 100}",
 					},
 					{
 						"CALL \"b\" 1KiB",
@@ -116,7 +118,7 @@ func TestServiceGraphToGraph(t *testing.T) {
 				ErrorRate:    0.0001,
 				ResponseSize: 10240,
 				Script: []script.Command{
-					script.SleepCommand(100 * time.Millisecond),
+					script.SleepCommand([]randutil.Choice{randutil.Choice{100, 100 * time.Millisecond}}),
 				},
 			},
 			{
@@ -157,7 +159,7 @@ func TestServiceGraphToGraph(t *testing.T) {
 							Size:        1024,
 						},
 					}),
-					script.SleepCommand(10 * time.Millisecond),
+					script.SleepCommand([]randutil.Choice{randutil.Choice{100, 100 * time.Millisecond}}),
 					script.RequestCommand{
 						ServiceName: "b",
 						Size:        1024,

--- a/isotope/convert/pkg/graphviz/graphviz_test.go
+++ b/isotope/convert/pkg/graphviz/graphviz_test.go
@@ -37,7 +37,7 @@ func TestServiceGraphToGraph(t *testing.T) {
 				ResponseSize: "10KiB",
 				Steps: [][]string{
 					{
-						"SLEEP : {'100ms': 100}",
+						"SLEEP {100ms: 100}",
 					},
 				},
 			},
@@ -73,7 +73,7 @@ func TestServiceGraphToGraph(t *testing.T) {
 						"CALL \"c\" 1KiB",
 					},
 					{
-						"SLEEP : {'100ms': 100}",
+						"SLEEP {100ms: 100}",
 					},
 					{
 						"CALL \"b\" 1KiB",

--- a/isotope/convert/pkg/graphviz/graphviz_test.go
+++ b/isotope/convert/pkg/graphviz/graphviz_test.go
@@ -118,7 +118,7 @@ func TestServiceGraphToGraph(t *testing.T) {
 				ErrorRate:    0.0001,
 				ResponseSize: 10240,
 				Script: []script.Command{
-					script.SleepCommand([]randutil.Choice{randutil.Choice{100, 100 * time.Millisecond}}),
+					script.SleepCommand([]randutil.Choice{{100, 100 * time.Millisecond}}),
 				},
 			},
 			{
@@ -159,7 +159,7 @@ func TestServiceGraphToGraph(t *testing.T) {
 							Size:        1024,
 						},
 					}),
-					script.SleepCommand([]randutil.Choice{randutil.Choice{100, 100 * time.Millisecond}}),
+					script.SleepCommand([]randutil.Choice{{100, 100 * time.Millisecond}}),
 					script.RequestCommand{
 						ServiceName: "b",
 						Size:        1024,

--- a/isotope/service/pkg/srv/executable.go
+++ b/isotope/service/pkg/srv/executable.go
@@ -57,12 +57,12 @@ func execute(
 
 func executeSleepCommand(cmd script.SleepCommand) {
 	result, err := randutil.WeightedChoice(cmd)
-    if err != nil {
-        panic(err)
-    }
+	if err != nil {
+		panic(err)
+	}
 
-    fmt.Println(result.Item)
-    time.Sleep(time.Duration(result.Item.(time.Duration)))
+	fmt.Println(result.Item)
+	time.Sleep(result.Item.(time.Duration))
 }
 
 // Execute sends an HTTP request to another service. Assumes DNS is available

--- a/isotope/service/pkg/srv/executable.go
+++ b/isotope/service/pkg/srv/executable.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	multierror "github.com/hashicorp/go-multierror"
+	"github.com/jmcvetta/randutil"
 
 	"istio.io/fortio/log"
 	"istio.io/tools/isotope/convert/pkg/graph/script"
@@ -36,6 +37,7 @@ func execute(
 	serviceTypes map[string]svctype.ServiceType) error {
 	switch cmd := step.(type) {
 	case script.SleepCommand:
+		fmt.Println(cmd)
 		executeSleepCommand(cmd)
 	case script.RequestCommand:
 		if err := executeRequestCommand(
@@ -54,7 +56,13 @@ func execute(
 }
 
 func executeSleepCommand(cmd script.SleepCommand) {
-	time.Sleep(time.Duration(cmd))
+	result, err := randutil.WeightedChoice(cmd)
+    if err != nil {
+        panic(err)
+    }
+
+    fmt.Println(result.Item)
+    time.Sleep(time.Duration(result.Item.(time.Duration)))
 }
 
 // Execute sends an HTTP request to another service. Assumes DNS is available


### PR DESCRIPTION
In this pull request, I've extended the sleep command. 

The sleep command used to take a single argument `sleep 100ms` and used to simulate processing time but this was limiting as it paused the same amount of time for each request.

In this pull request, I've updated the sleep command so that it can take a Map `sleep: {1s: 50, 50ms: 50}` and hence one can specific percentages for sleep durations. This make the benchmark able to simulate more realistic conditions.

I've divided my code into commits:
1. Extended Sleep Command: Replaced / Extended the sleep command
2. Fixed Test Cases: Updated the Test Cases Accordingly
3. Fixed Printing: A minor change to make the command printing to screen suitable.
4. Updated ReadMe: Updated the ReadMe file accordingly.