### PR TITLE
Expose an extra port in k8s services/deployments

### DIFF
--- a/isotope/convert/pkg/consts/consts.go
+++ b/isotope/convert/pkg/consts/consts.go
@@ -23,6 +23,11 @@ const (
 	// ServicePortName is the name of the service port.
 	ServicePortName = "http-web"
 
+	// ServiceGrpcPort is the GRPC port in which the service will listen.
+	ServiceGrpcPort = 8081
+	// ServiceGrpcPortName is the name of the service grpc port.
+	ServiceGrpcPortName = "grpc"
+
 	// ServiceGraphNamespace is the name of the namespace that all service graph
 	// related components will live in.
 	ServiceGraphNamespace = "service-graph"

--- a/isotope/convert/pkg/kubernetes/kubernetes.go
+++ b/isotope/convert/pkg/kubernetes/kubernetes.go
@@ -180,7 +180,8 @@ func makeService(service svc.Service) (k8sService apiv1.Service) {
 	k8sService.ObjectMeta.Namespace = ServiceGraphNamespace
 	k8sService.ObjectMeta.Labels = serviceGraphAppLabels
 	timestamp(&k8sService.ObjectMeta)
-	k8sService.Spec.Ports = []apiv1.ServicePort{{Port: consts.ServicePort, Name: consts.ServicePortName}, {Port: consts.ServiceGrpcPort, Name: consts.ServiceGrpcPortName}}
+	k8sService.Spec.Ports = []apiv1.ServicePort{{Port: consts.ServicePort, Name: consts.ServicePortName},
+		{Port: consts.ServiceGrpcPort, Name: consts.ServiceGrpcPortName}}
 	k8sService.Spec.Selector = map[string]string{"name": service.Name}
 	return
 }

--- a/isotope/convert/pkg/kubernetes/kubernetes.go
+++ b/isotope/convert/pkg/kubernetes/kubernetes.go
@@ -180,7 +180,7 @@ func makeService(service svc.Service) (k8sService apiv1.Service) {
 	k8sService.ObjectMeta.Namespace = ServiceGraphNamespace
 	k8sService.ObjectMeta.Labels = serviceGraphAppLabels
 	timestamp(&k8sService.ObjectMeta)
-	k8sService.Spec.Ports = []apiv1.ServicePort{{Port: consts.ServicePort, Name: consts.ServicePortName}}
+	k8sService.Spec.Ports = []apiv1.ServicePort{{Port: consts.ServicePort, Name: consts.ServicePortName}, {Port: consts.ServiceGrpcPort, Name: consts.ServiceGrpcPortName}}
 	k8sService.Spec.Selector = map[string]string{"name": service.Name}
 	return
 }
@@ -234,6 +234,9 @@ func makeDeployment(
 						Ports: []apiv1.ContainerPort{
 							{
 								ContainerPort: consts.ServicePort,
+							},
+							{
+								ContainerPort: consts.ServiceGrpcPort,
 							},
 						},
 					},


### PR DESCRIPTION
Util for services which expose more than 1 port. 
For instance, my test services start 2 servers: http on 8080, and grpc on 8081.