### PR TITLE
Add definitions for GOPATH and GO111MODULE

### DIFF
--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -88,7 +88,9 @@ RUN rm -rf /var/lib/apt/lists/*
 # Setup to run the Go compiler with host-side build cache, test cache, and module cache
 FROM scratch
 
+ENV GO111MODULE=on
 ENV GOROOT=/go
+ENV GOPATH=/go
 ENV GOCACHE=/gocache
 ENV PATH /go/bin:$PATH
 


### PR DESCRIPTION
This makes things work for me.

I do get  a warning at the  start of compilation claiming that GOPATH is redundantly set  to the same thing as GOROOT. But without GOPATH, nothing works.
