### PR TITLE
Added multi-zone cluster support

### DIFF
--- a/isotope/example-config.toml
+++ b/isotope/example-config.toml
@@ -10,12 +10,16 @@ environments = [
 
 [cluster]
 project_id = "istio-200620"
-# Cluster will be created with one n1-standard-1 node in the default node-pool
-# running Prometheus. In total, the cluster will have 1 Prometheus node, 1
-# client node, and N service-graph nodes (total of N + 2 nodes).
-name = "isotope-cluster-1"
-zone = "us-central1-a"
-version = "1.12.7-gke.7"
+# Cluster will be created with one n1-standard-1 node per zone in the default node-pool.
+# Only one of them will be running Prometheus. In total, the cluster will have 
+# 1 Prometheus node per zone, 1 client node per zone, and N service-graph nodes per zone.
+# In total (N + 2) nodes per zone.
+name = "isotope-cluster-2"
+# One can specify multiple zones for the cluster. The control place 
+# would be in the first zone you specify but the nodes would be 
+# spread around the zones.
+zones = ["us-central1-a", "us-central1-b", "us-central1-c"]
+version = "1.12.7-gke.25"
 
 [istio]
 archive_url = "https://github.com/istio/istio/releases/download/1.1.3/istio-1.1.3-linux.tar.gz"

--- a/isotope/run_tests.py
+++ b/isotope/run_tests.py
@@ -13,7 +13,7 @@ def main(args: argparse.Namespace) -> None:
     config = cfg.from_toml_file(args.config_path)
 
     cluster.set_up_if_not_exists(
-        config.cluster_project_id, config.cluster_name, config.cluster_zone,
+        config.cluster_project_id, config.cluster_name, config.cluster_zones,
         config.cluster_version, config.server_machine_type,
         config.server_disk_size_gb, config.server_num_nodes,
         config.client_machine_type, config.client_disk_size_gb)

--- a/isotope/runner/cluster.py
+++ b/isotope/runner/cluster.py
@@ -4,14 +4,16 @@ import logging
 import os
 
 from . import consts, prometheus, resources, sh, wait
+from typing import List
 
 
 def set_up_if_not_exists(
-        project_id: str, name: str, zone: str, version: str,
+        project_id: str, name: str, zones: List[str], version: str,
         service_graph_machine_type: str, service_graph_disk_size_gb: int,
         service_graph_num_nodes: int, client_machine_type: str,
         client_disk_size_gb: int) -> None:
     sh.run_gcloud(['config', 'set', 'project', project_id], check=True)
+    zone = zones[0]
 
     # TODO: This is the default tabular output. Filter the input to just the
     # names of the existing clusters.
@@ -22,12 +24,12 @@ def set_up_if_not_exists(
         logging.debug('%s already exists; bypassing creation', name)
     else:
         logging.debug('%s does not exist yet; creating...', name)
-        set_up(project_id, name, zone, version, service_graph_machine_type,
+        set_up(project_id, name, zones, version, service_graph_machine_type,
                service_graph_disk_size_gb, service_graph_num_nodes,
                client_machine_type, client_disk_size_gb)
 
 
-def set_up(project_id: str, name: str, zone: str, version: str,
+def set_up(project_id: str, name: str, zones: List[str], version: str,
            service_graph_machine_type: str, service_graph_disk_size_gb: int,
            service_graph_num_nodes: int, client_machine_type: str,
            client_disk_size_gb: int, deploy_prometheus=False) -> None:
@@ -46,7 +48,7 @@ def set_up(project_id: str, name: str, zone: str, version: str,
     """
     sh.run_gcloud(['config', 'set', 'project', project_id], check=True)
 
-    _create_cluster(name, zone, version, 'n1-standard-4', 16, 1)
+    _create_cluster(name, zones, version, 'n1-standard-4', 16, 1)
     _create_cluster_role_binding()
 
     if deploy_prometheus:
@@ -59,18 +61,21 @@ def set_up(project_id: str, name: str, zone: str, version: str,
     _create_service_graph_node_pool(service_graph_num_nodes,
                                     service_graph_machine_type,
                                     service_graph_disk_size_gb,
-                                    zone)
-    _create_client_node_pool(client_machine_type, client_disk_size_gb, zone)
+                                    zones[0])
+    _create_client_node_pool(client_machine_type, client_disk_size_gb, zones[0])
 
 
-def _create_cluster(name: str, zone: str, version: str, machine_type: str,
+def _create_cluster(name: str, zones: List[str], version: str, machine_type: str,
                     disk_size_gb: int, num_nodes: int) -> None:
     logging.info('creating cluster "%s"', name)
+    node_locations = ','.join(zones)
+    zone = zones[0]
+
     sh.run_gcloud(
         [
             'container', 'clusters', 'create', name, '--zone', zone,
-            '--cluster-version', version, '--machine-type', machine_type,
-            '--disk-size',
+            '--node-locations', node_locations, '--cluster-version', version,
+            '--machine-type', machine_type, '--disk-size',
             str(disk_size_gb), '--num-nodes',
             str(num_nodes)
         ],

--- a/isotope/runner/config.py
+++ b/isotope/runner/config.py
@@ -10,18 +10,19 @@ class RunnerConfig:
 
     def __init__(self, topology_paths: List[str], environments: List[str],
                  istio_archive_url: str, cluster_project_id: str,
-                 cluster_name: str, cluster_zone: str, cluster_version: str,
-                 server_machine_type: str, server_disk_size_gb: int,
-                 server_num_nodes: int, server_image: str,
-                 client_machine_type: str, client_disk_size_gb: int,
-                 client_image: str, client_qps: Optional[int],
-                 client_duration: str, client_num_conc_conns: int) -> None:
+                 cluster_name: str, cluster_zones: List[str],
+                 cluster_version: str, server_machine_type: str,
+                 server_disk_size_gb: int, server_num_nodes: int,
+                 server_image: str, client_machine_type: str,
+                 client_disk_size_gb: int, client_image: str,
+                 client_qps: Optional[int], client_duration: str,
+                 client_num_conc_conns: int) -> None:
         self.topology_paths = topology_paths
         self.environments = environments
         self.istio_archive_url = istio_archive_url
         self.cluster_project_id = cluster_project_id
         self.cluster_name = cluster_name
-        self.cluster_zone = cluster_zone
+        self.cluster_zones = cluster_zones
         self.cluster_version = cluster_version
         self.server_machine_type = server_machine_type
         self.server_disk_size_gb = server_disk_size_gb
@@ -39,7 +40,7 @@ class RunnerConfig:
         return {
             'istio_archive_url': self.istio_archive_url,
             'cluster_version': self.cluster_version,
-            'cluster_zone': self.cluster_zone,
+            'cluster_zones': self.cluster_zones,
             'server_machine_type': self.server_machine_type,
             'server_disk_size_gb': str(self.server_disk_size_gb),
             'server_num_nodes': str(self.server_num_nodes),
@@ -64,7 +65,7 @@ def from_dict(d: Dict[str, Any]) -> RunnerConfig:
     cluster = d['cluster']
     cluster_project_id = cluster['project_id']
     cluster_name = cluster['name']
-    cluster_zone = cluster['zone']
+    cluster_zones = cluster['zones']
     cluster_version = cluster['version']
 
     server = d['server']
@@ -92,7 +93,7 @@ def from_dict(d: Dict[str, Any]) -> RunnerConfig:
         istio_archive_url=istio_archive_url,
         cluster_project_id=cluster_project_id,
         cluster_name=cluster_name,
-        cluster_zone=cluster_zone,
+        cluster_zones=cluster_zones,
         cluster_version=cluster_version,
         server_machine_type=server_machine_type,
         server_disk_size_gb=server_disk_size_gb,


### PR DESCRIPTION
One can specify multiple zones (instead of a single cluster zone) and the nodes would be spread around the various multiple zones. This can help in bench-marking applications setup in a multi-zone way.