### PR TITLE
Mount user specific secrets in /config

### DIFF
--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -65,6 +65,7 @@ RUN mkdir -p ${OUTDIR}/usr/bin
 # hadolint ignore=DL3008
 RUN apt-get update && apt-get install -y --no-install-recommends \
     apt-transport-https \
+    build-essential \
     ca-certificates \
     curl \
     gnupg2 \
@@ -153,6 +154,13 @@ RUN chmod 555 ${OUTDIR}/usr/bin/kubectl
 ADD https://github.com/GoogleCloudPlatform/docker-credential-gcr/releases/download/v${GCR_AUTH_VERSION}/docker-credential-gcr_linux_amd64-${GCR_AUTH_VERSION}.tar.gz /tmp
 RUN tar -xzf /tmp/docker-credential-gcr_linux_amd64-${GCR_AUTH_VERSION}.tar.gz -C /tmp
 RUN mv /tmp/docker-credential-gcr ${OUTDIR}/usr/bin
+
+# Install su-exec which is a tool that operates like sudo without the overhead
+ADD https://github.com/ncopa/su-exec/archive/v0.2.tar.gz /tmp
+RUN tar -xzvf v${SU_EXEC_VERSION}.tar.gz
+WORKDIR /tmp/su-exec-${SU_EXEC_VERSION}
+RUN make
+RUN cp -a su-exec ${OUTDIR}/usr/bin
 
 # Cleanup stuff we don't need in the final image
 RUN rm -fr /usr/local/go/doc
@@ -343,6 +351,9 @@ RUN rm -fr /tmp/*
 COPY prow-entrypoint.sh /usr/local/bin/entrypoint
 RUN chmod +x /usr/local/bin/entrypoint
 
+# Run config setup in local environments
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint
+
 ##############
 # Final image
 ##############
@@ -379,13 +390,18 @@ COPY --from=python_context /usr/local/bin /usr/local/bin
 COPY --from=python_context /usr/local/lib /usr/local/lib
 COPY --from=python_context /usr/local/google-cloud-sdk /usr/local/google-cloud-sdk
 
+# su-exec is used in place of complex sudo setup operations
+RUN chmod u+sx /usr/bin/su-exec
+
 COPY bashrc /home/.bashrc
 
 RUN mkdir -p /go && \
     mkdir -p /gocache && \
     mkdir -p /gobin && \
+    mkdir -p /config/.docker && \
+    mkdir -p /config/.config/gcloud && \
+    mkdir -p /config-copy && \
     mkdir -p /home/.kube && \
-    mkdir -p /home/.config && \
     mkdir -p /home/.helm
 
 # TODO must sort out how to use uid mapping in docker so these don't need to be 777
@@ -395,8 +411,12 @@ RUN mkdir -p /go && \
 RUN chmod 777 /go && \
     chmod 777 /gocache && \
     chmod 777 /gobin && \
+    chmod 777 /config && \
+    chmod 777 /config/.docker && \
+    chmod 777 /config/.config/gcloud && \
     chmod 777 /home/.kube && \
-    chmod 777 /home/.config && \
     chmod 777 /home/.helm
 
 WORKDIR /
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint"]

--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -156,7 +156,7 @@ RUN tar -xzf /tmp/docker-credential-gcr_linux_amd64-${GCR_AUTH_VERSION}.tar.gz -
 RUN mv /tmp/docker-credential-gcr ${OUTDIR}/usr/bin
 
 # Install su-exec which is a tool that operates like sudo without the overhead
-ADD https://github.com/ncopa/su-exec/archive/v0.2.tar.gz /tmp
+ADD https://github.com/ncopa/su-exec/archive/v${SU_EXEC_VERSION}.tar.gz /tmp
 RUN tar -xzvf v${SU_EXEC_VERSION}.tar.gz
 WORKDIR /tmp/su-exec-${SU_EXEC_VERSION}
 RUN make

--- a/docker/build-tools/docker-entrypoint.sh
+++ b/docker/build-tools/docker-entrypoint.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+# Copyright Istio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Copy credentials from mountpoints using su-exec
+uid=$(id -u)
+gid=$(id -g)
+
+shopt -s dotglob
+
+# Make a copy of the hosts's config secrets
+su-exec 0:0 cp -aR /config/* /config-copy/
+
+# Set the ownershp of the host's config secrets to that of the ontainer
+su-exec 0:0 chown -R "${uid}":"${gid}" /config-copy
+
+# Permit only the UID:GID to read the copy of the host's config secrets
+chmod -R 700 /config-copy
+
+# Set ownership of /home to UID:GID
+su-exec 0:0 chown "${uid}":"${gid}" /home
+
+# Copy the config secrets without chaning permissions nor ownership for
+# consumption by tooolchains
+cp -aR /config-copy/* /home/
+
+exec "$@"


### PR DESCRIPTION
Copy the user specific secrets to the correct location and change
 their ownership/permissions to improve usability across a variety
 of platforms.
