### PR TITLE
Add readme for protoc-gen-openapi

### DIFF
--- a/protoc-gen-openapi/Makefile
+++ b/protoc-gen-openapi/Makefile
@@ -7,7 +7,7 @@ build:
 run:
 	rm -fr out
 	mkdir out
-	protoc --plugin=./protoc-gen-openapi --openapi_out=mode=true,single_file=true,use_ref=true:out/. -Itestdata testdata/testpkg/test1.proto testdata/testpkg/test2.proto testdata/testpkg/test6.proto testdata/testpkg2/test3.proto
+	protoc --plugin=./protoc-gen-openapi --openapi_out=single_file=true,use_ref=true:out/. -Itestdata testdata/testpkg/test1.proto testdata/testpkg/test2.proto testdata/testpkg/test6.proto testdata/testpkg2/test3.proto
 
 gotest:
 	go test

--- a/protoc-gen-openapi/README.md
+++ b/protoc-gen-openapi/README.md
@@ -1,0 +1,69 @@
+
+## What's this for?
+
+`protoc-gen-openapi` is a plugin for the Google protocol buffer compiler to generate
+openAPI V3 spec for any given input protobuf. It runs as a `protoc-gen-` binary that the
+protobuf compiler infers from the `openapi_out` flag.
+
+## Build `protoc-gen-openapi`
+
+`protoc-gen-openapi` is written in Go, so ensure that is installed on your system. You
+can follow the instructions on the [golang website](https://golang.org/doc/install) or
+on Debian or Ubuntu, you can install it from the package manager:
+
+```bash
+sudo apt-get install -y golang
+```
+
+To build, first ensure you have the protocol compiler (protoc):
+
+```bash
+go get github.com/golang/protobuf/proto
+```
+To build, run the following command from this project directory:
+
+```bash
+go build
+```
+
+Then ensure the resulting `protoc-gen-openapi` binary is in your `PATH`. A recommended location
+is `$HOME/bin`:
+
+```bash
+cp protoc-gen-openapi $HOME/bin
+```
+
+Since the following is often in your `$HOME/.bashrc` file:
+
+```bash
+export PATH=$HOME/bin:$PATH
+```
+
+## Using protoc-gen-openapi
+
+---
+**TIP**
+
+The -I option in protoc is useful when you need to specify proto paths for imports.
+
+---
+
+Then to generate the OpenAPI spec of the protobuf defined by file.proto, run
+
+```bash
+protoc --openapi_out=output_directory input_directory/file.proto
+```
+
+With that input, the output will be written to
+
+	output_directory/file.json
+
+Other supported options are:
+*   `per_file`
+    *   when set to `true`, the output is per proto file instead of per package.
+*   `single_file`
+    *   when set to `true`, the output is a single file of all the input protos specified.
+*   `use_ref`
+    *   when set to `true`, the output uses the `$ref` field in OpenAPI spec to reference other schemas.
+*   `yaml`
+    *   when set to `true`, the output is in yaml file.

--- a/protoc-gen-openapi/integration_test.go
+++ b/protoc-gen-openapi/integration_test.go
@@ -42,13 +42,13 @@ func TestOpenAPIGeneration(t *testing.T) {
 		{
 			name:       "Single File Generation",
 			perPackage: false,
-			genOpts:    ",single_file=true",
+			genOpts:    "single_file=true",
 			wantFiles:  []string{"openapiv3.json"},
 		},
 		{
 			name:       "Use $ref in the output",
 			perPackage: false,
-			genOpts:    ",single_file=true,use_ref=true",
+			genOpts:    "single_file=true,use_ref=true",
 			wantFiles:  []string{"testRef/openapiv3.json"},
 		},
 	}
@@ -76,12 +76,12 @@ func TestOpenAPIGeneration(t *testing.T) {
 
 			if tc.perPackage {
 				for _, files := range packages {
-					args := []string{"-Itestdata", "--openapi_out=mode=true" + tc.genOpts + ":" + tempDir}
+					args := []string{"-Itestdata", "--openapi_out=" + tc.genOpts + ":" + tempDir}
 					args = append(args, files...)
 					protocOpenAPI(t, args)
 				}
 			} else {
-				args := []string{"-Itestdata", "--openapi_out=mode=true" + tc.genOpts + ":" + tempDir}
+				args := []string{"-Itestdata", "--openapi_out=" + tc.genOpts + ":" + tempDir}
 				for _, files := range packages {
 					args = append(args, files...)
 				}

--- a/protoc-gen-openapi/main.go
+++ b/protoc-gen-openapi/main.go
@@ -44,7 +44,6 @@ func extractParams(parameter string) map[string]string {
 }
 
 func generate(request plugin.CodeGeneratorRequest) (*plugin.CodeGeneratorResponse, error) {
-	mode := true
 	perFile := false
 	singleFile := false
 	yaml := false
@@ -52,16 +51,7 @@ func generate(request plugin.CodeGeneratorRequest) (*plugin.CodeGeneratorRespons
 
 	p := extractParams(request.GetParameter())
 	for k, v := range p {
-		if k == "mode" {
-			switch strings.ToLower(v) {
-			case "true":
-				mode = true
-			case "false":
-				mode = false
-			default:
-				return nil, fmt.Errorf("unknown value '%s' for mode", v)
-			}
-		} else if k == "per_file" {
+		if k == "per_file" {
 			switch strings.ToLower(v) {
 			case "true":
 				perFile = true
@@ -109,7 +99,7 @@ func generate(request plugin.CodeGeneratorRequest) (*plugin.CodeGeneratorRespons
 		filesToGen[fd] = true
 	}
 
-	g := newOpenAPIGenerator(m, mode, perFile, singleFile, yaml, useRef)
+	g := newOpenAPIGenerator(m, perFile, singleFile, yaml, useRef)
 	return g.generateOutput(filesToGen)
 }
 

--- a/protoc-gen-openapi/openapiGenerator.go
+++ b/protoc-gen-openapi/openapiGenerator.go
@@ -176,7 +176,7 @@ func (g *openapiGenerator) generatePerPackageOutput(filesToGen map[*protomodel.F
 
 // Generate an OpenAPI spec for a collection of cross-linked files.
 func (g *openapiGenerator) generateFile(name string,
-	_ *protomodel.FileDescriptor,
+	pkg *protomodel.FileDescriptor,
 	messages map[string]*protomodel.MessageDescriptor,
 	enums map[string]*protomodel.EnumDescriptor,
 	_ map[string]*protomodel.ServiceDescriptor) plugin.CodeGeneratorResponse_File {
@@ -205,10 +205,8 @@ func (g *openapiGenerator) generateFile(name string,
 	// only get the API version when generate per package or per file,
 	// as we cannot guarantee all protos in the input are the same version.
 	if !g.singleFile {
-		if g.currentFrontMatterProvider != nil {
-			if fmd := g.currentFrontMatterProvider.Matter.Description; fmd != "" {
-				description = fmd
-			}
+		if g.currentFrontMatterProvider != nil && g.currentFrontMatterProvider.Matter.Description != "" {
+			description = g.currentFrontMatterProvider.Matter.Description
 		} else if pd := g.generateDescription(g.currentPackage); pd != "" {
 			description = pd
 		} else {
@@ -216,7 +214,13 @@ func (g *openapiGenerator) generateFile(name string,
 		}
 		// derive the API version from the package name
 		// which is a convention for Istio APIs.
-		s := strings.Split(name, ".")
+		var p string
+		if pkg != nil {
+			p = pkg.GetPackage()
+		} else {
+			p = name
+		}
+		s := strings.Split(p, ".")
 		version = s[len(s)-1]
 	} else {
 		description = "OpenAPI Spec for Istio APIs."

--- a/protoc-gen-openapi/testdata/golden/testRef/openapiv3.json
+++ b/protoc-gen-openapi/testdata/golden/testRef/openapiv3.json
@@ -39,43 +39,7 @@
             "type": "string"
           },
           "test2": {
-            "properties": {
-              "field1": {
-                "description": "field1 is a field",
-                "format": "int32",
-                "type": "integer"
-              },
-              "field3": {
-                "type": "number"
-              },
-              "field4": {
-                "type": "number"
-              },
-              "field5": {
-                "format": "int32",
-                "type": "integer"
-              },
-              "field6": {
-                "format": "int32",
-                "type": "integer"
-              },
-              "field7": {
-                "format": "int32",
-                "type": "integer"
-              },
-              "field8": {
-                "format": "int32",
-                "type": "integer"
-              },
-              "str": {
-                "description": "an array of strings",
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              }
-            },
-            "type": "object"
+            "$ref": "#/components/schemas/testpkg.Test2"
           }
         },
         "type": "object"
@@ -215,22 +179,7 @@
             "type": "object"
           },
           "messageOneOfField": {
-            "description": "messageoneof comment",
-            "properties": {
-              "port": {
-                "oneOf": [
-                  {
-                    "description": "Valid port number",
-                    "format": "int32",
-                    "type": "integer"
-                  },
-                  {
-                    "type": "string"
-                  }
-                ]
-              }
-            },
-            "type": "object"
+            "$ref": "#/components/schemas/testpkg2.MessageOneOf"
           },
           "str": {
             "description": "an array of strings",

--- a/protoc-gen-openapi/testdata/golden/testpkg.json
+++ b/protoc-gen-openapi/testdata/golden/testpkg.json
@@ -1,7 +1,8 @@
 {
   "openapi": "3.0.1",
   "info": {
-    "title": "OpenAPI Spec for Istio APIs."
+    "title": "OpenAPI Spec for Istio APIs.",
+    "version": "testpkg"
   },
   "components": {
     "schemas": {

--- a/protoc-gen-openapi/testdata/golden/testpkg.json
+++ b/protoc-gen-openapi/testdata/golden/testpkg.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.0.1",
   "info": {
-    "title": "OpenAPI Spec for Istio APIs.",
+    "title": "My Overview",
     "version": "testpkg"
   },
   "components": {

--- a/protoc-gen-openapi/testdata/golden/testpkg2.json
+++ b/protoc-gen-openapi/testdata/golden/testpkg2.json
@@ -1,7 +1,8 @@
 {
   "openapi": "3.0.1",
   "info": {
-    "title": "OpenAPI Spec for Istio APIs."
+    "title": "OpenAPI Spec for Istio APIs.",
+    "version": "testpkg2"
   },
   "components": {
     "schemas": {


### PR DESCRIPTION
- Also added version in the generated spec
- Clean up the unused `mode` option
- Make `$ref` to work with top-level message proto (no parent)