### PR TITLE
Increase cert rotation time

### DIFF
--- a/perf/istio-install/values-istio-non-sds.yaml
+++ b/perf/istio-install/values-istio-non-sds.yaml
@@ -18,7 +18,7 @@ gateways:
 
 security:
   # Short lived cert to test rotation.
-  workloadCertTtl: 30m
+  workloadCertTtl: 300m
 
 nodeagent:
   enabled: false


### PR DESCRIPTION
At 30m it is so low that we will miss things like memory leaks, etc. We
are effectively running a bunch of 30m tests rather than long running
tests. 300m still gives us plenty of rotations.