### PR TITLE
fix sanity check error for csv file in fortio.py

### DIFF
--- a/perf/benchmark/runner/fortio.py
+++ b/perf/benchmark/runner/fortio.py
@@ -161,7 +161,6 @@ def sync_fortio(url, table, selector=None, promUrl="", csv=None, csv_output=""):
     listurl = url + "/fortio/data/"
     listdata = requests.get(listurl)
     fd, datafile = tempfile.mkstemp(suffix=".json")
-
     out = os.fdopen(fd, "wt")
     stats = []
     cnt = 0
@@ -223,7 +222,7 @@ def sync_fortio(url, table, selector=None, promUrl="", csv=None, csv_output=""):
 
 
 def write_csv(keys, data, csv_output):
-    if csv_output == "":
+    if csv_output is None or csv_output == "":
         fd, csv_output = tempfile.mkstemp(suffix=".csv")
         out = os.fdopen(fd, "wt")
     else:


### PR DESCRIPTION
This PR is to fix the following error when generate csv file:
```
Traceback (most recent call last):
  File "./runner/fortio.py", line 298, in <module>
    sys.exit(main(sys.argv[1:]))
  File "./runner/fortio.py", line 264, in main
    args.csv_output)
  File "./runner/fortio.py", line 217, in sync_fortio
    write_csv(csv, data, csv_output)
  File "./runner/fortio.py", line 230, in write_csv
    out = open(csv_output, "w+")
```
