### PR TITLE
Avoid exit directly to make retry go through 60 times when sth fails

### DIFF
--- a/perf/istio-install/setup_prometheus.sh
+++ b/perf/istio-install/setup_prometheus.sh
@@ -19,6 +19,7 @@ set -x
 # shellcheck disable=SC2086
 WD=$(dirname $0)
 # shellcheck disable=SC2086
+# shellcheck disable=SC2164
 WD=$(cd $WD; pwd)
 # shellcheck disable=SC2086
 mkdir -p "${WD}/tmp"
@@ -26,6 +27,7 @@ mkdir -p "${WD}/tmp"
 function install_prometheus() {
   local DIRNAME="$1" # should be like tools/perf/istio-install/tmp
   # shellcheck disable=SC2086
+  # shellcheck disable=SC2164
   DIRNAME=$(cd $DIRNAME; pwd)
   INSTALLER_DIR="${DIRNAME}/installer"
   if [[ ! -e "$INSTALLER_DIR" ]]; then

--- a/perf/istio-install/setup_prometheus.sh
+++ b/perf/istio-install/setup_prometheus.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -ex
+set -x
 
 # shellcheck disable=SC2086
 WD=$(dirname $0)


### PR DESCRIPTION
This PR is to the latest benchmark postsubmit build failure:
```
+ for CMD in '"${CMDs_ARR[@]}"'
+ ATTEMPTS=0
+ kubectl get crds/prometheuses.monitoring.coreos.com
Error from server (NotFound): customresourcedefinitions.apiextensions.k8s.io "prometheuses.monitoring.coreos.com" not found
+ '[' 0 -eq 60 ']'
+ kubectl get crds/prometheuses.monitoring.coreos.com
Error from server (NotFound): customresourcedefinitions.apiextensions.k8s.io "prometheuses.monitoring.coreos.com" not found
+ cleanup
```
The tracking issue: https://github.com/istio/istio/issues/17565
This PR is a follow up fix for this: https://github.com/istio/tools/pull/396