### PR TITLE
Add an ENTRYPOINT to dockerd-entrypoint

### DIFF
--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -364,3 +364,4 @@ RUN chmod 777 /home/gocache && \
 VOLUME /var/lib/docker
 
 WORKDIR /
+ENTRYPOINT ["dockerd-entrypoint.sh"]


### PR DESCRIPTION
DIND includes a dockerd-entrypoint.sh script. Use that directly for
ENTRYPOINT.  Next iteration will include authentication when running
in Prow.