### PR TITLE
add a prow entrypoint script

### DIFF
--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -316,7 +316,7 @@ RUN rm -fr /usr/share/locale
 RUN rm -fr /usr/share/man
 RUN rm -fr /tmp/*
 
-ADD prow-entrypoint.sh /usr/local/bin/entrypoint
+COPY prow-entrypoint.sh /usr/local/bin/entrypoint
 RUN chmod +rx /usr/local/bin/entrypoint
 
 #############

--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -316,6 +316,9 @@ RUN rm -fr /usr/share/locale
 RUN rm -fr /usr/share/man
 RUN rm -fr /tmp/*
 
+ADD prow-entrypoint.sh /usr/local/bin/entrypoint
+RUN chmod +rx /usr/local/bin/entrypoint
+
 #############
 # Final image
 #############
@@ -364,4 +367,8 @@ RUN chmod 777 /home/gocache && \
 VOLUME /var/lib/docker
 
 WORKDIR /
-ENTRYPOINT ["dockerd-entrypoint.sh"]
+
+# TODO(sdake) Need a more intelligent entrypoint script here - which can
+# somehow detect if dockerd needs to be run in this container, or not.
+# Perhaps based upon an environment variable.
+#ENTRYPOINT ["dockerd-entrypoint.sh"]

--- a/docker/build-tools/prow-entrypoint.sh
+++ b/docker/build-tools/prow-entrypoint.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Copyright Istio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eux
+
+# Authenticate gcloud, allow failures
+if [[ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then
+  gcloud auth activate-service-account --key-file="${GOOGLE_APPLICATION_CREDENTIALS}" || true
+fi
+
+. docker-entrypoint.sh

--- a/docker/build-tools/prow-entrypoint.sh
+++ b/docker/build-tools/prow-entrypoint.sh
@@ -21,4 +21,5 @@ if [[ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then
   gcloud auth activate-service-account --key-file="${GOOGLE_APPLICATION_CREDENTIALS}" || true
 fi
 
+# shellcheck disable=SC1091
 . dockerd-entrypoint.sh

--- a/docker/build-tools/prow-entrypoint.sh
+++ b/docker/build-tools/prow-entrypoint.sh
@@ -22,4 +22,4 @@ if [[ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then
 fi
 
 # shellcheck disable=SC1091
-. dockerd-entrypoint.sh
+source dockerd-entrypoint.sh

--- a/docker/build-tools/prow-entrypoint.sh
+++ b/docker/build-tools/prow-entrypoint.sh
@@ -21,4 +21,4 @@ if [[ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then
   gcloud auth activate-service-account --key-file="${GOOGLE_APPLICATION_CREDENTIALS}" || true
 fi
 
-. docker-entrypoint.sh
+. dockerd-entrypoint.sh


### PR DESCRIPTION
Prow runs the script `entrypoint` using the shell with additional
commands passed in arguments. These arguments are the actual command
that prow expects to run. The `dockerd-entrypoint.sh` may be the wrong
script to be run here, or may not have the correct arguments in the
environment.

For the moment, turn off the ENTRYPOINT call added in this PR until
a suitabale solution can be found for running dockerd locally.