### PR TITLE
Add bashrc to build-tools container to enable tab completion for make

### DIFF
--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -379,6 +379,8 @@ COPY --from=python_context /usr/local/bin /usr/local/bin
 COPY --from=python_context /usr/local/lib /usr/local/lib
 COPY --from=python_context /usr/local/google-cloud-sdk /usr/local/google-cloud-sdk
 
+COPY bashrc /home/.bashrc
+
 RUN mkdir -p /go && \
     mkdir -p /gocache && \
     mkdir -p /home/.kube && \

--- a/docker/build-tools/bashrc
+++ b/docker/build-tools/bashrc
@@ -1,0 +1,21 @@
+# Copyright Istio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Override prompt to avoid the annoying "I have no name!" in the default prompt
+PS1="build-tools:\w\\$ \[$(tput sgr0)\]"
+export PS1
+
+# Tab completion for make that works with istio's unique setup
+make_options=$(find /work/ -iname "?akefil*" | xargs -I {} grep -hoE '^[a-zA-Z0-9_.-]+:([^=]|$)' {} | sed 's/[^a-zA-Z0-9_.-]*$//' | sort -u)
+complete -W "$make_options" make


### PR DESCRIPTION
Also overrides default PS1 to get rid of the `I have no name!` message.

Resolves https://github.com/istio/istio/issues/17483 -- this does not require changing DEFAULT_GOAL

I use a custom, _very generous_ completion script here because the default one that comes with `bash-completion` only looks at targets within a file named exactly `Makefile`. This looks at all the possible makefiles recursively from the current directory on down, excluding files in `vendor`, and adds all targets to the options. 

There's also a fun optimization here. Normally you'd put the `$(find ...` in the complete command, but this can take a sec every time you hit tab if you have a deep file tree. Since we live in a container and only ever have to worry about one repo, we just do it once and cache the results forever, so the tab completion comes back instantly every time.

![image](https://user-images.githubusercontent.com/1565303/66521621-631ca780-eaa0-11e9-83e7-578945a0af18.png)
