### PR TITLE
Relocate vfsgen from operator to this repo and slightly generalize it.

### DIFF
--- a/cmd/vfsgen/main.go
+++ b/cmd/vfsgen/main.go
@@ -1,0 +1,44 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"flag"
+	"log"
+	"net/http"
+
+	"github.com/shurcooL/vfsgen"
+)
+
+func main() {
+	inputDir := flag.String("i", "", "input directory to process")
+	outputFile := flag.String("o", "", "output go file to produce")
+	packageName := flag.String("p", "", "name of package in generated go output")
+	variableName := flag.String("v", "", "name of variable in generated go output")
+	flag.Parse()
+
+	if *inputDir == "" || *outputFile == "" || *packageName == "" || *variableName == "" {
+		log.Fatalf("Missing argument")
+	}
+
+	templates := http.Dir(*inputDir)
+	if err := vfsgen.Generate(templates, vfsgen.Options{
+		Filename:     *outputFile,
+		PackageName:  *packageName,
+		VariableName: *variableName,
+	}); err != nil {
+		log.Fatalln("vfsgen failed to generate code: ", err)
+	}
+}

--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -9,7 +9,6 @@ ENV PROTOTOOL_VERSION=v1.8.0
 ENV COUNTERFEITER_VERSION=v6.2.2
 ENV GOIMPORTS_VERSION=379209517ffe
 ENV GOLANGCI_LINT_VERSION=v1.16.0
-ENV VFSGEN_VERSION=6a9ea43bcacdf716a5c1b38efff722c07adf0069
 
 ENV OUTDIR=/out
 
@@ -59,7 +58,7 @@ RUN go get github.com/jteeuwen/go-bindata/go-bindata
 RUN go get istio.io/tools/protoc-gen-docs
 RUN go get istio.io/tools/cmd/annotations_prep
 ## https://github.com/istio/operator
-RUN GO111MODULE=on go get github.com/shurcooL/vfsgen@${VFSGEN_VERSION}
+RUN go get istio.io/tools/cmd/vfsgen
 
 # Put the stuff we need in its final output location
 RUN mkdir -p ${OUTDIR}/go/bin

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829
 	github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749
 	github.com/shurcooL/sanitized_anchor_name v0.0.0-20170918181015-86672fcb3f95 // indirect
-	github.com/shurcooL/vfsgen v0.0.0-20181202132449-6a9ea43bcacd // indirect
+	github.com/shurcooL/vfsgen v0.0.0-20181202132449-6a9ea43bcacd
 	github.com/spf13/cobra v0.0.3
 	golang.org/x/time v0.0.0-20181108054448-85acf8d2951c // indirect
 	golang.org/x/tools v0.0.0-20190328211700-ab21143f2384


### PR DESCRIPTION
This replaces istio/operator/cmd/vfsgen. I replaced the hardcoded arguments with a set of command-line flags to make this slightly more general. This tool can then be included in the build-tools container image and used when building the operator repo.
