### PR TITLE
Add Makefile target to create and run Docker container for developer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,8 @@
 # allow optional per-repo overrides
 -include Makefile.overrides.mk
 
+-include docker/istio-dev/istio-dev.mk
+
 # Set the environment variable BUILD_WITH_CONTAINER to use a container
 # to build the repo. The only dependencies in this mode are to have make and
 # docker. If you'd rather build with a local tool chain instead, you'll need to

--- a/docker/istio-dev/.gitignore
+++ b/docker/istio-dev/.gitignore
@@ -1,0 +1,1 @@
+image-built

--- a/docker/istio-dev/Dockerfile
+++ b/docker/istio-dev/Dockerfile
@@ -1,0 +1,83 @@
+FROM docker:stable as docker
+
+FROM gcr.io/istio-testing/build-tools:2019-09-16T11-57-35 as build-tools
+
+FROM ubuntu:xenial
+ARG user
+ARG group
+ARG uid=1000
+ARG gid=1000
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+COPY --from=build-tools /usr/bin/protoc /usr/bin/
+COPY --from=build-tools /usr/bin/shellcheck /usr/bin/
+COPY --from=build-tools /usr/bin/hadolint /usr/bin/
+COPY --from=build-tools /usr/bin/hugo /usr/bin/
+COPY --from=build-tools /usr/bin/helm /usr/bin/
+COPY --from=build-tools /go/ /usr/local/go/
+COPY --from=build-tools /usr/local/ /usr/local/
+COPY --from=build-tools /node_modules/ /node_modules/
+
+RUN chmod 755 /usr/local/go/pkg/mod /usr/local/go/src
+
+# Install development packages.
+RUN apt-get update && apt-get -qqy install --no-install-recommends \
+autoconf=2.69-9 \
+autotools-dev=20150820.1 \
+bash-completion=1:2.1-4.2ubuntu1.1 \
+build-essential=12.1ubuntu2 \
+ca-certificates=20170717~16.04.2 \
+curl=7.47.0-1ubuntu2.14 \
+git=1:2.7.4-0ubuntu1.6 \
+iptables=1.6.0-2ubuntu3 \
+jq=1.5+dfsg-1ubuntu0.1 \
+libtool=2.4.6-0.1 \
+lsb-release=9.20160110ubuntu0.2 \
+make=4.1-6 \
+python3=3.5.1-3 \
+sudo=1.8.16-0ubuntu1.7 \
+tmux=2.1-3build1 \
+unzip=6.0-20ubuntu1 \
+vim=2:7.4.1689-3ubuntu1.3 \
+wget=1.17.1-1ubuntu1.5 \
+xz-utils=5.1.1alpha+20120614-2ubuntu2 \
+&& rm -rf /var/lib/apt/lists/*
+
+# Create user and allow sudo without password.
+RUN addgroup --quiet --gid $gid $group \
+&& adduser --quiet --disabled-password --gecos ",,,," --uid $uid --ingroup $group $user \
+&& echo "${user} ALL=(ALL:ALL) NOPASSWD: ALL" > /etc/sudoers.d/$user
+
+# Install Docker CLI.
+COPY --from=docker /usr/local/bin/docker /usr/local/bin/docker
+
+# Install gcloud and kubectl.
+RUN echo "deb http://packages.cloud.google.com/apt cloud-sdk-$(lsb_release -c -s) main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
+&& curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - \
+&& apt-get update && apt-get -qqy install --no-install-recommends \
+google-cloud-sdk=262.0.0-0 \
+kubectl=1.15.3-00 \
+&& rm -rf /var/lib/apt/lists/*
+
+# Install bash completion files.
+RUN /usr/local/go/bin/kind completion bash > /etc/bash_completion.d/kind \
+&& /usr/bin/helm completion bash > /etc/bash_completion.d/helm \
+&& /usr/bin/kubectl completion bash > /etc/bash_completion.d/kubectl \
+&& curl -s -Lo - https://raw.githubusercontent.com/docker/cli/master/contrib/completion/bash/docker > /etc/bash_completion.d/docker
+
+USER $user
+
+# Fix the Docker socket access rights at login time to allow non-root access.
+RUN echo "sudo chmod o+rw /var/run/docker.sock" >> /home/${user}/.bashrc
+
+# Setup Go for the user.
+RUN echo "# Go environment." >> /home/${user}/.bashrc \
+&& echo "export GOROOT=/usr/local/go" >> /home/${user}/.bashrc \
+&& echo "export GOPATH=~/go" >> /home/${user}/.bashrc \
+&& echo "export PATH=\$GOROOT/bin:\$GOPATH/out/linux_amd64/release:\$GOPATH/bin:\$PATH" >> /home/${user}/.bashrc \
+&& echo "export GO111MODULE=on" >> /home/${user}/.bashrc \
+&& mkdir -p /home/${user}/go
+
+WORKDIR /home/$user/go
+ENTRYPOINT ["/bin/bash", "-c"]

--- a/docker/istio-dev/README.md
+++ b/docker/istio-dev/README.md
@@ -1,0 +1,66 @@
+# Istio Development Environment in Docker
+
+This `Dockerfile` creates an Ubuntu-based Docker image for developing on Istio.
+
+## Image Configuration
+
+- The base Istio development tools and the following additional tools are installed, with Bash completion configured:
+    - [Docker CLI](https://docs.docker.com/engine/reference/commandline/cli/)
+    - [Google Cloud SDK (gcloud)](https://cloud.google.com/sdk/gcloud/)
+    - [kubectl](https://kubernetes.io/docs/reference/kubectl/kubectl/)
+    - [Kubernetes IN Docker (KIND)](https://github.com/kubernetes-sigs/kind)
+    - [Helm](https://helm.sh/)
+- A user with the same name as the local host user is created. That user has full sudo rights without password.
+- The following volumes are mounted from the host into the container to share development files and configuration:
+    - Go directory: `$(GOPATH)` → `/home/$(USER)/go`
+    - Google Cloud SDK config: `$(HOME)/.config/gcloud` → `/home/$(USER)/.config/gcloud`
+    - Kubernetes config: `$(HOME)/.kube` → `/home/$(USER)/.kube`
+    - Docker socket, to access Docker from within the container: `/var/run/docker.sock` → `/var/run/docker.sock`
+- The working directory is `/home/$user/go/src/istio.io/istio`.
+
+## Creating The Container
+
+To create your dev container, run:
+
+```bash
+make dev-shell
+```
+
+The first time this target it run, a Docker image named `istio/dev:USER` is created, where USER is your local username.
+Any subsequent run won't rebuild the image unless the `Dockerfile` is modified.
+
+The first time this target is run, a container named `istio-dev` is run with this image, and an interactive shell is executed in the container.
+Any subsequent run won't restart the container and will only start an additional interactive shell.
+
+## Kubernetes Cluster Creation Using KIND
+
+A Kubernetes can be created using KIND. For instance, to create a cluster named `blah` with 2 workers, run the following command within the container:
+
+```bash
+export CLUSTER_NAME="blah"
+
+kind create cluster --name="$CLUSTER_NAME" --config=- <<EOF
+kind: Cluster
+apiVersion: kind.sigs.k8s.io/v1alpha3
+nodes:
+- role: control-plane
+- role: worker
+- role: worker
+EOF
+
+export KUBECONFIG=$(kind get kubeconfig-path --name="$CLUSTER_NAME")
+```
+
+KIND was originally intended to run from the host, so KIND rewrites the kubeconfig to redirect the port to kubeadmin.
+This rewriting must be undone to allow connecting directly from within the container:
+
+```bash
+docker exec "${CLUSTER_NAME}-control-plane" cat /etc/kubernetes/admin.conf > $KUBECONFIG
+```
+
+## Removing The Container
+
+```bash
+docker stop istio-dev
+docker rm istio-dev
+```

--- a/docker/istio-dev/istio-dev.mk
+++ b/docker/istio-dev/istio-dev.mk
@@ -1,0 +1,51 @@
+# Copyright 2019 Istio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+DEV_IMAGE_NAME = istio/dev:$(USER)
+DEV_CONTAINER_NAME = istio-dev
+
+# Build a dev environment Docker image.
+docker/istio-dev/image-built: docker/istio-dev/Dockerfile
+	@echo "building \"$(DEV_IMAGE_NAME)\" Docker image"
+	@docker build \
+		--build-arg user="${shell id -un}" \
+		--build-arg group="${shell id -gn}" \
+		--build-arg uid="${shell id -u}" \
+		--build-arg gid="${shell id -g}" \
+		--tag "$(DEV_IMAGE_NAME)" - < docker/istio-dev/Dockerfile
+	@touch $@
+
+# Start a dev environment Docker container.
+.PHONY = dev-shell clean-dev-shell
+dev-shell: docker/istio-dev/image-built
+	@if test -z "$(shell docker ps -a -q -f name=$(DEV_CONTAINER_NAME))"; then \
+	    echo "starting \"$(DEV_CONTAINER_NAME)\" Docker container"; \
+		docker run --detach \
+			--name "$(DEV_CONTAINER_NAME)" \
+			--volume "$(GOPATH)/out:/home/$(USER)/go/out:consistent" \
+			--volume "$(GOPATH)/pkg:/home/$(USER)/go/pkg:consistent" \
+			--volume "$(GOPATH)/src:/home/$(USER)/go/src:consistent" \
+			--volume "$(HOME)/.config/gcloud:/home/$(USER)/.config/gcloud:cached" \
+			--volume "$(HOME)/.kube:/home/$(USER)/.kube:cached" \
+			--volume /var/run/docker.sock:/var/run/docker.sock \
+			"$(DEV_IMAGE_NAME)" \
+			'while true; do sleep 60; done';  fi
+	@echo "executing shell in \"$(DEV_CONTAINER_NAME)\" Docker container"
+	@docker exec --tty --interactive "$(DEV_CONTAINER_NAME)" /bin/bash
+
+clean-dev-shell:
+	docker rm -f "$(DEV_CONTAINER_NAME)" || true
+	if test -n "$(shell docker images -q $(DEV_IMAGE_NAME))"; then \
+		docker rmi -f "$(shell docker images -q $(DEV_IMAGE_NAME))" || true; fi
+	rm -f docker/istio-dev/image-built


### PR DESCRIPTION
Dockerfile for an Istio development environment on Docker.
The image is built and the container is started with a single `make dev-shell`.
This is a more lightweight alternative to Vagrant.
The container image is setup to use KIND instead of Minikube.

This was previously in `istio/istio/tools/docker-dev`, cf. https://github.com/istio/istio/pull/14710.