### PR TITLE
Cleanup some pylint issues in benchmark Python code

### DIFF
--- a/perf/benchmark/README.md
+++ b/perf/benchmark/README.md
@@ -126,7 +126,7 @@ python runner/runner.py 16,64 1000,4000 180 --serversidecar --baseline
 - 12 tests total, each for **180** seconds, with all combinations of:
 - **16** and **64** connections
 - **1000** and **4000** QPS
-- `both`,  `serversidecar`, and `baseline` proxy modes
+- `both`, `serversidecar`, and `baseline` proxy modes
 
 ### Example 3
 

--- a/perf/benchmark/runner/fortio.py
+++ b/perf/benchmark/runner/fortio.py
@@ -197,7 +197,7 @@ def syncFortio(url, table, selector=None, promUrl="", csv=None):
                            METRICS_SUMMARY_DURATION)
             p = prom.Prom(promUrl, duration, start=prom_start)
             prom_metrics = p.fetch_cpu_and_mem()
-            if len(prom_metrics) == 0:
+            if prom_metrics:
                 print("... Not found")
                 continue
             else:
@@ -225,7 +225,6 @@ def syncFortio(url, table, selector=None, promUrl="", csv=None):
 def write_csv(keys, data):
     fd, datafile = tempfile.mkstemp(suffix=".csv")
     out = os.fdopen(fd, "wt")
-    cnt = 0
     lst = keys.split(',')
     out.write(keys + "\n")
 

--- a/perf/benchmark/runner/fortio.py
+++ b/perf/benchmark/runner/fortio.py
@@ -197,7 +197,7 @@ def syncFortio(url, table, selector=None, promUrl="", csv=None):
                            METRICS_SUMMARY_DURATION)
             p = prom.Prom(promUrl, duration, start=prom_start)
             prom_metrics = p.fetch_cpu_and_mem()
-            if prom_metrics:
+            if not prom_metrics:
                 print("... Not found")
                 continue
             else:

--- a/perf/benchmark/runner/graph.py
+++ b/perf/benchmark/runner/graph.py
@@ -12,19 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import sys
 import argparse
 import itertools  # for cycling through colors
 import pandas as pd
-import numpy as np
 from bokeh.plotting import figure, output_file, show
-from bokeh.io import output_notebook
-from bokeh.models import ColumnDataSource, HoverTool
-from bokeh.models.tools import CustomJSHover
 from bokeh.palettes import Dark2_5 as palette
-from bokeh.models import Legend
-
 
 # generate_chart displays numthreads vs. metric, writes to interactive HTML
 def generate_chart(mesh, csv, x_label, y_label_short):

--- a/perf/benchmark/runner/graph.py
+++ b/perf/benchmark/runner/graph.py
@@ -12,18 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from bokeh.plotting import figure, output_file, show
-import pandas as pd
 import os
+import sys
+import argparse
+import itertools  # for cycling through colors
+import pandas as pd
 import numpy as np
+from bokeh.plotting import figure, output_file, show
 from bokeh.io import output_notebook
 from bokeh.models import ColumnDataSource, HoverTool
 from bokeh.models.tools import CustomJSHover
 from bokeh.palettes import Dark2_5 as palette
-import itertools  # for cycling through colors
 from bokeh.models import Legend
-import sys
-import argparse
 
 
 # generate_chart displays numthreads vs. metric, writes to interactive HTML
@@ -108,7 +108,7 @@ def get_series(df, x_label, metric):
     # included, don't attempt to plot it)
     useries = {}
     for k, v in series.items():
-        if len(v) > 0:
+        if v:
             useries[k] = v
     y = useries
 
@@ -130,7 +130,7 @@ def build_chart(title, x_label, x_series, y_label, y_label_short, y_series):
     # generate y-axis label with units
     print(y_label)
     if y_label.startswith('p'):
-        y_axis_label = metric = " latency, milliseconds"
+        y_axis_label = " latency, milliseconds"
     else:
         if y_label.startswith('mem'):
             y_axis_label = "max memory usage, server proxy (MB)"
@@ -196,5 +196,4 @@ def getParser():
 
 
 if __name__ == "__main__":
-    import sys
     sys.exit(main(sys.argv[1:]))

--- a/perf/benchmark/runner/graph.py
+++ b/perf/benchmark/runner/graph.py
@@ -19,6 +19,7 @@ import pandas as pd
 from bokeh.plotting import figure, output_file, show
 from bokeh.palettes import Dark2_5 as palette
 
+
 # generate_chart displays numthreads vs. metric, writes to interactive HTML
 def generate_chart(mesh, csv, x_label, y_label_short):
     print(

--- a/perf/benchmark/runner/prom.py
+++ b/perf/benchmark/runner/prom.py
@@ -15,18 +15,14 @@
 from __future__ import print_function
 import datetime
 import calendar
-import requests
 import collections
 import os
 import json
 import argparse
 import logging
-try:
-    # Python 3
-    import http.client as http_client
-except ImportError:
-    # Python 2
-    import httplib as http_client
+import http.client as http_client
+import requests
+
 
 if os.environ.get("DEBUG", "0") != "0":
     http_client.HTTPConnection.debuglevel = 1
@@ -37,7 +33,7 @@ if os.environ.get("DEBUG", "0") != "0":
     req_log.propagate = True
 
 
-class Prom(object):
+class Prom():
     # url: base url for prometheus
     #
 
@@ -123,7 +119,7 @@ class Prom(object):
             str(
                 self.nseconds) +
             's]))')
-        if len(data["data"]["result"]) > 0:
+        if data["data"]["result"]:
             return data["data"]["result"][0]["values"]
         return []
 
@@ -132,15 +128,15 @@ class Prom(object):
         data_404 = self.fetch_num_requests_by_response_code(404)
         data_503 = self.fetch_num_requests_by_response_code(503)
         data_504 = self.fetch_num_requests_by_response_code(504)
-        if len(data_404) > 0:
+        if data_404:
             res["istio_requests_total_404"] = data_404[-1][1]
         else:
             res["istio_requests_total_404"] = "0"
-        if len(data_503) > 0:
+        if data_503:
             res["istio_requests_total_503"] = data_503[-1][1]
         else:
             res["istio_requests_total_503"] = "0"
-        if len(data_504) > 0:
+        if data_504:
             res["istio_requests_total_504"] = data_504[-1][1]
         else:
             res["istio_requests_total_504"] = "0"
@@ -149,7 +145,7 @@ class Prom(object):
     def fetch_mixer_rules_count_by_metric_name(self, metric_name):
         data = self.fetch_by_query(
             'scalar(topk(1, max(' + metric_name + ') by (configID)))')
-        if len(data["data"]["result"]) > 0:
+        if data["data"]["result"]:
             return data["data"]["result"][0]["values"]
         return []
 
@@ -170,31 +166,31 @@ class Prom(object):
         attribute_count = self.fetch_mixer_rules_count_by_metric_name(
             "mixer_config_attribute_count")
 
-        if len(config_count) > 0:
+        if config_count:
             res["mixer_config_rule_config_count"] = config_count[-1][1]
         else:
             res["mixer_config_rule_config_count"] = "0"
-        if len(config_error_count) > 0:
+        if config_error_count:
             res["mixer_config_rule_config_error_count"] = config_error_count[-1][1]
         else:
             res["mixer_config_rule_config_error_count"] = "0"
-        if len(config_match_error_count) > 0:
+        if config_match_error_count:
             res["mixer_config_rule_config_match_error_count"] = config_match_error_count[-1][1]
         else:
             res["mixer_config_rule_config_match_error_count"] = "0"
-        if len(unsatisfied_action_handler_count) > 0:
+        if unsatisfied_action_handler_count:
             res["mixer_config_unsatisfied_action_handler_count"] = unsatisfied_action_handler_count[-1][1]
         else:
             res["mixer_config_unsatisfied_action_handler_count"] = "0"
-        if len(instance_count) > 0:
+        if instance_count:
             res["mixer_config_instance_config_count"] = instance_count[-1][1]
         else:
             res["mixer_config_instance_config_count"] = "0"
-        if len(handler_count) > 0:
+        if handler_count:
             res["mixer_config_handler_config_count"] = handler_count[-1][1]
         else:
             res["mixer_config_handler_config_count"] = "0"
-        if len(attribute_count) > 0:
+        if attribute_count:
             res["mixer_config_attribute_count"] = attribute_count[-1][1]
         else:
             res["mixer_config_attribute_count"] = "0"
@@ -208,12 +204,12 @@ class Prom(object):
 
         data = self.fetch_by_query(query)
         res = {}
-        if len(data["data"]["result"]) > 0:
+        if data["data"]["result"]:
             if groupby is not None:
                 for i in range(len(data["data"]["result"])):
                     key = data["data"]["result"][i]["metric"][groupby]
                     values = data["data"]["result"][i]["values"]
-                    if len(values) > 0:
+                    if values:
                         res[metric + "_" + key] = values[-1][1]
                     else:
                         res[metric + "_" + key] = "0"
@@ -231,11 +227,11 @@ class Prom(object):
 
         data = self.fetch_by_query(query)
         res = {}
-        if len(data["data"]["result"]) > 0:
+        if data["data"]["result"]:
             for i in range(len(data["data"]["result"])):
                 key = data["data"]["result"][i]["metric"][groupby]
                 values = data["data"]["result"][i]["values"]
-                if len(values) > 0:
+                if values:
                     res[metric + "_" + percent + "_" +
                         key] = values[-1][1]
                 else:
@@ -247,11 +243,11 @@ class Prom(object):
             self.nseconds) + 's])) by (grpc_method)'
         data = self.fetch_by_query(query)
         res = {}
-        if len(data["data"]["result"]) > 0:
+        if data["data"]["result"]:
             for i in range(len(data["data"]["result"])):
                 key = data["data"]["result"][i]["metric"]["grpc_method"]
                 values = data["data"]["result"][i]["values"]
-                if len(values) > 0:
+                if values:
                     res["grpc_server_handled_total_5xx_" +
                         key] = values[-1][1]
                 else:
@@ -265,11 +261,11 @@ class Prom(object):
             self.nseconds) + 's])) by (grpc_method)'
         data = self.fetch_by_query(query)
         res = {}
-        if len(data["data"]["result"]) > 0:
+        if data["data"]["result"]:
             for i in range(len(data["data"]["result"])):
                 key = data["data"]["result"][i]["metric"]["groupby"]
                 values = data["data"]["result"][i]["values"]
-                if len(values) > 0:
+                if values:
                     res["grpc_server_handled_total_4xx_" +
                         key] = values[-1][1]
                 else:
@@ -408,7 +404,7 @@ def computeMinMaxAvg(d, groupby=None, xform=None, aggregate=True):
             for idx in range(len(values)):
                 try:
                     values[idx] += float(v[idx][1])
-                except IndexError as err:
+                except IndexError:
                     # Data about that time is not yet populated.
                     break
         if aggregate:

--- a/perf/benchmark/runner/runner.py
+++ b/perf/benchmark/runner/runner.py
@@ -35,7 +35,7 @@ def pod_info(filterstr="", namespace="twopods", multi_ok=True):
     if not multi_ok and len(items) > 1:
         raise Exception("more than one found " + op)
 
-    if len(items) < 1:
+    if not items:
         raise Exception("no pods found with command [" + cmd + "]")
 
     i = items[0]
@@ -53,7 +53,7 @@ def run_command_sync(command):
     return op.strip()
 
 
-class Fortio(object):
+class Fortio():
     ports = {
         "http": {"direct_port": 8077, "port": 8080, "ingress": 80},
         "grpc": {"direct_port": 8076, "port": 8079, "ingress": 80},
@@ -163,12 +163,12 @@ class Fortio(object):
         fortio_cmd = (
             "fortio load -c {conn} -qps {qps} -t {duration}s -a -r {r} {grpc} -httpbufferkb=128 " +
             "-labels {labels}").format(
-            conn=conn,
-            qps=qps,
-            duration=duration,
-            r=self.r,
-            grpc=grpc,
-            labels=labels)
+                conn=conn,
+                qps=qps,
+                duration=duration,
+                r=self.r,
+                grpc=grpc,
+                labels=labels)
 
         if self.run_ingress:
             p = kubectl(self.client.name, self.ingress(fortio_cmd))


### PR DESCRIPTION
This PR cleans up the benchmark Python code (I just used ` pylint  --disable=R,C *.py`). There are still a lot of comments from pylint e.g. most of the variables are in camel case and not snake case (which is the Python standard).