### PR TITLE
Fix most helm linting errors.

### DIFF
--- a/examples/luacheck/Chart.yaml
+++ b/examples/luacheck/Chart.yaml
@@ -1,6 +1,7 @@
 apiVersion: v1
 description: A Helm chart for installing lua filter
-name: luajwt
+name: luacheck
 version: 1.1.0
 appVersion: 1.1.0
 tillerVersion: ">=2.7.2"
+icon: https://istio.io/favicons/android-192x192.png

--- a/perf/benchmark/Chart.yaml
+++ b/perf/benchmark/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-name: twoPodTest
+name: benchmark
 version: 1.0
 description: Helm chart for istio twoPodTest
 keywords:
@@ -8,3 +8,4 @@ keywords:
 sources:
   - http://github.com/istio/istio
 engine: gotpl
+icon: https://istio.io/favicons/android-192x192.png

--- a/perf/istio-install/base/Chart.yaml
+++ b/perf/istio-install/base/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-name: istio
+name: base
 version: 0.5.0
 description: Helm chart for istio integration test
 keywords:

--- a/perf/load/Chart.yaml
+++ b/perf/load/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-name: servicegraph
+name: load
 version: 1.0
 description: Helm chart for servicegraph test
 keywords:
@@ -9,3 +9,4 @@ keywords:
 sources:
   - http://github.com/istio/istio
 engine: gotpl
+icon: https://istio.io/favicons/android-192x192.png

--- a/perf/load/loadclient/Chart.yaml
+++ b/perf/load/loadclient/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-name: load client
+name: loadclient
 version: 1.0
 description: Helm chart for loading thru ingress
 keywords:
@@ -9,3 +9,4 @@ keywords:
 sources:
   - http://github.com/istio/istio
 engine: gotpl
+icon: https://istio.io/favicons/android-192x192.png

--- a/perf/load/pilot/Chart.yaml
+++ b/perf/load/pilot/Chart.yaml
@@ -9,3 +9,4 @@ keywords:
 sources:
   - http://github.com/istio/istio
 engine: gotpl
+icon: https://istio.io/favicons/android-192x192.png

--- a/perf/load/values.yaml
+++ b/perf/load/values.yaml
@@ -28,3 +28,5 @@ replicasSleep: 10
 # ingress should be set correctly
 ingress: 127.0.0.1
 https: false
+
+Namespace: test

--- a/perf/security/file-mount-tests/non-sds-2/Chart.yaml
+++ b/perf/security/file-mount-tests/non-sds-2/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-name: workload rotation
+name: non-sds-2
 version: 1.0
 description: Helm chart for sds citadel tests
 keywords:
@@ -11,3 +11,4 @@ keywords:
 sources:
   - http://github.com/istio/istio
 engine: gotpl
+icon: https://istio.io/favicons/android-192x192.png

--- a/perf/security/sds-tests/citadel-2/Chart.yaml
+++ b/perf/security/sds-tests/citadel-2/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-name: workload rotation
+name: citadel-2
 version: 1.0
 description: Helm chart for sds citadel tests
 keywords:
@@ -11,3 +11,4 @@ keywords:
 sources:
   - http://github.com/istio/istio
 engine: gotpl
+icon: https://istio.io/favicons/android-192x192.png

--- a/perf/security/workload-deployments/Chart.yaml
+++ b/perf/security/workload-deployments/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-name: security tests
+name: workload-deployments
 version: 1.0
 description: Helm chart for sds citadel tests
 keywords:
@@ -11,3 +11,4 @@ keywords:
 sources:
   - http://github.com/istio/istio
 engine: gotpl
+icon: https://istio.io/favicons/android-192x192.png

--- a/perf/stability/allconfig/Chart.yaml
+++ b/perf/stability/allconfig/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-name: istio
+name: allconfig
 version: 0.5.0
 description: Helm chart for istio integration test
 keywords:

--- a/perf/stability/gateway-bouncer/Chart.yaml
+++ b/perf/stability/gateway-bouncer/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-name: istio
+name: gateway-bouncer
 version: 1.1.0
 description: Helm chart of the 'Gateway Bouncer' scenario.
 keywords:

--- a/perf/stability/gateway-bouncer/values.yaml
+++ b/perf/stability/gateway-bouncer/values.yaml
@@ -8,3 +8,5 @@ pilotDowntimeDurationSec: 60s
 numOfClientConns: 10
 numOfClientQps: 100
 clientConnTimeoutDuration: 15s
+
+namespace: test

--- a/perf/stability/graceful-shutdown/Chart.yaml
+++ b/perf/stability/graceful-shutdown/Chart.yaml
@@ -8,3 +8,4 @@ keywords:
 sources:
   - http://github.com/istio/istio
 engine: gotpl
+icon: https://istio.io/favicons/android-192x192.png

--- a/perf/stability/http10/Chart.yaml
+++ b/perf/stability/http10/Chart.yaml
@@ -8,3 +8,4 @@ keywords:
 sources:
   - http://github.com/istio/istio
 engine: gotpl
+icon: https://istio.io/favicons/android-192x192.png

--- a/perf/stability/istio-chaos-partial/Chart.yaml
+++ b/perf/stability/istio-chaos-partial/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-name: istioChaosPartial
+name: istio-chaos-partial
 version: 1.0
 description: Helm chart for istio chaos test
 keywords:
@@ -8,3 +8,4 @@ keywords:
 sources:
   - http://github.com/istio/istio
 engine: gotpl
+icon: https://istio.io/favicons/android-192x192.png

--- a/perf/stability/istio-chaos-total/Chart.yaml
+++ b/perf/stability/istio-chaos-total/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-name: istioChaosTotal
+name: istio-chaos-total
 version: 1.0
 description: Helm chart for istio chaos test
 keywords:
@@ -8,3 +8,4 @@ keywords:
 sources:
   - http://github.com/istio/istio
 engine: gotpl
+icon: https://istio.io/favicons/android-192x192.png

--- a/perf/stability/istio-upgrader/Chart.yaml
+++ b/perf/stability/istio-upgrader/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-name: gracefulShutdown
+name: istio-upgrader
 version: 1.0
 description: Helm chart for istio upgrader test
 keywords:
@@ -8,3 +8,4 @@ keywords:
 sources:
   - http://github.com/istio/istio
 engine: gotpl
+icon: https://istio.io/favicons/android-192x192.png

--- a/perf/stability/looper/Chart.yaml
+++ b/perf/stability/looper/Chart.yaml
@@ -8,3 +8,4 @@ keywords:
 sources:
   - http://github.com/istio/istio
 engine: gotpl
+icon: https://istio.io/favicons/android-192x192.png

--- a/perf/stability/multicluster-vpn/Chart.yaml
+++ b/perf/stability/multicluster-vpn/Chart.yaml
@@ -9,3 +9,4 @@ keywords:
 sources:
   - http://github.com/istio/istio
 engine: gotpl
+icon: https://istio.io/favicons/android-192x192.png

--- a/perf/stability/mysql/Chart.yaml
+++ b/perf/stability/mysql/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-name: mysql-istio-testing
+name: mysql
 version: 1.0
 description: Helm chart for testing MySQL with Istio.
 keywords:
@@ -8,3 +8,4 @@ keywords:
 sources:
   - http://github.com/istio/istio
 engine: gotpl
+icon: https://istio.io/favicons/android-192x192.png

--- a/perf/stability/rabbitmq/Chart.yaml
+++ b/perf/stability/rabbitmq/Chart.yaml
@@ -8,3 +8,4 @@ keywords:
 sources:
   - http://github.com/istio/istio
 engine: gotpl
+icon: https://istio.io/favicons/android-192x192.png

--- a/perf/stability/redis/Chart.yaml
+++ b/perf/stability/redis/Chart.yaml
@@ -8,3 +8,4 @@ keywords:
 sources:
   - http://github.com/istio/istio
 engine: gotpl
+icon: https://istio.io/favicons/android-192x192.png

--- a/perf/stability/sds-certmanager/Chart.yaml
+++ b/perf/stability/sds-certmanager/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-name: istio
+name: sds-certmanager
 version: 1.1.0
 description: Helm chart of the 'K8S Ingress + SDS + CertManager' scenario.
 keywords:

--- a/perf/stability/sds-certmanager/values.yaml
+++ b/perf/stability/sds-certmanager/values.yaml
@@ -8,3 +8,5 @@ certManagerImage: quay.io/jetstack/cert-manager-controller:v0.6.2
 numOfClientConns: 10
 numOfClientQps: 100
 clientConnTimeoutDuration: 15s
+
+namespace: test


### PR DESCRIPTION
- There are still four errors left, which I wasn't able to fix, so
the helm linter is still turned off for now.

These changes are mostly about adding icon entries to charts, ensuring the chart's name and directory name match, and adding a few missing keys in values.yaml.