### PR TITLE
Add doc link to schema descriptions in CRDs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ replace (
 )
 
 require (
-	cuelang.org/go v0.0.0-20190921151558-75b9c7fa7b70
+	cuelang.org/go v0.0.12-0.20191008111816-7e4dc22a913d
 	fortio.org/fortio v1.1.0
 	github.com/client9/gospell v0.0.0-20160306015952-90dfc71015df
 	github.com/docker/go-units v0.3.3

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ cuelang.org/go v0.0.0-20190921151558-75b9c7fa7b70 h1:MV22jNum2TRegWZ/D7oSRHGeP9W
 cuelang.org/go v0.0.0-20190921151558-75b9c7fa7b70/go.mod h1:1bVjlo3IfzlqfJeH9+0BDisn57t0kwJvDRcRmywVfFQ=
 cuelang.org/go v0.0.11 h1:t7s006dOWh6tgnwPifvO3l704eg8oPuIH7AR1hfTFYk=
 cuelang.org/go v0.0.11/go.mod h1:V6nzWY/JLJLymbvIHq8M37qsGjyD4BWTOPYZRK6+UZc=
+cuelang.org/go v0.0.12-0.20191008111816-7e4dc22a913d h1:TKTo+HAGGT4oyZ17no4mPKKrwZ6VQPfBa2Vy3EcVjQ0=
+cuelang.org/go v0.0.12-0.20191008111816-7e4dc22a913d/go.mod h1:gehQASsTv+lFZknWIG0hANGVSBiHD7HyKWmAdEZL3No=
 fortio.org/fortio v1.1.0 h1:RcZTb73HO2NXj6K9U6DZ02BVeA2TzmCdqFD80Y/AU8Y=
 fortio.org/fortio v1.1.0/go.mod h1:Go0fRqoPJ1xy5JOWcS23jyF58byVZxFyEePYsGmCR0k=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
@@ -218,6 +220,7 @@ github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7z
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/retr0h/go-gilt v0.0.0-20190206215556-f73826b37af2/go.mod h1:7PJr6TwZ6FwyTMn8zrm5QbMfH7yCiv56Wi9hRPhpWSM=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
+github.com/rogpeppe/testscript v1.1.0/go.mod h1:lzMlnW8LS56mcdJoQYkrlzqOoTFCOemzt5LusJ93bDM=
 github.com/russross/blackfriday v1.5.2 h1:HyvC0ARfnZBqnXwABFeSZHpKvJHJJfPz81GNueLj0oo=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
@@ -338,6 +341,7 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/natefinch/lumberjack.v2 v2.0.0-20150622162204-20b71e5b60d7/go.mod h1:l0ndWWf7gzL7RNwBG7wST/UCcT4T24xpD6X8LsfU/+k=


### PR DESCRIPTION
For each top level CRD, cue-gen generates a description from the `$description` and `$location` annotations in the proto files. `$schema` annotation is needed if the doc link is needed in the resulting schema description.

A snippet of the generated schema of MeshPolicy:
```
openAPIV3Schema:
      properties:
        spec:
          description: 'Authentication policy for Istio services. See more details
            at: https://istio.io/docs/reference/config/istio.authentication.v1alpha1.html'
```