### PR TITLE
Add securityyContext to template and cleanup unused variable

### DIFF
--- a/perf/benchmark/templates/fortio.yaml
+++ b/perf/benchmark/templates/fortio.yaml
@@ -115,6 +115,8 @@ spec:
         emptyDir: {}
       containers:
       - name: captured
+        securityContext:
+          runAsUser: 1
         volumeMounts:
         - name: shared-data
           mountPath: /var/lib/fortio
@@ -133,14 +135,18 @@ spec:
 {{ toYaml $.Values.appresources | indent 10 }}
 {{- end }}
       - name: shell
+        securityContext:
+          runAsUser: 1
         volumeMounts:
         - name: shared-data
           mountPath: /var/lib/fortio
-        image: tutum/curl:trusty
+        image: {{ $.Values.curlImage }}
         args:
         - /bin/sleep
         - infinity
       - name: uncaptured
+        securityContext:
+          runAsUser: 1
         image: {{ $.Values.fortioImage }}
         args:
 {{- if eq $.name "fortioclient" }}

--- a/perf/benchmark/values.yaml
+++ b/perf/benchmark/values.yaml
@@ -11,8 +11,7 @@ appresources1:
     memory: "1000m"
 
 fortioImage: fortio/fortio:latest_release
-# access log service
-alsImage: gcr.io/mixologist-142215/als:v001
+curlImage: tutum/curl:trusty
 domain: local
 gateway: fortio-gateway
 rbac:


### PR DESCRIPTION
This PR add a `securityContext` to the benchmark charts (this allows users to use the charts also in restricted clusters with PSP enabled). Also this PR removes an unused variable and moves the hardcoded `curl` image to a variable. 