### PR TITLE
Update container definition.

### DIFF
--- a/docker/api-build-tools/Dockerfile
+++ b/docker/api-build-tools/Dockerfile
@@ -3,10 +3,10 @@ FROM golang:1.12 as golang_build_env
 # Setup environment
 ENV OUTDIR=/out
 ENV PROTOBUF_VERSION=3.9.0
-ENV GOGO_PROTOBUF_VERSION=1.2.1
-ENV GOLANG_PROTOBUF_VERSION=1.3.1
-ENV PROTOLOCK_VERSION=0.14.0
-ENV PROTOTOOL_VERSION=1.8.0
+ENV GOGO_PROTOBUF_VERSION=65acae22fc9d1fe290b33faa2bd64cdc20a463a0
+ENV GOLANG_PROTOBUF_VERSION=v1.3.1
+ENV PROTOLOCK_VERSION=v0.14.0
+ENV PROTOTOOL_VERSION=v1.8.0
 
 RUN mkdir -p ${OUTDIR}/usr/bin
 RUN mkdir -p ${OUTDIR}/usr/include
@@ -33,23 +33,21 @@ RUN for f in code error_details status http; do \
         done
 RUN curl -L -o /tmp/include/protobuf/gogoproto/gogo.proto https://raw.githubusercontent.com/gogo/protobuf/master/gogoproto/gogo.proto
 
-# Install protoc plugins
-RUN GO111MODULE=on go get github.com/golang/protobuf/protoc-gen-go@v${GOLANG_PROTOBUF_VERSION}
-RUN GO111MODULE=on go get github.com/gogo/protobuf/protoc-gen-gofast@v${GOGO_PROTOBUF_VERSION}
-RUN GO111MODULE=on go get github.com/gogo/protobuf/protoc-gen-gogo@v${GOGO_PROTOBUF_VERSION}
-RUN GO111MODULE=on go get github.com/gogo/protobuf/protoc-gen-gogofast@v${GOGO_PROTOBUF_VERSION}
-RUN GO111MODULE=on go get github.com/gogo/protobuf/protoc-gen-gogofaster@v${GOGO_PROTOBUF_VERSION}
-RUN GO111MODULE=on go get github.com/gogo/protobuf/protoc-gen-gogoslick@v${GOGO_PROTOBUF_VERSION}
-RUN GO111MODULE=on go get github.com/uber/prototool@v${PROTOTOOL_VERSION}
-RUN go get github.com/nilslice/protolock/...
-# TODO(sdake) Not sure why a versioned version of protolock can't be retrieved.
-#@v${PROTOLOCK_VERSION}
+# Install external dependencies
+RUN GO111MODULE=on go get github.com/golang/protobuf/protoc-gen-go@${GOLANG_PROTOBUF_VERSION}
+RUN GO111MODULE=on go get github.com/gogo/protobuf/protoc-gen-gofast@${GOGO_PROTOBUF_VERSION}
+RUN GO111MODULE=on go get github.com/gogo/protobuf/protoc-gen-gogo@${GOGO_PROTOBUF_VERSION}
+RUN GO111MODULE=on go get github.com/gogo/protobuf/protoc-gen-gogofast@${GOGO_PROTOBUF_VERSION}
+RUN GO111MODULE=on go get github.com/gogo/protobuf/protoc-gen-gogofaster@${GOGO_PROTOBUF_VERSION}
+RUN GO111MODULE=on go get github.com/gogo/protobuf/protoc-gen-gogoslick@${GOGO_PROTOBUF_VERSION}
+RUN GO111MODULE=on go get github.com/uber/prototool/cmd/prototool@${PROTOTOOL_VERSION}
+RUN GO111MODULE=on go get github.com/nilslice/protolock/cmd/protolock@${PROTOLOCK_VERSION}
 
-# Install custom istio.io tools
+# Install custom Istio tools
 RUN go get istio.io/tools/protoc-gen-docs
 RUN go get istio.io/tools/cmd/annotations_prep
 
-# Install go static binaries
+# Put the stuff we need in its final output location
 RUN install -c ${GOPATH}/bin/* ${OUTDIR}/usr/bin
 RUN cp -aR /tmp/bin/protoc ${OUTDIR}/usr/bin
 RUN cp -aR /tmp/include/* ${OUTDIR}/usr/include
@@ -57,7 +55,6 @@ RUN cp -aR /tmp/include/* ${OUTDIR}/usr/include
 # Optimization step
 RUN upx --lzma /${OUTDIR}/usr/bin/*
 
-# Finally, Render a distroless image with the binaries and protobuf includes
-FROM gcr.io/distroless/base:latest
-
+# Finally, render the image with the binaries and protobuf includes
+FROM ubuntu:xenial
 COPY --from=golang_build_env /out/ /

--- a/go.mod
+++ b/go.mod
@@ -26,10 +26,8 @@ require (
 	github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829
-	github.com/russross/blackfriday v2.0.0+incompatible
 	github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749
 	github.com/shurcooL/sanitized_anchor_name v0.0.0-20170918181015-86672fcb3f95 // indirect
-	github.com/shurcooL/vfsgen v0.0.0-20181202132449-6a9ea43bcacd // indirect
 	github.com/spf13/cobra v0.0.3
 	golang.org/x/time v0.0.0-20181108054448-85acf8d2951c // indirect
 	golang.org/x/tools v0.0.0-20181210225255-6a3e9aa2ab77

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,3 @@
-cuelang.org/go v0.0.4 h1:YY7QFmPPluSSOEvkQ+cevzDnDMfNYcafE6ghFlX7RvU=
-cuelang.org/go v0.0.5-0.20190711165736-1233594eb1d7 h1:bm5Z7BV6LgecW5as7PRb/yRMfLwniE+HbzvIZQgwyOQ=
-cuelang.org/go v0.0.5-0.20190711165736-1233594eb1d7/go.mod h1:VIdM1Tv9WLZrnFHlSCCd8/chGu0Jo8s/VF0Y1HT9zyI=
 cuelang.org/go v0.0.5-0.20190714195934-4e5b69a67cf9 h1:H2/gNRB7dUQZBrPywxyIjQv/DBHRhTHZ5IkQyjuIfcM=
 cuelang.org/go v0.0.5-0.20190714195934-4e5b69a67cf9/go.mod h1:VIdM1Tv9WLZrnFHlSCCd8/chGu0Jo8s/VF0Y1HT9zyI=
 fortio.org/fortio v1.1.0 h1:RcZTb73HO2NXj6K9U6DZ02BVeA2TzmCdqFD80Y/AU8Y=
@@ -103,16 +100,12 @@ github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R
 github.com/prometheus/procfs v0.0.0-20190117184657-bf6a532e95b1 h1:/K3IL0Z1quvmJ7X0A1AwNEK7CRkVK3YwfOU/QAL4WGg=
 github.com/prometheus/procfs v0.0.0-20190117184657-bf6a532e95b1/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/retr0h/go-gilt v0.0.0-20190206215556-f73826b37af2/go.mod h1:7PJr6TwZ6FwyTMn8zrm5QbMfH7yCiv56Wi9hRPhpWSM=
-github.com/russross/blackfriday v2.0.0+incompatible h1:cBXrhZNUf9C+La9/YpS+UHpUT8YD6Td9ZMSU9APFcsk=
-github.com/russross/blackfriday v2.0.0+incompatible/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749 h1:bUGsEnyNbVPw06Bs80sCeARAlK8lhwqGyi6UT8ymuGk=
 github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749/go.mod h1:ZY1cvUeJuFPAdZ/B6v7RHavJWZn2YPVFQ1OSXhCGOkg=
 github.com/shurcooL/sanitized_anchor_name v0.0.0-20170918181015-86672fcb3f95 h1:/vdW8Cb7EXrkqWGufVMES1OH2sU9gKVb2n9/1y5NMBY=
 github.com/shurcooL/sanitized_anchor_name v0.0.0-20170918181015-86672fcb3f95/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
-github.com/shurcooL/vfsgen v0.0.0-20181202132449-6a9ea43bcacd h1:ug7PpSOB5RBPK1Kg6qskGBoP3Vnj/aNYFTznWvlkGo0=
-github.com/shurcooL/vfsgen v0.0.0-20181202132449-6a9ea43bcacd/go.mod h1:TrYk7fJVaAttu97ZZKrO9UbRa8izdowaMIZcxYMbVaw=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/spf13/cobra v0.0.1/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/cobra v0.0.3 h1:ZlrZ4XsMRm04Fr5pSFxBgfND2EBVa1nLpiy1stUsX/8=


### PR DESCRIPTION
- Use the correct paths to install protolock and prototool. As it was, the binary for
prototool wasn't actually included in the container.

- Update go.mod (via 'go mod tidy'). Once that change hits the repo, it'll then be possible
to use GO111MODULE=on when pulling in protoc-gen-docs and annotation_prep. Without this
change in  the repo, these modules must be built using the legacy approach.