### PR TITLE
Fix GOSUMDB

### DIFF
--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -330,7 +330,7 @@ ENV LANG=C.UTF-8
 # Go support
 ENV GO111MODULE=on
 ENV GOPROXY=https://proxy.golang.org
-ENV GOSUMDB=https://sum.golang.org
+ENV GOSUMDB=sum.golang.org
 ENV GOROOT=/usr/local/go
 ENV GOPATH=/home/go
 ENV GOCACHE=/home/gocache


### PR DESCRIPTION
The current one is invalid. I don't know why.. but go docs suggest that we just use `sum.golang.org` (actually its the default), and the errors I see go away when I do so... see https://tip.golang.org/cmd/go/#hdr-Module_authentication_failures