### PR TITLE
Fix unsafe yaml loading and change default type for service-graph.yaml example

### DIFF
--- a/isotope/README.md
+++ b/isotope/README.md
@@ -16,7 +16,7 @@ various service graph topologies.
 
 ## Topology Converter
 
-The topology converter, located under the convert/ direcory, is a Go Utility for simulating real world microservice topologies in Kubernetes.  The converter accepts a yaml file which describes one or more microservices as a workflow graph (ie service A waits 100 ms, then calls services B and C in paralell, each of which return a 1MB payload, etc).  `converter kubernetes` processes a yaml file, producing kubernetes manifests, as described below.  `converter graphviz` produces a visualization of your microservice architecture specified in service-graph.yaml.
+The topology converter, located under the convert/ directory, is a Go Utility for simulating real world microservice topologies in Kubernetes.  The converter accepts a yaml file which describes one or more microservices as a workflow graph (ie service A waits 100 ms, then calls services B and C in paralell, each of which return a 1MB payload, etc).  `converter kubernetes` processes a yaml file, producing kubernetes manifests, as described below.  `converter graphviz` produces a visualization of your microservice architecture specified in service-graph.yaml.
 
 ### service-graph.yaml
 
@@ -148,7 +148,7 @@ script:
 apiVersion: v1alpha1
 kind: MockServiceGraph
 defaults:
-  type: grpc
+  type: http
   requestSize: 1 KB
   responseSize: 16 KB
 services:

--- a/isotope/runner/entrypoint.py
+++ b/isotope/runner/entrypoint.py
@@ -22,7 +22,7 @@ from . import consts
 def extract_name(topology_path: str) -> str:
     """Returns the name of the entrypoint service in the topology."""
     with open(topology_path, 'r') as f:
-        topology = yaml.load(f)
+        topology = yaml.load(f, Loader=yaml.FullLoader)
 
     services = topology['services']
     entrypoint_services = [svc for svc in services if svc.get('isEntrypoint')]


### PR DESCRIPTION
This PR fix two issues:
(1) When I run cd into `isotope` and run `./run_tests.py example-config.tom`.
I got the following warning:
```
$ ./run_tests.py example-config.toml
DEBUG	> ['gcloud', 'config', 'set', 'project', 'xxxxxxxxx']
DEBUG	> ['gcloud', 'container', 'clusters', 'list', '--zone', 'us-central1-a']
DEBUG	> isotope-cluster-2 already exists; bypassing creation
/Users/carolynprh/istio-all/tools/isotope/runner/entrypoint.py:25: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
  topology = yaml.load(f)
INFO	> generating Kubernetes manifests from example-topologies/canonical.yaml
```

We need to add loader type to avoid this.

(2) The default type of service graph yaml example in isotope README should be `http` not `grpc`?