### PR TITLE
add H2UPGRADE param for namespace in service graph

### DIFF
--- a/perf/load/common.sh
+++ b/perf/load/common.sh
@@ -21,6 +21,7 @@ GATEWAY_URL=${SYSTEM_GATEWAY_URL:-$INGRESS_GATEWAY_URL}
 fi
 
 HTTPS=${HTTPS:-"false"}
+H2UPGRADE=${H2UPGRADE:-"false"}
 
 function run_test() {
   local ns=${1:?"namespaces"}
@@ -34,6 +35,7 @@ function run_test() {
           --set domain="${DNS_DOMAIN}" \
           --set ingress="${GATEWAY_URL}" \
           --set https="${HTTPS}" \
+          --set h2upgrade="${H2UPGRADE}" \
           . > "${YAML}"
   echo "Wrote ${YAML}"
 

--- a/perf/load/templates/h2upgrade.yaml
+++ b/perf/load/templates/h2upgrade.yaml
@@ -1,0 +1,34 @@
+{{- define "h2upgrade" }}
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: {{ .serviceNamePrefix }}{{ .serviceName }}-h2upgrade
+spec:
+  configPatches:
+  - applyTo: CLUSTER
+    match:
+      context: {{ .ctx }}
+      cluster:
+        service: {{ .serviceNamePrefix }}{{ .serviceName }}.{{ .Namespace }}.svc.cluster.local
+    patch:
+      operation: MERGE
+      value: # cluster specification
+        http2_protocol_options: { max_concurrent_streams: 47707 }
+---
+{{- end }}
+
+{{- if .Values.h2upgrade }}
+
+{{- range $i, $svcName := $.Values.services }}
+
+{{- $svc := dict "serviceName" $svcName "serviceNamePrefix" $.Values.serviceNamePrefix "Namespace" $.Values.Namespace }}
+
+{{- $_ := set $svc "ctx" "GATEWAY" }}
+{{- template "h2upgrade" $svc }}
+
+{{- $_ := set $svc "ctx" "SIDECAR_OUTBOUND" }}
+{{- template "h2upgrade" $svc }}
+
+{{- end }} 
+
+{{- end }} # h2upgrade

--- a/perf/load/values.yaml
+++ b/perf/load/values.yaml
@@ -35,3 +35,27 @@ livenessProbe: false
 tcpLivenessProbe: false
 tcpReadinessProbe: false
 domain: ""
+
+h2upgrade: false # set to true if you want to upgrade http connections to h2
+# service in this graph.
+# TODO:(mjog) reduce the server-graph-gen.yaml by iterating over services.
+services:
+- "0"
+- "0-0"
+- "0-0-0"
+- "0-1"
+- "0-1-0"
+- "0-2"
+- "0-2-0"
+- "0-3"
+- "0-3-0"
+- "0-4"
+- "0-4-0"
+- "0-5"
+- "0-5-0"
+- "0-6"
+- "0-6-0"
+- "0-7"
+- "0-7-0"
+- "0-8"
+- "0-8-0"


### PR DESCRIPTION
This PR adds the ability to upgrade http2 connections.

Since [h2 upgrade policy is not implemented](https://github.com/istio/api/blob/master/networking/v1alpha3/destination_rule.proto#L454)  This can be used in the interim. I am still testing with this, but it is expected to work.