### PR TITLE
Fix for docker.push not working on mac

### DIFF
--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -331,7 +331,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     pkg-config \
     python3 \
     daemon \
-    wget
+    wget \
+    jq
 
 # Docker including docker-ce, docker-ce-cli, and containerd.io
 ADD https://download.docker.com/linux/ubuntu/gpg /tmp/docker-key


### PR DESCRIPTION
On a mac, the command `make docker.push` fails because it cannot get the docker
login credentials from .docker/config.json. Docker on Mac settings has the
docker logins securely stored in the mac os keychain. Hence the config.json
does not have the auth information stored in it. This solution requires users
to manually uncheck the option to securely store the password in the macos
keychain. This generates the plaintext-password.json file which contains the
encrypted password. This can then be copied to the mounted config.json file
with the changes made in this PR.