### PR TITLE
Added deployments version functionality

### DIFF
--- a/isotope/convert/pkg/consts/consts.go
+++ b/isotope/convert/pkg/consts/consts.go
@@ -41,6 +41,10 @@ const (
 	// the name of the service.
 	ServiceNameEnvKey = "SERVICE_NAME"
 
+	// ServiceVersionEnvKey is the key of the environment variable whose
+	// value is the version number of the service.
+	ServiceVersionNumEnvKey = "VERSION_NUMBER"
+
 	// FortioMetricsPort is the port on which /metrics is available.
 	FortioMetricsPort = 42422
 )

--- a/isotope/convert/pkg/graph/svc/service.go
+++ b/isotope/convert/pkg/graph/svc/service.go
@@ -29,6 +29,9 @@ type Service struct {
 	// Type describes what protocol the service supports (e.g. HTTP, gRPC).
 	Type svctype.ServiceType `json:"type,omitempty"`
 
+	// Service Version
+	Version string `json:"version,omitempty"`
+
 	// NumReplicas is the number of replicas backing this service.
 	NumReplicas int32 `json:"numReplicas,omitempty"`
 

--- a/isotope/convert/pkg/kubernetes/kubernetes.go
+++ b/isotope/convert/pkg/kubernetes/kubernetes.go
@@ -233,6 +233,7 @@ func makeDeployment(
 						},
 						Env: []apiv1.EnvVar{
 							{Name: consts.ServiceNameEnvKey, Value: service.Name},
+							{Name: consts.ServiceVersionNumEnvKey, Value: service.Version[1:]},
 						},
 						VolumeMounts: []apiv1.VolumeMount{
 							{

--- a/isotope/convert/pkg/kubernetes/kubernetes.go
+++ b/isotope/convert/pkg/kubernetes/kubernetes.go
@@ -189,17 +189,25 @@ func makeDeployment(
 	service svc.Service, nodeSelector map[string]string,
 	serviceImage string, serviceMaxIdleConnectionsPerHost int) (
 	k8sDeployment appsv1.Deployment) {
+
+	if service.Version == "" {
+		service.Version = "v1"
+	}
+
+	AppLabels := map[string]string{"app": "service-graph", "version": service.Version}
+
 	k8sDeployment.APIVersion = "apps/v1"
 	k8sDeployment.Kind = "Deployment"
-	k8sDeployment.ObjectMeta.Name = service.Name
+	k8sDeployment.ObjectMeta.Name = service.Name + "-" + service.Version
 	k8sDeployment.ObjectMeta.Namespace = ServiceGraphNamespace
-	k8sDeployment.ObjectMeta.Labels = serviceGraphAppLabels
+	k8sDeployment.ObjectMeta.Labels = AppLabels
 	timestamp(&k8sDeployment.ObjectMeta)
 	k8sDeployment.Spec = appsv1.DeploymentSpec{
 		Replicas: &service.NumReplicas,
 		Selector: &metav1.LabelSelector{
 			MatchLabels: map[string]string{
-				"name": service.Name,
+				"name":    service.Name,
+				"version": service.Version,
 			},
 		},
 		Template: apiv1.PodTemplateSpec{
@@ -207,7 +215,8 @@ func makeDeployment(
 				Labels: combineLabels(
 					serviceGraphNodeLabels,
 					map[string]string{
-						"name": service.Name,
+						"name":    service.Name,
+						"version": service.Version,
 					}),
 				Annotations: prometheusScrapeAnnotations,
 			},

--- a/isotope/example-config.toml
+++ b/isotope/example-config.toml
@@ -5,17 +5,16 @@ topology_paths = [
 
 environments = [
   "NONE",
-  "ISTIO",
 ]
 
 [cluster]
-project_id = "istio-200620"
+project_id = "absolute-garden-516"
 # Cluster will be created with one n1-standard-1 node in the default node-pool
 # running Prometheus. In total, the cluster will have 1 Prometheus node, 1
 # client node, and N service-graph nodes (total of N + 2 nodes).
-name = "isotope-cluster-1"
+name = "policy-4"
 zone = "us-central1-a"
-version = "1.12.7-gke.7"
+version = "1.12.7-gke.25"
 
 [istio]
 archive_url = "https://github.com/istio/istio/releases/download/1.1.3/istio-1.1.3-linux.tar.gz"
@@ -24,7 +23,7 @@ archive_url = "https://github.com/istio/istio/releases/download/1.1.3/istio-1.1.
 machine_type = "n1-standard-1"
 disk_size_gb = 16
 num_nodes = 4
-image = "tahler/isotope-service:1"
+image = "saimsalman/isotope:v2"
 
 [client]
 machine_type = "n1-highcpu-4"

--- a/isotope/example-topologies/canonical.yaml
+++ b/isotope/example-topologies/canonical.yaml
@@ -4,12 +4,18 @@ defaults:
   numRbacPolicies: 3
 services:
 - name: a
+  version: v1
+- name: a
+  version: v2
 - name: b
+  version: v1
 - name: c
+  version: v1
   script:
   - call: a
   - call: b
 - name: d
+  version: v1
   isEntrypoint: true
   script:
   - - call: a

--- a/isotope/service/main.go
+++ b/isotope/service/main.go
@@ -55,8 +55,13 @@ func main() {
 		log.Fatalf(`env var "%s" is not set`, consts.ServiceNameEnvKey)
 	}
 
+	serviceVersion, ok := os.LookupEnv(consts.ServiceVersionNumEnvKey)
+	if !ok {
+		log.Fatalf(`env var "%s" is not set`, consts.ServiceVersionNumEnvKey)
+	}
+
 	defaultHandler, err := srv.HandlerFromServiceGraphYAML(
-		serviceGraphYAMLFilePath, serviceName)
+		serviceGraphYAMLFilePath, serviceName, serviceVersion)
 	if err != nil {
 		log.Fatalf("%s", err)
 	}

--- a/isotope/service/pkg/srv/graph.go
+++ b/isotope/service/pkg/srv/graph.go
@@ -32,14 +32,14 @@ import (
 // HandlerFromServiceGraphYAML makes a handler to emulate the service with name
 // serviceName in the service graph represented by the YAML file at path.
 func HandlerFromServiceGraphYAML(
-	path string, serviceName string) (Handler, error) {
+	path string, serviceName string, serviceVersion string) (Handler, error) {
 
 	serviceGraph, err := serviceGraphFromYAMLFile(path)
 	if err != nil {
 		return Handler{}, err
 	}
 
-	service, err := extractService(serviceGraph, serviceName)
+	service, err := extractService(serviceGraph, serviceName, serviceVersion)
 	if err != nil {
 		return Handler{}, err
 	}
@@ -95,10 +95,11 @@ func serviceGraphFromYAMLFile(
 
 // extractService finds the service in serviceGraph with the specified name.
 func extractService(
-	serviceGraph graph.ServiceGraph, name string) (
+	serviceGraph graph.ServiceGraph, name string, version string) (
 	service svc.Service, err error) {
+	version = "v" + version
 	for _, svc := range serviceGraph.Services {
-		if svc.Name == name {
+		if svc.Name == name && svc.Version == version {
 			service = svc
 			return
 		}


### PR DESCRIPTION
One can specify version numbers for each service in the topology:

```
defaults:
  requestSize: 1 KB
  responseSize: 1 KB
  numRbacPolicies: 3
services:
- name: a
  version: v1
- name: a
  version: v2
- name: b
  version: v1
- name: c
  version: v1
  script:
  - call: a
  - call: b
- name: d
  version: v1
  isEntrypoint: true
  script:
  - - call: a
    - call: c
  - call: b
```
