### PR TITLE
Added probabilistic call

### DIFF
--- a/isotope/convert/pkg/graph/script/request_command.go
+++ b/isotope/convert/pkg/graph/script/request_command.go
@@ -16,6 +16,7 @@ package script
 
 import (
 	"encoding/json"
+	"errors"
 
 	"istio.io/tools/isotope/convert/pkg/graph/size"
 )
@@ -26,6 +27,8 @@ type RequestCommand struct {
 	ServiceName string `json:"service"`
 	// Size is the number of bytes in the request body.
 	Size size.ByteSize `json:"size"`
+	// Percentage is the
+	Probability int `json:"probability"`
 }
 
 var (
@@ -53,7 +56,12 @@ func (c *RequestCommand) UnmarshalJSON(b []byte) (err error) {
 		if err != nil {
 			return
 		}
+
 		*c = RequestCommand(unmarshallableRequestCommand)
+
+		if c.Probability < 0 || c.Probability > 100 {
+			return errors.New("math: invalid probability, outside range: [0,100]")
+		}
 	}
 	return
 }

--- a/isotope/service/pkg/srv/executable.go
+++ b/isotope/service/pkg/srv/executable.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"math/rand"
 	"net/http"
 	"sync"
 	"time"
@@ -58,12 +59,28 @@ func executeSleepCommand(cmd script.SleepCommand) {
 	time.Sleep(time.Duration(cmd))
 }
 
+func executeRequestCommandHelper(cmd script.RequestCommand) bool {
+	rand.Seed(time.Now().UnixNano())
+	number := rand.Intn(100 + 1)
+	ret := true
+
+	if number < cmd.Probability {
+		ret = false
+	}
+	return ret
+}
+
 // Execute sends an HTTP request to another service. Assumes DNS is available
 // which maps exe.ServiceName to the relevant URL to reach the service.
 func executeRequestCommand(
 	cmd script.RequestCommand,
 	forwardableHeader http.Header,
 	serviceTypes map[string]svctype.ServiceType) error {
+
+	if executeRequestCommandHelper(cmd) {
+		return nil
+	}
+
 	destName := cmd.ServiceName
 	_, ok := serviceTypes[destName]
 	if !ok {


### PR DESCRIPTION
One can now assign a probability with each call request. Added an example below.

```
  - call:
      service: b
      size: 1KiB
      probability: 60
```

In the example there is a 60\% chance that a call request would be made to service b.