### PR TITLE
Change Cue to read fieldfilter from config file when generating CRD

### DIFF
--- a/openapi/cue/genoapi.go
+++ b/openapi/cue/genoapi.go
@@ -451,8 +451,6 @@ func (x *builder) genOpenAPI(name string, inst *cue.Instance) (*openapi.OrderedM
 	if *crd {
 		// CRD schema does not allow $ref fields.
 		gen.ExpandReferences = true
-
-		gen.FieldFilter = "min.*|max.*"
 	}
 
 	return gen.Schemas(inst)


### PR DESCRIPTION
So that we are not embedding the fieldfilter regex in the code and be more flexible with what fields are allowed in different k8s versions.