### PR TITLE
Fix benchmark --perf label errors

### DIFF
--- a/perf/benchmark/runner/runner.py
+++ b/perf/benchmark/runner/runner.py
@@ -221,7 +221,7 @@ def perf(mesh, pod, labels, duration=20, runfn=run_command_sync):
 
 def kubecp(mesh, from_file, to_file):
     namespace = os.environ.get("NAMESPACE", "twopods")
-    cmd = "kubectl --namespace {namespace} cp {from_file} {to_file} -c" + mesh + \
+    cmd = "kubectl --namespace {namespace} cp {from_file} {to_file} -c " + mesh + \
         "-proxy".format(from_file=from_file,
                         to_file=to_file,
                         namespace=namespace)


### PR DESCRIPTION
This PR solves issue: https://github.com/istio/istio/issues/16731
WIP: No review needed currently. 

When I set --perf=true, I got the following error:
```
(runner) bash-3.2$ python runner/runner.py 4,64 1000 100 --serversidecar --perf=true
Namespace(baseline=False, client=None, clientsidecar=True, conn=[4, 64], duration=100, ingress=None, labels=None, mesh='istio', mode='http', perf='true', qps=[1000], server=None, serversidecar=True, size=1024)
kubectl --namespace twopods exec -i -t fortioclient-588f7fb74d-r6rqj  -- fortio load -c 4 -qps 1000 -t 100s -a -r 0.00005  -httpbufferkb=128 -labels 93978b8e_qps_1000_c_4_1024_serveronly http://10.32.0.7:8080/echo?size=1024
kubectl --namespace {namespace} cp {from_file} {to_file} -c istio-proxy
error: one of src or dest must be a remote file specification
Traceback (most recent call last):
  File "runner/runner.py", line 350, in <module>
    sys.exit(main(sys.argv[1:]))
  File "runner/runner.py", line 345, in main
    return run(args)
  File "runner/runner.py", line 271, in run
    fortio.run(conn=conn, qps=qps, duration=args.duration, size=args.size)
  File "runner/runner.py", line 175, in run
    duration=40)
  File "runner/runner.py", line 203, in perf
    kubecp(mesh, PERFSH, pod + ":" + perfpath)
  File "runner/runner.py", line 229, in kubecp
    return run_command_sync(cmd)
  File "runner/runner.py", line 38, in run_command_sync
    op = subprocess.check_output(command, shell=True)
  File "/usr/local/Cellar/python/3.7.4/Frameworks/Python.framework/Versions/3.7/lib/python3.7/subprocess.py", line 395, in check_output
    **kwargs).stdout
  File "/usr/local/Cellar/python/3.7.4/Frameworks/Python.framework/Versions/3.7/lib/python3.7/subprocess.py", line 487, in run
    output=stdout, stderr=stderr)
subprocess.CalledProcessError: Command 'kubectl --namespace {namespace} cp {from_file} {to_file} -c istio-proxy' returned non-zero exit status 1.
(runner) bash-3.2$ Defaulting container name to captured.
Use 'kubectl describe pod/fortioclient-588f7fb74d-r6rqj -n twopods' to see all of the containers in this pod.
error: input/output error
```