### PR TITLE
Remove dep and use go modules (isotope/service)

### DIFF
--- a/isotope/service/Dockerfile
+++ b/isotope/service/Dockerfile
@@ -1,18 +1,15 @@
 # Note: this image must be built from the root of the repository for access to
 # the vendor folder.
 
-FROM golang:1.10.2 AS builder
-
-RUN go get -u github.com/golang/dep/cmd/dep
+FROM golang:1.12.7 AS builder
 
 WORKDIR /go/src/istio.io/tools
 
 COPY . .
-RUN dep ensure -vendor-only
 
 WORKDIR /go/src/istio.io/tools/isotope/service
 
-RUN CGO_ENABLED=0 GOOS=linux \
+RUN GO111MODULE=on CGO_ENABLED=0 GOOS=linux \
     go build -a -installsuffix cgo -o ./main ./main.go
 
 FROM scratch


### PR DESCRIPTION
This PR fixes the ability to build `isotope/service`. Without the patch you will get the following error message:

```bash
docker build -t isotope/service:test . -f isotope/service/Dockerfile 
Sending build context to Docker daemon  21.15MB
Step 1/11 : FROM golang:1.10.2 AS builder
 ---> 3f30f1fc3c43
Step 2/11 : RUN go get -u github.com/golang/dep/cmd/dep
 ---> Using cache
 ---> 1f164eb4b352
Step 3/11 : WORKDIR /go/src/istio.io/tools
 ---> Using cache
 ---> 49cc311f92da
Step 4/11 : COPY . .
 ---> 0631c0d6a229
Step 5/11 : RUN dep ensure -vendor-only
 ---> Running in 958c1c0d7a5b
could not find project Gopkg.toml, use dep init to initiate a manifest
The command '/bin/sh -c dep ensure -vendor-only' returned a non-zero code: 1
```

and with the patch everything works as expected:

```bash
docker build -t isotope/service:test . -f isotope/service/Dockerfile
Sending build context to Docker daemon  21.15MB
Step 1/9 : FROM golang:1.12.7 AS builder
 ---> be63d15101cb
Step 2/9 : WORKDIR /go/src/istio.io/tools
 ---> Using cache
 ---> ad0b878813fc
Step 3/9 : COPY . .
 ---> 658d1f0679d6
Step 4/9 : WORKDIR /go/src/istio.io/tools/isotope/service
 ---> Running in 57dabd08d235
Removing intermediate container 57dabd08d235
 ---> 39b685b6b0b6
Step 5/9 : RUN GO111MODULE=on CGO_ENABLED=0 GOOS=linux     go build -a -installsuffix cgo -o ./main ./main.go
 ---> Running in 0ef151ab24f5
go: finding github.com/peterbourgon/diskv v2.0.1+incompatible
...
Removing intermediate container 0ef151ab24f5
 ---> f348d548ddb1
Step 6/9 : FROM scratch
 ---> 
Step 7/9 : COPY --from=builder     /go/src/istio.io/tools/isotope/service/main /usr/local/bin/isotope_service
 ---> Using cache
 ---> 59223395254e
Step 8/9 : EXPOSE 8080
 ---> Using cache
 ---> 90ec7263cfad
Step 9/9 : ENTRYPOINT ["/usr/local/bin/isotope_service"]
 ---> Using cache
 ---> 180d18b61d67
Successfully built 180d18b61d67
Successfully tagged isotope/service:test
```