### PR TITLE
support set sidecar.istio.io/interceptionMode for perf test

### DIFF
--- a/perf/benchmark/README.md
+++ b/perf/benchmark/README.md
@@ -46,6 +46,7 @@ For instructions on how to run these scripts with Linkerd, see the [linkerd/](li
     ```bash
     export NAMESPACE=twopods
     export DNS_DOMAIN=local
+    export INTERCEPTION_MODE=REDIRECT
     cd ../benchmark
     ./setup_test.sh
     ```

--- a/perf/benchmark/setup_test.sh
+++ b/perf/benchmark/setup_test.sh
@@ -28,6 +28,7 @@ DNS_DOMAIN=${DNS_DOMAIN:?"DNS_DOMAIN should be like v104.qualistio.org or local"
 TMPDIR=${TMPDIR:-${WD}/tmp}
 RBAC_ENABLED="false"
 LINKERD_INJECT="${LINKERD_INJECT:-'disabled'}"
+INTERCEPTION_MODE=${INTERCEPTION_MODE:-'REDIRECT'}
 echo "linkerd inject is ${LINKERD_INJECT}"
 
 mkdir -p "${TMPDIR}"
@@ -48,6 +49,7 @@ function run_test() {
       --set includeOutboundIPRanges=$(svc_ip_range) \
       --set injectL="${LINKERD_INJECT}" \
       --set domain="${DNS_DOMAIN}" \
+      --set interceptionMode="${INTERCEPTION_MODE}" \
           . > "${TMPDIR}"/twopods.yaml
   echo "Wrote file ${TMPDIR}/twopods.yaml"
 

--- a/perf/benchmark/templates/fortio.yaml
+++ b/perf/benchmark/templates/fortio.yaml
@@ -77,6 +77,9 @@ spec:
   template:
     metadata:
       annotations:
+        {{- if $.Values.interceptionMode }}
+        sidecar.istio.io/interceptionMode: {{ $.Values.interceptionMode }}
+        {{- end }}
         {{- if $.Values.excludeOutboundIPRanges }}
         traffic.sidecar.istio.io/excludeOutboundIPRanges: {{ $.Values.excludeOutboundIPRanges }}
         {{- end }}

--- a/perf/benchmark/values-istio-auth.yaml
+++ b/perf/benchmark/values-istio-auth.yaml
@@ -65,3 +65,5 @@ grafana:
 
 prometheus:
     enabled: true
+
+interceptionMode: REDIRECT

--- a/perf/benchmark/values.yaml
+++ b/perf/benchmark/values.yaml
@@ -41,3 +41,4 @@ client: # client overrides
   injectL: "disabled" # "enabled" or "disabled"
 
 cert: false
+interceptionMode: REDIRECT


### PR DESCRIPTION
AFAIK, TPROXY mode is slightly better in the performance test. we could suggest the user to use TPROXY if possible if we have test results to support this.
Signed-off-by: forrestchen <forrestchen@tencent.com>