### PR TITLE
Fix import issue of http client

### DIFF
--- a/perf/benchmark/runner/prom.py
+++ b/perf/benchmark/runner/prom.py
@@ -15,14 +15,18 @@
 from __future__ import print_function
 import datetime
 import calendar
+import requests
 import collections
 import os
 import json
 import argparse
 import logging
-import http.client as http_client
-import requests
-
+try:
+    # Python 3
+    import http.client as http_client
+except ImportError:
+    # Python 2
+    import httplib as http_client
 
 if os.environ.get("DEBUG", "0") != "0":
     http_client.HTTPConnection.debuglevel = 1


### PR DESCRIPTION
In some test infra environment it is still running python2, add back the try import part for safe check