### PR TITLE
Saim: Added (pilot + mixer policy)

### DIFF
--- a/isotope/convert/pkg/consts/consts.go
+++ b/isotope/convert/pkg/consts/consts.go
@@ -41,6 +41,10 @@ const (
 	// the name of the service.
 	ServiceNameEnvKey = "SERVICE_NAME"
 
+	// ServiceVersionEnvKey is the key of the environment variable whose
+	// value is the version number of the service.
+	ServiceVersionNumEnvKey = "VERSION_NUMBER"
+
 	// FortioMetricsPort is the port on which /metrics is available.
 	FortioMetricsPort = 42422
 )

--- a/isotope/convert/pkg/graph/svc/service.go
+++ b/isotope/convert/pkg/graph/svc/service.go
@@ -29,6 +29,9 @@ type Service struct {
 	// Type describes what protocol the service supports (e.g. HTTP, gRPC).
 	Type svctype.ServiceType `json:"type,omitempty"`
 
+	// Service Version
+	Version string `json:"version,omitempty"`
+
 	// NumReplicas is the number of replicas backing this service.
 	NumReplicas int32 `json:"numReplicas,omitempty"`
 

--- a/isotope/convert/pkg/graph/svc/unmarshal.go
+++ b/isotope/convert/pkg/graph/svc/unmarshal.go
@@ -39,6 +39,9 @@ func (svc *Service) UnmarshalJSON(b []byte) (err error) {
 		err = ErrEmptyName
 		return
 	}
+	if svc.Version == "" {
+		svc.Version = "v1"
+	}
 	return
 }
 

--- a/isotope/example-config.toml
+++ b/isotope/example-config.toml
@@ -3,6 +3,10 @@ topology_paths = [
   "example-topologies/canonical.yaml",
 ]
 
+policy_files = [
+  "example-policies/canonical.yaml",
+]
+
 environments = [
   "NONE",
   "ISTIO",

--- a/isotope/example-config.toml
+++ b/isotope/example-config.toml
@@ -9,7 +9,6 @@ policy_files = [
 
 environments = [
   "NONE",
-  "ISTIO",
 ]
 
 [cluster]
@@ -32,7 +31,7 @@ archive_url = "https://github.com/istio/istio/releases/download/1.1.3/istio-1.1.
 machine_type = "n1-standard-1"
 disk_size_gb = 16
 num_nodes = 4
-image = "tahler/isotope-service:1"
+image = "saimsalman/isotope:v2"
 
 [client]
 machine_type = "n1-highcpu-4"

--- a/isotope/example-policies/canonical.yaml
+++ b/isotope/example-policies/canonical.yaml
@@ -1,0 +1,107 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: a
+spec:
+  hosts:
+  - a.service-graph.svc.cluster.local
+  http:
+  - route:
+    - destination:
+        host: a.service-graph.svc.cluster.local
+        subset: v1
+      weight: 75
+    - destination:
+        host: a.service-graph.svc.cluster.local
+        subset: v2
+      weight: 25
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: b
+spec:
+  hosts:
+  - b.service-graph.svc.cluster.local
+  http:
+  - route:
+    - destination:
+        host: b.service-graph.svc.cluster.local
+        subset: v1
+      weight: 100
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: c
+spec:
+  hosts:
+  - c.service-graph.svc.cluster.local
+  http:
+  - route:
+    - destination:
+        host: c.service-graph.svc.cluster.local
+        subset: v1
+      weight: 100
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: d
+spec:
+  hosts:
+  - d.service-graph.svc.cluster.local
+  http:
+  - route:
+    - destination:
+        host: d.service-graph.svc.cluster.local
+        subset: v1
+      weight: 100
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: b
+spec:
+  host: b.service-graph.svc.cluster.local
+  subsets:
+  - name: v1
+    labels:
+      version: v1
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: a
+spec:
+  host: a.service-graph.svc.cluster.local
+  subsets:
+  - name: v1
+    labels:
+      version: v1
+  - name: v2
+    labels:
+      version: v2
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: c
+spec:
+  host: c.service-graph.svc.cluster.local
+  subsets:
+  - name: v1
+    labels:
+      version: v1
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: d
+spec:
+  host: d.service-graph.svc.cluster.local
+  subsets:
+  - name: v1
+    labels:
+      version: v1
+---

--- a/isotope/example-topologies/canonical.yaml
+++ b/isotope/example-topologies/canonical.yaml
@@ -4,12 +4,18 @@ defaults:
   numRbacPolicies: 3
 services:
 - name: a
+  version: v1
+- name: a
+  version: v2
 - name: b
+  version: v1
 - name: c
+  version: v1
   script:
   - call: a
   - call: b
 - name: d
+  version: v1
   isEntrypoint: true
   script:
   - - call: a

--- a/isotope/run_tests.py
+++ b/isotope/run_tests.py
@@ -26,8 +26,9 @@ def main(args: argparse.Namespace) -> None:
                 consts.SERVICE_GRAPH_NAMESPACE, config, args.helm_values)
             pipeline.run(topology_path, mesh_environment, config.server_image,
                          config.client_image, config.istio_archive_url,
-                         config.client_qps, config.client_duration,
-                         config.client_num_conc_conns, config.labels())
+                         config.policy_files, config.client_qps,
+                         config.client_duration, config.client_num_conc_conns,
+                         config.labels())
 
 
 def parse_args() -> argparse.Namespace:

--- a/isotope/runner/config.py
+++ b/isotope/runner/config.py
@@ -8,16 +8,17 @@ import toml
 class RunnerConfig:
     """Represents the intermediary between a config file"""
 
-    def __init__(self, topology_paths: List[str], environments: List[str],
-                 istio_archive_url: str, cluster_project_id: str,
-                 cluster_name: str, cluster_zones: List[str],
-                 cluster_version: str, server_machine_type: str,
-                 server_disk_size_gb: int, server_num_nodes: int,
-                 server_image: str, client_machine_type: str,
-                 client_disk_size_gb: int, client_image: str,
-                 client_qps: Optional[int], client_duration: str,
-                 client_num_conc_conns: int) -> None:
+    def __init__(self, topology_paths: List[str], policy_files: List[str],
+                 environments: List[str], istio_archive_url: str,
+                 cluster_project_id: str, cluster_name: str,
+                 cluster_zones: List[str], cluster_version: str,
+                 server_machine_type: str, server_disk_size_gb: int,
+                 server_num_nodes: int, server_image: str,
+                 client_machine_type: str, client_disk_size_gb: int,
+                 client_image: str, client_qps: Optional[int],
+                 client_duration: str, client_num_conc_conns: int) -> None:
         self.topology_paths = topology_paths
+        self.policy_files = policy_files
         self.environments = environments
         self.istio_archive_url = istio_archive_url
         self.cluster_project_id = cluster_project_id
@@ -57,6 +58,7 @@ class RunnerConfig:
 
 def from_dict(d: Dict[str, Any]) -> RunnerConfig:
     topology_paths = d.get('topology_paths', [])
+    policy_files = d.get('policy_files', [])
     environments = d.get('environments', [])
 
     istio = d['istio']
@@ -89,6 +91,7 @@ def from_dict(d: Dict[str, Any]) -> RunnerConfig:
 
     return RunnerConfig(
         topology_paths=topology_paths,
+        policy_files=policy_files,
         environments=environments,
         istio_archive_url=istio_archive_url,
         cluster_project_id=cluster_project_id,

--- a/isotope/runner/pipeline.py
+++ b/isotope/runner/pipeline.py
@@ -58,7 +58,7 @@ def run(topology_path: str, env: mesh.Environment, service_image: str,
         logging.info('starting test with environment "%s"', env.name)
         result_output_path = '{}_{}.json'.format(topology_name, env.name)
 
-        _test_service_graph(manifest_path, policy_files,
+        _test_service_graph(env, manifest_path, policy_files,
                             result_output_path, ingress_url,
                             test_qps, test_duration,
                             test_num_concurrent_connections)
@@ -120,8 +120,8 @@ def _get_gke_node_selector(node_pool_name: str) -> str:
     return 'cloud.google.com/gke-nodepool={}'.format(node_pool_name)
 
 
-def _test_service_graph(yaml_path: str, policy_files: List[str],
-                        test_result_output_path: str,
+def _test_service_graph(env: mesh.Environment, yaml_path: str,
+                        policy_files: List[str], test_result_output_path: str,
                         test_target_url: str, test_qps: Optional[int],
                         test_duration: str,
                         test_num_concurrent_connections: int) -> None:
@@ -130,7 +130,9 @@ def _test_service_graph(yaml_path: str, policy_files: List[str],
     with kubectl.manifest(yaml_path):
         wait.until_deployments_are_ready(consts.SERVICE_GRAPH_NAMESPACE)
         wait.until_service_graph_is_ready()
-        _apply_policy_files(policy_files, consts.ISTIO_NAMESPACE)
+
+        if env.name == "istio":
+            _apply_policy_files(policy_files, consts.ISTIO_NAMESPACE)
         # TODO: Why is this extra buffer necessary?
         logging.debug('sleeping for 30 seconds as an extra buffer')
         time.sleep(30)

--- a/isotope/service/main.go
+++ b/isotope/service/main.go
@@ -55,8 +55,13 @@ func main() {
 		log.Fatalf(`env var "%s" is not set`, consts.ServiceNameEnvKey)
 	}
 
+	serviceVersion, ok := os.LookupEnv(consts.ServiceVersionNumEnvKey)
+	if !ok {
+		log.Fatalf(`env var "%s" is not set`, consts.ServiceVersionNumEnvKey)
+	}
+
 	defaultHandler, err := srv.HandlerFromServiceGraphYAML(
-		serviceGraphYAMLFilePath, serviceName)
+		serviceGraphYAMLFilePath, serviceName, serviceVersion)
 	if err != nil {
 		log.Fatalf("%s", err)
 	}

--- a/isotope/service/pkg/srv/graph.go
+++ b/isotope/service/pkg/srv/graph.go
@@ -32,14 +32,14 @@ import (
 // HandlerFromServiceGraphYAML makes a handler to emulate the service with name
 // serviceName in the service graph represented by the YAML file at path.
 func HandlerFromServiceGraphYAML(
-	path string, serviceName string) (Handler, error) {
+	path string, serviceName string, serviceVersion string) (Handler, error) {
 
 	serviceGraph, err := serviceGraphFromYAMLFile(path)
 	if err != nil {
 		return Handler{}, err
 	}
 
-	service, err := extractService(serviceGraph, serviceName)
+	service, err := extractService(serviceGraph, serviceName, serviceVersion)
 	if err != nil {
 		return Handler{}, err
 	}
@@ -95,10 +95,11 @@ func serviceGraphFromYAMLFile(
 
 // extractService finds the service in serviceGraph with the specified name.
 func extractService(
-	serviceGraph graph.ServiceGraph, name string) (
+	serviceGraph graph.ServiceGraph, name string, version string) (
 	service svc.Service, err error) {
+	version = "v" + version
 	for _, svc := range serviceGraph.Services {
-		if svc.Name == name {
+		if svc.Name == name && svc.Version == version {
 			service = svc
 			return
 		}


### PR DESCRIPTION
Extended PR (https://github.com/istio/tools/pull/214).

The user can supply yaml files (which contain mixer or pilot) policies which would be applied to the cluster before the experiment is run. Currently, one has to self-write those configuration files.