### PR TITLE
WIP: A smaller prow runner image

### DIFF
--- a/docker/prow-launcher/Dockerfile
+++ b/docker/prow-launcher/Dockerfile
@@ -1,0 +1,38 @@
+FROM ubuntu:xenial as build_context
+
+ENV DOCKER_VERSION=18.06.1
+ENV VERSION_SUFFIX="~ce~3-0~ubuntu"
+
+ADD install-docker.sh /tmp/
+
+# Installing
+RUN apt-get update
+RUN apt-get -qqy install --no-install-recommends \
+  apt-transport-https \
+  ca-certificates \
+  curl \
+  lsb-release \
+  software-properties-common \
+  time \
+  make
+
+RUN /tmp/install-docker.sh
+
+# Add entrypoint to start docker
+ADD prow-runner.sh /usr/local/bin/entrypoint
+RUN chmod +rx /usr/local/bin/entrypoint
+
+FROM scratch
+COPY --from=build_context / /
+
+# Docker in Docker settings
+VOLUME /var/lib/docker
+EXPOSE 2375
+
+ENV PATH /usr/local/go/bin:/opt/go/bin:/usr/lib/google-cloud-sdk/bin:/root/.local/bin:${PATH}
+
+# Set CI variable which can be checked by test scripts to verify
+# if running in the continuous integration environment.
+ENV CI prow
+
+ENTRYPOINT ["entrypoint"]

--- a/docker/prow-launcher/build.sh
+++ b/docker/prow-launcher/build.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+# This is a temporary script, only to be used until we have a better official
+# place and procedure for generation. PLEASE use with caution
+# (read: not for general usage).
+
+HUB=docker.io/sdake
+VERSION=$(date +%Y-%m-%d)
+
+docker build --no-cache -t $HUB/prow-launcher:$VERSION .
+docker push $HUB/prow-launcher:$VERSION

--- a/docker/prow-launcher/install-docker.sh
+++ b/docker/prow-launcher/install-docker.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -eux
+
+#Version: 18.06.1~ce-0~ubuntu-xenial
+DOCKER_VERSION=18.06.1
+VERSION_SUFFIX="~ce~3-0~ubuntu"
+
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
+add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+ $(lsb_release -cs) stable"
+apt-get update
+apt-get -qqy install docker-ce="${DOCKER_VERSION}${VERSION_SUFFIX}"

--- a/docker/prow-launcher/prow-runner.sh
+++ b/docker/prow-launcher/prow-runner.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -eux
+
+service docker start
+
+[[ -n ${GOPATH:-} ]] && export PATH=${GOPATH}/bin:${PATH}
+
+# Authenticate gcloud, allow failures
+if [[ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then
+  gcloud auth activate-service-account --key-file="${GOOGLE_APPLICATION_CREDENTIALS}" || true
+fi
+
+exec "$@"


### PR DESCRIPTION
This contains docker, golang, and make.  Unfortunately our
build system depends on a system installed golang.  I think we could
improve on the make system by running with a dummy golang cache if
golang is not installed.  This would reduce the size of this image as
well (by ~400mb).