### PR TITLE
Push :latest tag for build tools

### DIFF
--- a/docker/build-tools/build-and-push.sh
+++ b/docker/build-tools/build-and-push.sh
@@ -19,5 +19,6 @@ CONTAINER_CLI=${CONTAINER_CLI:-docker}
 HUB=gcr.io/istio-testing
 VERSION=$(date +%Y-%m-%dT%H-%M-%S)
 
-${CONTAINER_CLI} build -t "${HUB}/build-tools:${VERSION}" .
+${CONTAINER_CLI} build -t "${HUB}/build-tools:${VERSION}" -t "${HUB}/build-tools:latest" .
 ${CONTAINER_CLI} push "${HUB}/build-tools:${VERSION}"
+${CONTAINER_CLI} push "${HUB}/build-tools:latest"


### PR DESCRIPTION
I think this could be a bit helpful if I just want to try something out local I can `docker run gcr.io/istio-testing/build-tools` instead of looking up the latest one somewhere. I do *not* think we should use :latest in any of the repos.