### PR TITLE
Validate duration for benchmark

### DIFF
--- a/perf/benchmark/runner/runner.py
+++ b/perf/benchmark/runner/runner.py
@@ -21,6 +21,7 @@ import argparse
 import subprocess
 import shlex
 import uuid
+from fortio import METRICS_START_SKIP_DURATION, METRICS_END_SKIP_DURATION
 
 POD = collections.namedtuple('Pod', ['name', 'namespace', 'ip', 'labels'])
 
@@ -268,6 +269,11 @@ def rc(command):
 
 
 def run(args):
+    min_duration = METRICS_START_SKIP_DURATION + METRICS_END_SKIP_DURATION
+    if args.duration <= min_duration:
+        print(f"Duration must be greater than {min_duration}")
+        exit(1)
+
     fortio = Fortio(
         conn=args.conn,
         qps=args.qps,


### PR DESCRIPTION
I tried to run the benchmark test for a pretty short duration (60 seconds) with: `python runner/runner.py 1,1000 1000 60` everything worked fine until I wanted to fetch the results:

```bash
python ./runner/fortio.py $FORTIO_CLIENT_URL --prometheus=$PROMETHEUS_URL --csv StartTime,ActualDuration,Labels,NumThreads,ActualQPS,p50,p90,p99,cpu_mili_avg_telemetry_mixer,cpu_mili_max_telemetry_mixer,mem_MB_max_telemetry_mixer,cpu_mili_avg_fortioserver_deployment_proxy,cpu_mili_max_fortioserver_deployment_proxy,mem_MB_max_fortioserver_deployment_proxy,cpu_mili_avg_ingressgateway_proxy,cpu_mili_max_ingressgateway_proxy,mem_MB_max_ingressgateway_proxy
Handling connection for 8080
Handling connection for 8080
Fetching prometheus metrics for 2019-09-11 13:37:28 279b364c_qps_1000_c_1000_1024_both
... 279b364c_qps_1000_c_1000_1024_both duration=60s is less than minimum 92s
Handling connection for 8080
Fetching prometheus metrics for 2019-09-11 13:36:24 279b364c_qps_1000_c_1_1024_both
... 279b364c_qps_1000_c_1_1024_both duration=60s is less than minimum 92s
Handling connection for 8080
Fetching prometheus metrics for 2019-09-11 13:36:17 339a9349_qps_1000_c_1_1024_both
... 339a9349_qps_1000_c_1_1024_both duration=1s is less than minimum 92s
Handling connection for 8080
Fetching prometheus metrics for 2019-09-11 13:31:48 0afe0f34_qps_1000_c_64_1024_both
... 0afe0f34_qps_1000_c_64_1024_both duration=60s is less than minimum 92s
Handling connection for 8080
Fetching prometheus metrics for 2019-09-11 13:30:47 0afe0f34_qps_1000_c_64_1024_serveronly
... 0afe0f34_qps_1000_c_64_1024_serveronly duration=59s is less than minimum 92s
Handling connection for 8080
Fetching prometheus metrics for 2019-09-11 13:29:47 0afe0f34_qps_1000_c_32_1024_both
... 0afe0f34_qps_1000_c_32_1024_both duration=60s is less than minimum 92s
Handling connection for 8080
Fetching prometheus metrics for 2019-09-11 13:28:45 0afe0f34_qps_1000_c_32_1024_serveronly
... 0afe0f34_qps_1000_c_32_1024_serveronly duration=60s is less than minimum 92s
Handling connection for 8080
Fetching prometheus metrics for 2019-09-11 13:27:45 0afe0f34_qps_1000_c_16_1024_both
... 0afe0f34_qps_1000_c_16_1024_both duration=60s is less than minimum 92s
Handling connection for 8080
Fetching prometheus metrics for 2019-09-11 13:26:43 0afe0f34_qps_1000_c_16_1024_serveronly
... 0afe0f34_qps_1000_c_16_1024_serveronly duration=60s is less than minimum 92s
Handling connection for 8080
Fetching prometheus metrics for 2019-09-11 13:25:43 0afe0f34_qps_1000_c_8_1024_both
... 0afe0f34_qps_1000_c_8_1024_both duration=60s is less than minimum 92s
Handling connection for 8080
Fetching prometheus metrics for 2019-09-11 13:24:42 0afe0f34_qps_1000_c_8_1024_serveronly
... 0afe0f34_qps_1000_c_8_1024_serveronly duration=60s is less than minimum 92s
Handling connection for 8080
Fetching prometheus metrics for 2019-09-11 13:23:41 0afe0f34_qps_1000_c_4_1024_both
... 0afe0f34_qps_1000_c_4_1024_both duration=60s is less than minimum 92s
Handling connection for 8080
Fetching prometheus metrics for 2019-09-11 13:22:41 0afe0f34_qps_1000_c_4_1024_serveronly
... 0afe0f34_qps_1000_c_4_1024_serveronly duration=60s is less than minimum 92s
Handling connection for 8080
Fetching prometheus metrics for 2019-09-11 13:21:40 0afe0f34_qps_1000_c_2_1024_both
... 0afe0f34_qps_1000_c_2_1024_both duration=60s is less than minimum 92s
Handling connection for 8080
Fetching prometheus metrics for 2019-09-11 13:20:40 0afe0f34_qps_1000_c_2_1024_serveronly
... 0afe0f34_qps_1000_c_2_1024_serveronly duration=60s is less than minimum 92s
Handling connection for 8080
Fetching prometheus metrics for 2019-09-11 13:19:39 0afe0f34_qps_1000_c_1_1024_both
... 0afe0f34_qps_1000_c_1_1024_both duration=60s is less than minimum 92s
Handling connection for 8080
Fetching prometheus metrics for 2019-09-11 13:18:39 0afe0f34_qps_1000_c_1_1024_serveronly
... 0afe0f34_qps_1000_c_1_1024_serveronly duration=60s is less than minimum 92s
Wrote 0 records to /var/folders/sj/j7x18ftx7l331_lb3w0xj97h0000gn/T/tmp5nmj63e0.json
Wrote 0 records to /var/folders/sj/j7x18ftx7l331_lb3w0xj97h0000gn/T/tmpq8w2lhwv.csv
```

The important part here is `duration=60s is less than minimum 92s`. IMHO this should be checked before running the actual tests since 92s is a hard requirement: https://github.com/istio/tools/blob/master/perf/benchmark/runner/fortio.py#L189