### PR TITLE
Create protobufs for operator repository

### DIFF
--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -123,6 +123,29 @@ RUN chmod 555 ${OUTDIR}/usr/bin/hadolint
 ADD https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_Linux-64bit.tar.gz /tmp
 RUN tar -xzvf /tmp/hugo_${HUGO_VERSION}_Linux-64bit.tar.gz -C ${OUTDIR}/usr/bin
 
+# Replicate k8s.io/api proto structure and generated protos
+# in /usr/include/protobuf/k8s.io/api
+RUN mkdir -p ${OUTDIR}/usr/include/protobuf/k8s.io/api
+RUN git clone https://github.com/kubernetes/api.git
+WORKDIR /tmp/api
+RUN find . -name \*proto -exec cp -a --parents {} ${OUTDIR}/usr/include/protobuf/k8s.io/api \;
+
+# Replicate k8s.io/apimachinery proto structure and generated protos
+# in /usr/include/protobuf/k8s.io/apimachinery
+WORKDIR /tmp
+RUN mkdir -p ${OUTDIR}/usr/include/protobuf/k8s.io/apimachinery
+RUN git clone https://github.com/kubernetes/apimachinery.git
+WORKDIR /tmp/apimachinery
+RUN find . -name \*proto -exec cp -a --parents {} ${OUTDIR}/usr/include/protobuf/k8s.io/apimachinery \;
+
+# Replicate gogo/protobuf proto structure and generatede protos
+# in /usr/include/protobuf/github.com/gogo/protobuf
+WORKDIR /tmp
+RUN mkdir -p ${OUTDIR}/usr/include/protobuf/github.com/gogo/protobuf
+RUN git clone https://github.com/gogo/protobuf.git
+WORKDIR /tmp/protobuf
+RUN find . -name \*proto -exec cp -a --parents {} ${OUTDIR}/usr/include/protobuf/github.com/gogo/protobuf \;
+
 # Use inplace decompression on the go binaries
 RUN upx --lzma ${OUTDIR}/go/bin/*
 


### PR DESCRIPTION
This clones the various protobufs needed for the operator repo.

After running with this PR, and running with the following diff on
the operator repository:
```
 $(api_pb_gos): $(api_protos)
-       @protoc $(gogofast_plugin) $^
+       protoc -I$(pwd) -I/usr/include/protobuf $(gogofast_plugin) $^
```

The operator repo gets closer - exiting with the error:
```
Stevens-MacBook-Pro:operator sdake$ make generate-api-go
protoc -I/work -I/usr/include/protobuf --gogofast_out=plugins=grpc,Mgogoproto/gogo.proto=github.com/gogo/protobuf/gogoproto,Mgoogle/protobuf/any.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/descriptor.proto=github.com/gogo/protobuf/protoc-gen-gogo/descriptor,Mgoogle/protobuf/duration.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/struct.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/timestamp.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/wrappers.proto=github.com/gogo/protobuf/types,Mgoogle/rpc/status.proto=github.com/gogo/googleapis/google/rpc,Mgoogle/rpc/code.proto=github.com/gogo/googleapis/google/rpc,Mgoogle/rpc/error_details.proto=github.com/gogo/googleapis/google/rpc,: pkg/apis/istio/v1alpha2/istiocontrolplane_types.proto pkg/apis/istio/v1alpha2/values/values_types.proto
2019/08/20 12:50:20 protoc-gen-gogo: error:inconsistent package import paths: "pkg/apis/istio/v1alpha2", "pkg/apis/istio/v1alpha2/values"
--gogofast_out: protoc-gen-gogofast: Plugin failed with status code 1.
Makefile.core.mk:90: recipe for target 'pkg/apis/istio/v1alpha2/istiocontrolplane_types.pb.go' failed
make: *** [pkg/apis/istio/v1alpha2/istiocontrolplane_types.pb.go] Error 1
make: *** [generate-api-go] Error 2
```

I think the operator defect is not a result of this PR.