### PR TITLE
Permit /go/src to be writeable by mere users

### DIFF
--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -193,6 +193,7 @@ RUN mkdir -p /gocache && \
 # the directory mounted rather then overridding with the permission of the volume file.
 RUN chmod 777 /gocache && \
     chmod 777 /go/pkg/mod && \
-    chmod 777 /root
+    chmod 777 /root && \
+    chmod 777 /go/src
 
 WORKDIR /


### PR DESCRIPTION
For the operator repository, it is necessary to enable a CONTAINER_OPTION of:

```
--mount type=volume,source=istio-installer-cache,destination="${GOPATH}/src/istio.io" \
```

This permits putting stuff in ${GOPATH}/src/istio.io.  I'm not
convinced the operator repository is doing things correctly
here.  This repo checks out a copy of istio.io/installer to
$GOPATH/src/istio.io/installer.  This seems problematic as
it may overwrite the existing installer repository.  In a
container based build, this simply creates a new docker volume
cache to store this information.

This pattern might be generalizable to other repositories,
in which case we can remove it as a COTAINER_OPTION. Time will tell
if other repositories (ab)use the ${GOPATH}/src directory.