### PR TITLE
Fix openapi gen per file output naming

### DIFF
--- a/protoc-gen-openapi/openapiGenerator.go
+++ b/protoc-gen-openapi/openapiGenerator.go
@@ -36,7 +36,15 @@ var specialTypes = map[string]*openapi3.Schema{
 	"google.protobuf.Struct": {
 		Properties: map[string]*openapi3.SchemaRef{
 			"fields": {
-				Value: openapi3.NewObjectSchema().WithAnyAdditionalProperties()},
+				Value: openapi3.NewObjectSchema().WithAnyAdditionalProperties(),
+			},
+		},
+	},
+	"google.protobuf.ListValue": {
+		Properties: map[string]*openapi3.SchemaRef{
+			"values": {
+				Value: openapi3.NewArraySchema().WithItems(openapi3.NewObjectSchema()),
+			},
 		},
 	},
 }
@@ -128,7 +136,7 @@ func (g *openapiGenerator) generatePerFileOutput(filesToGen map[*protomodel.File
 			extension := path.Ext(filename)
 			name := filename[0 : len(filename)-len(extension)]
 
-			rf := g.generateFile(pkg.Name+"."+name, file, messages, enums, services)
+			rf := g.generateFile(name, file, messages, enums, services)
 			response.File = append(response.File, &rf)
 		}
 	}


### PR DESCRIPTION
Example: for VirtualService.proto, the generate file name would be `virtual_service.json`, instead of `istio.networking.v1alpha3.virtual_service.json`.

- Also add a new predefined pb type to avoid stack overflow of generation

