### PR TITLE
For f prefix formatting on older version

### DIFF
--- a/perf/benchmark/runner/runner.py
+++ b/perf/benchmark/runner/runner.py
@@ -271,7 +271,7 @@ def rc(command):
 def run(args):
     min_duration = METRICS_START_SKIP_DURATION + METRICS_END_SKIP_DURATION
     if args.duration <= min_duration:
-        print(f"Duration must be greater than {min_duration}")
+        print("Duration must be greater than {min_duration}".format(min_duration=min_duration))
         exit(1)
 
     fortio = Fortio(


### PR DESCRIPTION
The test docker image still use python3.5, which doesn't support f prefix formatting.