### PR TITLE
Added Pause Command

### DIFF
--- a/isotope/README.md
+++ b/isotope/README.md
@@ -104,6 +104,22 @@ Each step in the script includes a command.
 sleep: {{ Duration }}
 ```
 
+###### Pause
+
+`pause`: Similar to `sleep` but one can provide a probability distribution instead of just a fixed Duration.
+
+
+A normal random variable with mean = 1.0 and stdev = 0.25 is generated and the program is paused according to the random variable.
+
+```yaml
+pause:
+  dist: "Normal"
+  mean: 1.0
+  sigma: 0.25
+```
+
+Currently, only `normal` and `log-normal` distributions are only supported. But any probability distribution which has two parameters (mean, stdev) can be easily supported.
+
 ###### Send Request
 
 `call`: Sends a HTTP/gRPC request (depending on the receiving service's type)

--- a/isotope/convert/pkg/graph/script/command.go
+++ b/isotope/convert/pkg/graph/script/command.go
@@ -25,6 +25,7 @@ type Command interface{}
 const (
 	sleepCommandKey   = "sleep"
 	requestCommandKey = "call"
+	processCommandKey = "process"
 )
 
 func commandsToMarshallable(cmds []Command) ([]interface{}, error) {
@@ -47,6 +48,8 @@ func commandToMarshallable(cmd Command) (interface{}, error) {
 		return map[string]RequestCommand{requestCommandKey: cmd}, nil
 	case ConcurrentCommand:
 		return commandsToMarshallable(cmd)
+	case ProcessCommand:
+		return map[string]ProcessCommand{processCommandKey: cmd}, nil
 	default:
 		return nil, InvalidCommandTypeError{cmd}
 	}
@@ -97,6 +100,11 @@ func (c *unmarshallableCommand) UnmarshalJSON(b []byte) error {
 			if err != nil {
 				return err
 			}
+		case processCommandKey:
+			c.Command, err = parseProcessCommandFromJSONMap(b)
+			if err != nil {
+				return err
+			}
 		default:
 			return UnknownCommandKeyError{key}
 		}
@@ -116,6 +124,18 @@ func parseJSONCommandKey(b []byte) (s string, err error) {
 	}
 	// Should only loop once, setting s to the single command key in the map.
 	for s = range m {
+	}
+	return
+}
+
+// b must contain a single key whose value is an unmarshallable ProcessCommand.
+func parseProcessCommandFromJSONMap(b []byte) (cmd ProcessCommand, err error) {
+	var m map[string]ProcessCommand
+	err = json.Unmarshal(b, &m)
+	if err != nil {
+		return
+	}
+	for _, cmd = range m {
 	}
 	return
 }

--- a/isotope/convert/pkg/graph/script/process_command.go
+++ b/isotope/convert/pkg/graph/script/process_command.go
@@ -16,7 +16,6 @@ package script
 
 import (
 	"encoding/json"
-	"fmt"
 
 	"gonum.org/v1/gonum/stat/distuv"
 )
@@ -38,8 +37,6 @@ type ProcessCommand struct {
 // UnmarshalJSON converts a JSON object to a ProcessCommand.
 func (c *ProcessCommand) UnmarshalJSON(b []byte) (err error) {
 	var data ProcessCommandConfig
-
-	fmt.Println(b)
 
 	err = json.Unmarshal(b, &data)
 	if err != nil {

--- a/isotope/convert/pkg/graph/script/process_command.go
+++ b/isotope/convert/pkg/graph/script/process_command.go
@@ -1,0 +1,62 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this currentFile except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package script
+
+import (
+	"encoding/json"
+	"gonum.org/v1/gonum/stat/distuv"
+)
+
+// ProcessCommand describes a command which contains a probability distribution
+// of durations that the process should pause for.
+type ProcessCommandConfig struct {
+	Dist  string  `json:"dist"`
+	Mean  float64 `json:"mean"`
+	Sigma float64 `json:"sigma"`
+}
+
+type ProcessCommand struct {
+	Dist interface {
+		Rand() float64
+	}
+}
+
+// UnmarshalJSON converts a JSON object to a ProcessCommand.
+func (c *ProcessCommand) UnmarshalJSON(b []byte) (err error) {
+	var data ProcessCommandConfig
+
+	err = json.Unmarshal(b, &data)
+	if err != nil {
+		return
+	}
+
+	if data.Dist == "Normal" {
+		dist := distuv.Normal{
+			Mu:    data.Mean,
+			Sigma: data.Sigma,
+		}
+
+		*c = ProcessCommand{Dist: dist}
+	} else if data.Dist == "LogNormal" {
+		dist := distuv.LogNormal{
+			Mu:    data.Mean,
+			Sigma: data.Sigma,
+		}
+
+		*c = ProcessCommand{Dist: dist}
+	}
+
+	return
+}

--- a/isotope/convert/pkg/graph/script/process_command.go
+++ b/isotope/convert/pkg/graph/script/process_command.go
@@ -16,6 +16,8 @@ package script
 
 import (
 	"encoding/json"
+	"fmt"
+
 	"gonum.org/v1/gonum/stat/distuv"
 )
 
@@ -36,6 +38,8 @@ type ProcessCommand struct {
 // UnmarshalJSON converts a JSON object to a ProcessCommand.
 func (c *ProcessCommand) UnmarshalJSON(b []byte) (err error) {
 	var data ProcessCommandConfig
+
+	fmt.Println(b)
 
 	err = json.Unmarshal(b, &data)
 	if err != nil {

--- a/isotope/convert/pkg/graph/script/process_command_test.go
+++ b/isotope/convert/pkg/graph/script/process_command_test.go
@@ -1,0 +1,53 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this currentFile except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package script
+
+import (
+	"encoding/json"
+	"testing"
+
+	"gonum.org/v1/gonum/stat/distuv"
+)
+
+func TestProcessCommand_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		input   []byte
+		command ProcessCommand
+		err     error
+	}{
+		{
+			[]byte(`{"dist":"Normal","mean":1,"sigma":0.25}`),
+			ProcessCommand{Dist: distuv.Normal{Mu: 1.0, Sigma: 0.25}},
+			nil,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run("", func(t *testing.T) {
+			t.Parallel()
+
+			var command ProcessCommand
+			err := json.Unmarshal(test.input, &command)
+
+			if test.err != err {
+				t.Errorf("expected %v; actual %v", test.err, err)
+			}
+			if test.command != command {
+				t.Errorf("expected %v; actual %v", test.command, command)
+			}
+		})
+	}
+}

--- a/isotope/service/pkg/srv/executable.go
+++ b/isotope/service/pkg/srv/executable.go
@@ -37,6 +37,8 @@ func execute(
 	switch cmd := step.(type) {
 	case script.SleepCommand:
 		executeSleepCommand(cmd)
+	case script.ProcessCommand:
+		executeProcessCommand(cmd)
 	case script.RequestCommand:
 		if err := executeRequestCommand(
 			cmd, forwardableHeader, serviceTypes); err != nil {
@@ -55,6 +57,11 @@ func execute(
 
 func executeSleepCommand(cmd script.SleepCommand) {
 	time.Sleep(time.Duration(cmd))
+}
+
+func executeProcessCommand(cmd script.ProcessCommand) {
+	fmt.Println(time.Duration(cmd.Dist.Rand() * 10e8))
+	time.Sleep(time.Duration(cmd.Dist.Rand() * 10e8))
 }
 
 // Execute sends an HTTP request to another service. Assumes DNS is available


### PR DESCRIPTION
Similar to the sleep command, the pause command also simulates processing time but one can provide a distribution instead of a single static value.

Example: 

```yaml
pause:
  dist: "Normal"
  mean: 1.0
  sigma: 0.25
```

In the above example a normal random variable with mean: 1.0 and stdev: 0.25 would be generated and the program can be paused according to the random value generated each time.

I've divided the pull requests into three commits:

1. Added Process Command --> Added new code for the process command
2. Added Process Command Unit Test --> Added the corresponding unit test
3. Update README File --> Updated the README File Accordingly.