### PR TITLE
Update readme for istio install

### DIFF
--- a/perf/istio-install/README.md
+++ b/perf/istio-install/README.md
@@ -6,16 +6,16 @@ This setup requires a very large cluster - at least 32 vCPUs reserved for Istio 
 
 ## Setup Istio with different releases
 
-To setup istio, run `./setup_istio_releash.sh TAG RELEASE_TYPE`
+To setup istio, run `./setup_istio_releash.sh TAG Stream[Optional]`
 
-1. To setup Istio with a specific release, run `DNS_DOMAIN=your-example-domain ./setup_istio_release.sh 1.3.3 release`.
+1. To setup Istio with a specific release, run `DNS_DOMAIN=your-example-domain ./setup_istio_release.sh 1.3.3`.
 
-1. To setup Istio with latest build of a dev release, get the dev release tag first from https://gcsweb.istio.io/gcs/istio-build/dev/, then run `DNS_DOMAIN=your-example-domain ./setup_istio_release.sh 1.4-alpha.0039742337ddf3b766ac974e9a7aad003896cfcf dev`.
+1. To setup Istio with latest build of a dev stream, run `DNS_DOMAIN=your-example-domain ./setup_istio_release.sh 1.4-dev`.
 
-1. To setup Istio with prerelease candidate, run ```DNS_DOMAIN=v11mcp.qualistio.org ./setup_istio_release.sh 1.4.0-alpha.0 pre-release
+1. To setup Istio with prerelease candidate, run ```DNS_DOMAIN=your-example-domain ./setup_istio_release.sh 1.4.0-alpha.0 pre-release
                                               ```
 
-1. To just output the deployment file, run `DRY_RUN=1 DNS_DOMAIN=your-example-domain ./setup_istio_release.sh 1.3.3 release`.
+1. To just output the deployment file, run `DRY_RUN=1 DNS_DOMAIN=your-example-domain ./setup_istio_release.sh 1.3.3`.
 
 
 You may also override the Helm repo or release URL and run ./setup_istio.sh directly, for example:
@@ -33,5 +33,5 @@ Look at values.yaml for details on the parameters.
 To overwrite helm flags, create a file to hold helm flags you want to overwrite and save as extra-values.yaml or other file names.
 
 ```bash
-DNS_DOMAIN=your-example-domain EXTRA_VALUES=extra-values.yaml ./setup_istio_release.sh 1.3.3 release
+DNS_DOMAIN=your-example-domain EXTRA_VALUES=extra-values.yaml ./setup_istio_release.sh 1.3.3
 ```

--- a/perf/istio-install/README.md
+++ b/perf/istio-install/README.md
@@ -4,43 +4,34 @@ For performance testing, it is recommended to setup Istio with performance orien
 
 This setup requires a very large cluster - at least 32 vCPUs reserved for Istio is recommended.
 
-## Setup With Performance Parameters
+## Setup Istio with different releases
 
-Look at values.yaml for details on the parameters.
+To setup istio, run `./setup_istio_releash.sh TAG RELEASE_TYPE`
 
-To setup Istio with a specific release, run `DNS_DOMAIN=your-example-domain ./setup_istio.sh release-1.1-20190125-09-16`.
+1. To setup Istio with a specific release, run `DNS_DOMAIN=your-example-domain ./setup_istio_release.sh 1.3.3 release`.
 
-To setup Istio with latest of a branch, run `DNS_DOMAIN=your-example-domain ./setup_istio.sh release-1.2-latest`.
-This command will setup the latest build from the 1.2 release branch.
+1. To setup Istio with latest build of a dev release, get the dev release tag first from https://gcsweb.istio.io/gcs/istio-build/dev/, then run `DNS_DOMAIN=your-example-domain ./setup_istio_release.sh 1.4-alpha.0039742337ddf3b766ac974e9a7aad003896cfcf dev`.
 
-To just output the deployment file, run `DRY_RUN=1 DNS_DOMAIN=your-example-domain ./setup_istio.sh release-1.1-20190125-09-16`.
+1. To setup Istio with prerelease candidate, run ```DNS_DOMAIN=v11mcp.qualistio.org ./setup_istio_release.sh 1.4.0-alpha.0 pre-release
+                                              ```
 
-### Latest release
+1. To just output the deployment file, run `DRY_RUN=1 DNS_DOMAIN=your-example-domain ./setup_istio_release.sh 1.3.3 release`.
 
-DNS_DOMAIN=v11p.qualistio.org ./setup_istio.sh release-1.1-latest
-You may replace the release in the command to the release to test.
 
-You may also override the Helm repo or release URL:
+You may also override the Helm repo or release URL and run ./setup_istio.sh directly, for example:
 
 ```bash
-export HELMREPO_URL=https://storage.googleapis.com/istio-release/releases/1.1.0-rc.0/charts/index.yaml
-export RELEASE_URL=https://github.com/istio/istio/releases/download/untagged-c41cff3404b8cc79a97e/istio-1.1.0-rc.0-linux.tar.gz
+export HELMREPO_URL=https://storage.googleapis.com/istio-release/releases/1.3.3/charts/index.yaml
+export RELEASE_URL=https://github.com/istio/istio/releases/download/1.3.3/istio-1.3.3-linux.tar.gz
 
-DNS_DOMAIN=your-example-domain ./setup_istio.sh release-1.1-20190203-09-16
+DNS_DOMAIN=your-example-domain ./setup_istio.sh 1.3.3
 ```
 
 ### Overwrite helm flags
+Look at values.yaml for details on the parameters. 
 
 To overwrite helm flags, create a file to hold helm flags you want to overwrite and save as extra-values.yaml or other file names.
 
 ```bash
-DNS_DOMAIN=your-example-domain EXTRA_VALUES=extra-values.yaml ./setup_istio.sh release-1.1-20190203-09-16
+DNS_DOMAIN=your-example-domain EXTRA_VALUES=extra-values.yaml ./setup_istio_release.sh 1.3.3 release
 ```
-
-### Installing release candidates
-
-```bash
-DNS_DOMAIN=v11mcp.qualistio.org ./setup_istio_release.sh 1.1.4 pre-release
-```
-
-This option uses pre-release buckets to get builds and charts.

--- a/perf/istio-install/setup_istio.sh
+++ b/perf/istio-install/setup_istio.sh
@@ -26,23 +26,13 @@ mkdir -p "${WD}/tmp"
 
 release="${1:?"release"}"
 
-if [[ "${release}" == *-latest ]];then
-  # shellcheck disable=SC2086
-  release=$(curl -f -L https://storage.googleapis.com/istio-prerelease/daily-build/${release}.txt)
-  # shellcheck disable=SC2181
-  if [[ $? -ne 0 ]];then
-    echo "${release} branch does not exist"
-    exit 1
-  fi
-fi
-
 shift
 
 function download() {
   local DIRNAME="$1"
   local release="$2"
 
-  local url="https://gcsweb.istio.io/gcs/istio-prerelease/daily-build/${release}/istio-${release}-linux.tar.gz"
+  local url="https://gcsweb.istio.io/gcs/istio-prerelease/prerelease/${release}/istio-${release}-linux.tar.gz"
   # shellcheck disable=SC2236
   if [[ -n "${RELEASE_URL}" ]];then
     url="${RELEASE_URL}"
@@ -151,8 +141,8 @@ function install_istio() {
           "$WD/setup_prometheus.sh" ${DIRNAME}
       fi
       if [[ -n "${MIXERLESS}" ]]; then
-        kubectl -n istio-system apply -f https://raw.githubusercontent.com/istio/proxy/master/extensions/stats/testdata/istio/metadata-exchange_filter.yaml
-        kubectl -n istio-system apply -f https://raw.githubusercontent.com/istio/proxy/master/extensions/stats/testdata/istio/stats_filter.yaml
+        kubectl -n istio-system apply -f https://raw.githubusercontent.com/istio/istio/master/tests/integration/telemetry/stats/prometheus/testdata/metadata_exchange_filter.yaml
+        kubectl -n istio-system apply -f https://raw.githubusercontent.com/istio/istio/master/tests/integration/telemetry/stats/prometheus/testdata/stats_filter.yaml
       fi
   fi
 


### PR DESCRIPTION
The readme looks a bit outdated also it is confusing regarding the usage between ./setup_istio.sh and ./setup_istio_release.sh, trying to 1. reorganize it. 2. update the deprecated part 3. encourage to use ./setup_istio_release.sh across. 

 can you help take a look? @howardjohn 