### PR TITLE
Set environment variable for GKE_VERION

### DIFF
--- a/perf/benchmark/README.md
+++ b/perf/benchmark/README.md
@@ -21,6 +21,7 @@ cd perf/istio-install/
 export PROJECT_ID=<your-gcp-project>
 export ISTIO_VERSION=<version>
 export ZONE=<a-gcp-zone>
+export GKE_VERSION=1.13.7-gke.xx
 export CLUSTER_NAME=<any-name>
 ./create_cluster.sh $CLUSTER_NAME
 ```


### PR DESCRIPTION
This PR resolves: https://github.com/istio/istio/issues/16739

@mandarjog By examine the nodeagent log, I found that this failure is due to authentication failure.
```
2019-09-05T22:18:08.816815Z	error	sdsServiceLog	CONNECTION ID: router~10.32.3.7~istio-ingressgateway-786d8c847d-fzgqr.istio-system~istio-system.svc.cluster.local-29220, RESOURCE NAME: default, EVENT: Close connection. Failed to get secret for proxy "router~10.32.3.7~istio-ingressgateway-786d8c847d-fzgqr.istio-system~istio-system.svc.cluster.local" from secret cache: rpc error: code = Unauthenticated desc = request authenticate failure
```
According to here https://github.com/istio/istio.io/pull/4701, Istio 1.3 only supports trustworthy JWT, and trustworthy JWT is only available on Kubernetes 1.3+. 

However, the defaultClusterVersion is 1.12.8, which blocks both modes.
```
$ gcloud container get-server-config --zone us-central1-a
Fetching server config for us-central1-a
defaultClusterVersion: 1.12.8-gke.10
```
Therefore, we should ask user to set GKE_VERSION environment variable at least 1.13+