### PR TITLE
Update instruction of flame

### DIFF
--- a/perf/benchmark/flame/README.md
+++ b/perf/benchmark/flame/README.md
@@ -40,6 +40,9 @@ Flame graphs are created from data collected using linux `perf_events` by the `p
     sudo sysctl kernel.kptr_restrict=0
     ```
     This setting is very permissive so it must be used with care.
+    
+    If running perf still gives error:```You may not have permission to collect stats. Consider tweaking /proc/sys/kernel/perf_event_paranoid:```
+    after running above commands, try ssh into node and run the container with --privileged flag.
 
 3. Copy [`get_perfdata.sh`](get_perfdata.sh) to the container and run it as follows. The following command collects samples at `177Hz` for `20s`.
     ```

--- a/perf/benchmark/flame/get_perfdata.sh
+++ b/perf/benchmark/flame/get_perfdata.sh
@@ -13,7 +13,7 @@ PID=$(pgrep envoy)
 # This is specific to the kernel version
 # example: /usr/lib/linux-tools-4.4.0-131/perf
 # provided by `linux-tools-generic`
-PERFDIR=$(find /usr/lib -name 'linux-tools-*' -type d | head)
+PERFDIR=$(find /usr/lib -name 'linux-tools-*' -type d | head -n 1)
 if [[ -z "${PERFDIR}" ]]; then
     echo "Missing perf tool. Install apt-get install linux-tools-generic"
     exit 1


### PR DESCRIPTION
Keep getting "You may not have permission to collect stats. Consider tweaking /proc/sys/kernel/perf_event_paranoid" error even setting the perf_event_paranoid to value below 2. Have to run container with --privileged to bypass the issue.

Also the command would fail if there are multiple linux-tools* directories.