### PR TITLE
Lower CPU requests for istio-proxy

### DIFF
--- a/perf/istio-install/values.yaml
+++ b/perf/istio-install/values.yaml
@@ -12,7 +12,7 @@ global:
     accessLogFile: ""
     resources:
       requests:
-        cpu: 500m
+        cpu: 250m
         memory: 256Mi
       limits:
         memory: 256Mi 


### PR DESCRIPTION
The proxy is only using 50-200m. Dropping the cpu requests means we can
run 2x as many service graphs on a cluster.