### PR TITLE
fix an issue in openapi generator

### DIFF
--- a/protoc-gen-openapi/openapiGenerator.go
+++ b/protoc-gen-openapi/openapiGenerator.go
@@ -32,7 +32,7 @@ import (
 )
 
 // Some special types with predefined schemas.
-var specialTypes = map[string]*openapi3.Schema{
+var specialTypes = map[string]openapi3.Schema{
 	"google.protobuf.Struct": {
 		Properties: map[string]*openapi3.SchemaRef{
 			"fields": {
@@ -370,7 +370,7 @@ func (g *openapiGenerator) fieldType(field *protomodel.FieldDescriptor) *openapi
 	case descriptor.FieldDescriptorProto_TYPE_MESSAGE:
 		msg := field.FieldType.(*protomodel.MessageDescriptor)
 		if s, ok := specialTypes[g.absoluteName(msg)]; ok {
-			schema = s
+			schema = &s
 		} else if msg.GetOptions().GetMapEntry() {
 			isMap = true
 			sr := g.fieldTypeRef(msg.Fields[1])


### PR DESCRIPTION
Pre-generated spec was reused so their description was the same even though they showed up in different fields. This fix is to address that and solve the issue in presubmit of https://github.com/istio/api/pull/957
https://k8s-gubernator.appspot.com/build/istio-prow/pull/istio_api/957/api-presubmit/1624/