### PR TITLE
Remove python version requirement from Pipfile

### DIFF
--- a/perf/benchmark/runner/Pipfile
+++ b/perf/benchmark/runner/Pipfile
@@ -12,5 +12,3 @@ bokeh = "*"
 pandas = "*"
 numpy = "*"
 
-[requires]
-python_version = ">=3.0.0"


### PR DESCRIPTION
We encountered new failures in the benchmark daily release build. 
```
+ cd /home/prow/go/src/istio.io/tools/perf/benchmark/runner
+ pipenv install
Traceback (most recent call last):
  File "/root/.local/bin/pipenv", line 10, in <module>
    sys.exit(cli())
  File "/root/.local/lib/python3.5/site-packages/pipenv/vendor/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/root/.local/lib/python3.5/site-packages/pipenv/vendor/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/root/.local/lib/python3.5/site-packages/pipenv/vendor/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/root/.local/lib/python3.5/site-packages/pipenv/vendor/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/root/.local/lib/python3.5/site-packages/pipenv/vendor/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/root/.local/lib/python3.5/site-packages/pipenv/vendor/click/decorators.py", line 64, in new_func
    return ctx.invoke(f, obj, *args, **kwargs)
  File "/root/.local/lib/python3.5/site-packages/pipenv/vendor/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/root/.local/lib/python3.5/site-packages/pipenv/vendor/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/root/.local/lib/python3.5/site-packages/pipenv/cli/command.py", line 254, in install
    editable_packages=state.installstate.editables,
  File "/root/.local/lib/python3.5/site-packages/pipenv/core.py", line 1741, in do_install
    pypi_mirror=pypi_mirror,
  File "/root/.local/lib/python3.5/site-packages/pipenv/core.py", line 574, in ensure_project
    pypi_mirror=pypi_mirror,
  File "/root/.local/lib/python3.5/site-packages/pipenv/core.py", line 494, in ensure_virtualenv
    python = ensure_python(three=three, python=python)
  File "/root/.local/lib/python3.5/site-packages/pipenv/core.py", line 397, in ensure_python
    path_to_python = find_a_system_python(python)
  File "/root/.local/lib/python3.5/site-packages/pipenv/core.py", line 360, in find_a_system_python
    python_entry = finder.find_python_version(line)
  File "/root/.local/lib/python3.5/site-packages/pipenv/vendor/pythonfinder/pythonfinder.py", line 95, in find_python_version
    version_dict = PythonVersion.parse(major)
  File "/root/.local/lib/python3.5/site-packages/pipenv/vendor/pythonfinder/models/python.py", line 359, in parse
    version_dict = parse_python_version(str(version))
  File "/root/.local/lib/python3.5/site-packages/pipenv/vendor/pythonfinder/utils.py", line 86, in parse_python_version
    raise InvalidPythonVersion("%s is not a python version" % version_str)
pipenv.vendor.pythonfinder.exceptions.InvalidPythonVersion: >=3.0.0 is not a python version
```
Here is a fix.