### PR TITLE
Allow failures in gcr docker auth

### DIFF
--- a/docker/build-tools/prow-entrypoint.sh
+++ b/docker/build-tools/prow-entrypoint.sh
@@ -30,6 +30,7 @@ done
 
 # Authenticate gcloud, allow failures
 if [[ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then
+  # Jobs that need this will fail later and jobs that don't should fail because of this
   gcloud auth activate-service-account --key-file="${GOOGLE_APPLICATION_CREDENTIALS}" || true
   gcloud auth configure-docker -q || true
 fi

--- a/docker/build-tools/prow-entrypoint.sh
+++ b/docker/build-tools/prow-entrypoint.sh
@@ -31,7 +31,7 @@ done
 # Authenticate gcloud, allow failures
 if [[ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then
   gcloud auth activate-service-account --key-file="${GOOGLE_APPLICATION_CREDENTIALS}" || true
-  gcloud auth configure-docker -q
+  gcloud auth configure-docker -q || true
 fi
 
 exec "$@"


### PR DESCRIPTION
This doesn't work in our release setup. We can just ignore failures; jobs that need this will fail later and jobs that don't should fail because of this