### PR TITLE
Update perf benchmark docs with clearer examples

### DIFF
--- a/perf/benchmark/README.md
+++ b/perf/benchmark/README.md
@@ -127,6 +127,12 @@ python runner/runner.py 16,64 1000,4000 180 --serversidecar --baseline
 - **1000** and **4000** QPS
 - `both`,  `serversidecar`, and `baseline` proxy modes
 
+### Example 3
+Example 1 and 2 is to gather the latency results by increasing the number of connections. If you want to gather CPU and memory related
+results, you should increasing the number of QPS, like:
+```bash
+python runner/runner.py 10 100,500,1000,2000,4000 240  --serversidecar --baseline 
+```
 
 ## [Optional] Disable Mixer
 
@@ -140,8 +146,11 @@ kubectl -n istio-system get cm istio -o yaml > /tmp/meshconfig.yaml
 python ../../bin/update_mesh_config.py disable_mixer /tmp/meshconfig.yaml | kubectl -n istio-system apply -f /tmp/meshconfig.yaml
 ```
 
-2. Run `runner.py`, in any sidecar mode, with the `--labels=nomixer` flag.
-
+2. Run `runner.py`, in any sidecar mode, with the `--labels=nomixer` flag. If you run this command:
+```bash
+python runner/runner.py 1,2,4,8,16,32,64 1000 240 --serversidecar --baseline --labels=nomixer
+```
+it will generate the output showing in the `Example Output` section. Which includes both with Mixer and without Mixer test results.
 3. Re-enable Mixer:
 
 ```bash


### PR DESCRIPTION
This PR:
1. Add the command about how to gather CPU and memory related results
2. Add an example command of using --label=nomixer mode