### PR TITLE
Add a prow entrypoint script

### DIFF
--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -310,6 +310,10 @@ RUN rm -fr /usr/share/locale
 RUN rm -fr /usr/share/man
 RUN rm -fr /tmp/*
 
+# Run dockerd in CI
+COPY prow-entrypoint.sh /usr/local/bin/entrypoint
+RUN chmod +x usr/local/bin/entrypoint
+
 #############
 # Final image
 #############

--- a/docker/build-tools/prow-entrypoint.sh
+++ b/docker/build-tools/prow-entrypoint.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# Copyright Istio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+dockerd &
+
+# Authenticate gcloud, allow failures
+if [[ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then
+  gcloud auth activate-service-account --key-file="${GOOGLE_APPLICATION_CREDENTIALS}" || true
+fi
+
+exec "$@"


### PR DESCRIPTION
This entrypoint script will be run when entrypoint is not
supressed. In the future, this should be consumed by myinit
or tini to clean up zombie processes.

This will trigger dockerd to run as a background process.
After dockerd is running, the remainder of the command line
is exec'ed.