### PR TITLE
Fix inconsistent namespace between benchmark doc and runner.py

### DIFF
--- a/perf/benchmark/runner/runner.py
+++ b/perf/benchmark/runner/runner.py
@@ -14,7 +14,7 @@ import time
 POD = collections.namedtuple('Pod', ['name', 'namespace', 'ip', 'labels'])
 
 
-def pod_info(filterstr="", namespace="service-graph", multi_ok=True):
+def pod_info(filterstr="", namespace="twopods", multi_ok=True):
     cmd = "kubectl -n {namespace} get pod {filterstr}  -o json".format(
         namespace=namespace, filterstr=filterstr)
     op = subprocess.check_output(shlex.split(cmd))
@@ -75,7 +75,7 @@ class Fortio(object):
         self.duration = duration
         self.mode = mode
         self.size = size
-        self.ns = os.environ.get("NAMESPACE", "service-graph")
+        self.ns = os.environ.get("NAMESPACE", "twopods")
         # bucket resolution in seconds
         self.r = "0.00005"
         self.mixer = mixer
@@ -211,7 +211,7 @@ def perf(mesh, pod, labels, duration=20, runfn=run_command_sync):
 
 
 def kubecp(mesh, from_file, to_file):
-    namespace = os.environ.get("NAMESPACE", "service-graph")
+    namespace = os.environ.get("NAMESPACE", "twopods")
     cmd = "kubectl --namespace {namespace} cp {from_file} {to_file} -c" + mesh + \
         "-proxy".format(from_file=from_file, to_file=to_file, namespace=namespace)
     print(cmd)
@@ -219,7 +219,7 @@ def kubecp(mesh, from_file, to_file):
 
 
 def kubectl(pod, remote_cmd, runfn=run_command, container=None):
-    namespace = os.environ.get("NAMESPACE", "service-graph")
+    namespace = os.environ.get("NAMESPACE", "twopods")
     c = ""
     if container is not None:
         c = "-c " + container


### PR DESCRIPTION
**Issue**:
Due to the mismatched namespaces between `perf/benchmark/README.md deploy workloads section` and `perf/benchmark/runner/runner.py`, we run into this issue:
```
(runner) bash-3.2$ python runner/runner.py 1,2,4,8,16,32,64 1000 240 --serversidecar
Namespace(baseline=False, client=None, clientsidecar=True, conn=[1, 2, 4, 8, 16, 32, 64], duration=240, ingress=None, labels=None, mesh='istio', perf=False, qps=[1000], server=None, serversidecar=True, size=1024)
Traceback (most recent call last):
 File "runner/runner.py", line 313, in <module>
   sys.exit(main(sys.argv[1:]))
 File "runner/runner.py", line 308, in main
   return run(args)
 File "runner/runner.py", line 253, in run
   mesh=args.mesh)
 File "runner/runner.py", line 86, in __init__
   self.server = pod_info("-lapp=" + server, namespace=self.ns)
 File "runner/runner.py", line 28, in pod_info
   raise Exception("no pods found with command [" + cmd + "]")
Exception: no pods found with command [kubectl -n service-graph get pod -lapp=fortioserver  -o json]
```

**To Fix**:
make `service-graph` namespace to be `twopods`