### PR TITLE
API version cleanup

### DIFF
--- a/perf/benchmark/templates/fortio.yaml
+++ b/perf/benchmark/templates/fortio.yaml
@@ -64,7 +64,7 @@ spec:
   mode: 'ON'
 ---
 {{- end }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
@@ -84,8 +84,8 @@ spec:
         traffic.sidecar.istio.io/includeOutboundIPRanges: {{ $.Values.includeOutboundIPRanges }}
         {{- end }}
         sidecar.istio.io/inject: "{{ $.V.inject }}"
-        linkerd.io/inject: "{{ $.Values.injectL }}"
-{{- if eq $.Values.injectL "enabled" }}
+        linkerd.io/inject: "{{ $.V.injectL }}"
+{{- if eq $.V.injectL "enabled" }}
         config.linkerd.io/skip-outbound-ports: "8077" 
         config.linkerd.io/skip-inbound-ports: "8077"          
 {{- end }}
@@ -227,10 +227,7 @@ spec:
       mode: SIMPLE
       privateKey: /etc/istio/ingressgateway-certs/tls.key
       serverCertificate: /etc/istio/ingressgateway-certs/tls.crt
-
 ---
-
-
 {{- if $.Values.cert }}
 apiVersion: certmanager.k8s.io/v1alpha1
 kind: Certificate

--- a/perf/istio-install/base/templates/als.yaml
+++ b/perf/istio-install/base/templates/als.yaml
@@ -1,5 +1,5 @@
 {{- if $.Values.als.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:


### PR DESCRIPTION
This PR updates the API version of some helm templates to use the stable `apps/v1`