### PR TITLE
A fix and a feature

### DIFF
--- a/cmd/license-lint/README.md
+++ b/cmd/license-lint/README.md
@@ -12,16 +12,22 @@ any modules have a restricted or unknown license:
     $ license-lint --config <config file>
     ```
 
-1. Report. Dumps license information for all dependencies:
+1. Report. Lists license information for all dependencies:
 
     ```bash
     $ license-lint --config <config file> --report
     ```
 
-1. CSV. Dumps license information for all dependencies in CSV format:
+1. CSV. Lists license information for all dependencies in CSV format:
 
     ```bash
     $ license-lint --config <config file> --report
+    ```
+
+1. Dumps. Shows all licenses for all dependencies:
+
+    ```bash
+    $ license-lint --config <config file> --dump
     ```
 
 The configuration is specified in a YAML file with four stanzas:

--- a/cmd/license-lint/main.go
+++ b/cmd/license-lint/main.go
@@ -22,9 +22,11 @@ import (
 
 func main() {
 	var report bool
+	var dump bool
 	var csv bool
 	var config string
 	flag.BoolVar(&report, "report", false, "Generate a report of all license usage.")
+	flag.BoolVar(&dump, "dump", false, "Generate a dump of all licenses used.")
 	flag.BoolVar(&csv, "csv", false, "Generate a report of all license usage in CSV format.")
 	flag.StringVar(&config, "config", "", "Path to config file.")
 	flag.Parse()
@@ -77,7 +79,7 @@ func main() {
 
 		// categorize the modules
 		for _, module := range modules {
-			if !report {
+			if !report && !dump {
 				// if we're not producing a report, then exclude any module on the whitelist
 				if cfg.whitelistedModules[module.moduleName] {
 					continue
@@ -156,6 +158,26 @@ func main() {
 				for _, m := range unlicensedModules {
 					fmt.Printf("  %s\n", m.moduleName)
 				}
+			}
+		} else if dump {
+			for _, l := range unrestrictedLicenses {
+				fmt.Printf("MODULE: %s\n%s\n", l.module.moduleName, l.text)
+			}
+
+			for _, l := range reciprocalLicenses {
+				fmt.Printf("MODULE: %s\n%s\n", l.module.moduleName, l.text)
+			}
+
+			for _, l := range restrictedLicenses {
+				fmt.Printf("MODULE: %s\n%s\n", l.module.moduleName, l.text)
+			}
+
+			for _, l := range unrecognizedLicenses {
+				fmt.Printf("MODULE: %s\n%s\n", l.module.moduleName, l.text)
+			}
+
+			for _, m := range unlicensedModules {
+				fmt.Printf("MODULE: %s\n%s\n", m.moduleName, "<none>")
 			}
 		} else {
 			failLint := false

--- a/cmd/protoc-gen-docs/htmlGenerator.go
+++ b/cmd/protoc-gen-docs/htmlGenerator.go
@@ -463,7 +463,8 @@ func (g *htmlGenerator) generateMessage(message *protomodel.MessageDescriptor) {
 					continue
 				}
 
-				if field.Options != nil && field.Options.GetDeprecated() != dep {
+				if (field.Options != nil && field.Options.GetDeprecated() != dep) ||
+					(field.Options == nil || dep) {
 					continue
 				}
 
@@ -563,7 +564,8 @@ func (g *htmlGenerator) generateEnum(enum *protomodel.EnumDescriptor) {
 					continue
 				}
 
-				if v.Options != nil && v.Options.GetDeprecated() != dep {
+				if (v.Options != nil && v.Options.GetDeprecated() != dep) ||
+					(v.Options == nil || dep) {
 					continue
 				}
 
@@ -616,7 +618,8 @@ func (g *htmlGenerator) generateService(service *protomodel.ServiceDescriptor) {
 				continue
 			}
 
-			if method.Options != nil && method.Options.GetDeprecated() != dep {
+			if (method.Options != nil && method.Options.GetDeprecated() != dep) ||
+				(method.Options == nil || dep) {
 				continue
 			}
 


### PR DESCRIPTION
- Add a -dump option to the license linter.

- Fix bogus handling of deprecated entries that was causing duplicates
being emitted in generated HTML content from protos.