### PR TITLE
Fix a couple bugs in the reference doc extraction tool.

### DIFF
--- a/cmd/protoc-gen-docs/Makefile
+++ b/cmd/protoc-gen-docs/Makefile
@@ -7,11 +7,11 @@ build:
 run:
 	rm -fr fm page fragment pf sp
 	mkdir fm page fragment pf sp
-	protoc --plugin=./protoc-gen-docs --docs_out=warnings=false,emit_yaml=true,mode=html_page:page/. testdata/test1.proto testdata/test2.proto testdata/test3.proto
-	protoc --plugin=./protoc-gen-docs --docs_out=warnings=false,mode=html_fragment_with_front_matter:fm/. testdata/test1.proto testdata/test2.proto testdata/test3.proto
-	protoc --plugin=./protoc-gen-docs --docs_out=warnings=false,mode=html_fragment:fragment/. testdata/test1.proto testdata/test2.proto testdata/test3.proto
-	protoc --plugin=./protoc-gen-docs --docs_out=warnings=true,per_file=true,mode=html_fragment_with_front_matter:pf/. testdata/test1.proto
-	protoc --plugin=./protoc-gen-docs --docs_out=warnings=true,dictionary=dictionaries/en-US,custom_word_list=dictionaries/custom.txt,mode=html_fragment_with_front_matter:sp/. testdata/test6.proto
+	protoc -Iprotos -I. --plugin=./protoc-gen-docs --docs_out=warnings=false,emit_yaml=true,mode=html_page:page/. testdata/test1.proto testdata/test2.proto testdata/test3.proto
+	protoc -Iprotos -I. --plugin=./protoc-gen-docs --docs_out=warnings=false,mode=html_fragment_with_front_matter:fm/. testdata/test1.proto testdata/test2.proto testdata/test3.proto
+	protoc -Iprotos -I. --plugin=./protoc-gen-docs --docs_out=warnings=false,mode=html_fragment:fragment/. testdata/test1.proto testdata/test2.proto testdata/test3.proto
+	protoc -Iprotos -I. --plugin=./protoc-gen-docs --docs_out=warnings=true,per_file=true,mode=html_fragment_with_front_matter:pf/. testdata/test1.proto
+	protoc -Iprotos -I. --plugin=./protoc-gen-docs --docs_out=warnings=true,dictionary=dictionaries/en-US,custom_word_list=dictionaries/custom.txt,mode=html_fragment_with_front_matter:sp/. testdata/test6.proto
 
 clean:
-	@rm -fr fm page fragment pf sp protoc-gen-docs
+	@rm -fr fm page fragment pf sp sp2 protoc-gen-docs

--- a/cmd/protoc-gen-docs/main.go
+++ b/cmd/protoc-gen-docs/main.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 // TODO: Finish support for YAML output
-// TODO: consider using protoc-gen-validate frontMatter to improve doc generation
 
 package main
 


### PR DESCRIPTION
- Completely removing HTML comment lines was throwing off the line
number reported by the spell checker. We now just elide the blank parts,
leaving the lines intact.

- Remove a hack to convert < and > into HTML entities before passing through
the Blackfriday markdown processor. This is no longer needed and was breaking
automatic link discovery.

- Get the tests compiling again.

- Tickle the docker file so we get a fresh image built and published.