### PR TITLE
Make the benchmark pipeline job easier to configure

### DIFF
--- a/perf/benchmark/README.md
+++ b/perf/benchmark/README.md
@@ -74,14 +74,17 @@ The test has three sidecar modes:
 **How to run**:
 
 1. run with CLI argument directly
-```bash
-python runner.py --conn <conn> --qps <qps> --duration <duration> --OPTIONAL-FLAGS
-```
 
-2. run with config yaml
-```bash
+``
+python runner.py --conn <conn> --qps <qps> --duration <duration> --OPTIONAL-FLAGS
+``
+
+1. run with config yaml
+
+``
 python runner.py --config_file ./configs/mixer_latency.yaml
-```
+``
+
 Required fields to specified via CLI or config file:
 
 - `conn` = number of concurrent connections
@@ -115,9 +118,11 @@ Note:
 For example:
 
 ### Example 1
+
 ```bash
 python runner.py --config_file ./configs/mixer_latency.yaml
 ```
+
 - This will run with configuration specified in the mixer_latency.yaml
 - Run with mixerv1 on and measure the latency
 

--- a/perf/benchmark/README.md
+++ b/perf/benchmark/README.md
@@ -73,11 +73,16 @@ The test has three sidecar modes:
 
 **How to run**:
 
+1. run with CLI argument directly
 ```bash
-python runner.py <conn> <qps> <duration> --OPTIONAL-FLAGS
+python runner.py --conn <conn> --qps <qps> --duration <duration> --OPTIONAL-FLAGS
 ```
 
-Required fields:
+2. run with config yaml
+```bash
+python runner.py --config_file ./configs/mixer_latency.yaml
+```
+Required fields to specified via CLI or config file:
 
 - `conn` = number of concurrent connections
 - `qps` = queries per second for each connection
@@ -110,9 +115,16 @@ Note:
 For example:
 
 ### Example 1
+```bash
+python runner.py --config_file ./configs/mixer_latency.yaml
+```
+- This will run with configuration specified in the mixer_latency.yaml
+- Run with mixerv1 on and measure the latency
+
+### Example 2
 
 ```bash
-python runner.py 1,2,4,8,16,32,64 1000 240 --serversidecar
+python runner.py --conn 1,2,4,8,16,32,64 --qps 1000 --duration 240 --serversidecar
 ```
 
 - This will run separate tests for the `both` and `serversidecar` modes
@@ -120,10 +132,10 @@ python runner.py 1,2,4,8,16,32,64 1000 240 --serversidecar
 - Each connection will send **1000** QPS
 - Each test will run for **240** seconds
 
-### Example 2
+### Example 3
 
 ```bash
-python runner.py 16,64 1000,4000 180 --serversidecar --baseline
+python runner.py --conn 16,64 --qps 1000,4000 --duration 180 --serversidecar --baseline
 ```
 
 - 12 tests total, each for **180** seconds, with all combinations of:
@@ -131,19 +143,19 @@ python runner.py 16,64 1000,4000 180 --serversidecar --baseline
 - **1000** and **4000** QPS
 - `both`, `serversidecar`, and `baseline` proxy modes
 
-### Example 3
+### Example 4
 
 Example 1 and 2 is to gather the latency results by increasing the number of connections. If you want to gather CPU and memory related
 results, you should increasing the number of QPS, like:
 
 ```bash
-python runner.py 10 100,500,1000,2000,4000 240  --serversidecar --baseline
+python runner.py --conn 10  --qps 100,500,1000,2000,4000 --duration 240  --serversidecar --baseline
 ```
 
-### Example 4: flame graph
+### Example 5: flame graph
 
 ```bash
-python runner.py 1,2,4,8,16,32,64 1000 240 --perf=true
+python runner.py --conn 1,2,4,8,16,32,64 --qps 1000 --duration 240 --perf=true
 ```
 
 This will generate corresponding `xxx_perf.data.perf` file with its `.svg` flame graph in the `perf/benchmark/flame` repo.

--- a/perf/benchmark/README.md
+++ b/perf/benchmark/README.md
@@ -174,7 +174,7 @@ Calls to Istio's Mixer component (policy and telemetry) adds latency to the side
 
     ```bash
     kubectl -n istio-system get cm istio -o yaml > /tmp/meshconfig.yaml
-    python ../../bin/update_mesh_config.py disable_mixer /tmp/meshconfig.yaml | kubectl -n istio-system apply -f -
+    python ./update_mesh_config.py disable_mixer /tmp/meshconfig.yaml | kubectl -n istio-system apply -f -
     ```
 
 1. Run `runner.py`, in any sidecar mode, with the `--labels=nomixer` flag. If you run this command:
@@ -189,7 +189,7 @@ Calls to Istio's Mixer component (policy and telemetry) adds latency to the side
 
     ```bash
     kubectl -n istio-system get cm istio -o yaml > /tmp/meshconfig.yaml
-    python ../../bin/update_mesh_config.py enable_mixer /tmp/meshconfig.yaml  | kubectl -n istio-system apply -f -
+    python ./update_mesh_config.py enable_mixer /tmp/meshconfig.yaml  | kubectl -n istio-system apply -f -
     ```
 
 ## Gather Result Metrics

--- a/perf/benchmark/configs/mixer_cpu_mem.yaml
+++ b/perf/benchmark/configs/mixer_cpu_mem.yaml
@@ -1,0 +1,19 @@
+# Configuration Set1: CPU and memory with mixer enabled
+mixer_mode: "mixer"
+conn:
+    - 16
+qps:
+    - 10
+    - 100
+    - 500
+    - 1000
+    - 2000
+    - 3000
+duration: 240
+size: 1024
+metrics:
+    - cpu
+    - mem
+perf_record: false
+run_serversidecar: true
+run_baseline: true

--- a/perf/benchmark/configs/mixer_latency.yaml
+++ b/perf/benchmark/configs/mixer_latency.yaml
@@ -1,0 +1,20 @@
+# Configuration Set2: Latency Quantiles with mixer enabled
+mixer_mode: "mixer"
+conn:
+    - 1
+    - 2
+    - 4
+    - 8
+    - 16
+    - 32
+    - 64
+qps:
+    - 1000
+duration: 240
+metrics:
+    - p50
+    - p90
+    - p99
+perf_record: true
+run_serversidecar: true
+run_baseline: true

--- a/perf/benchmark/configs/nomixer_cpu_mem.yaml
+++ b/perf/benchmark/configs/nomixer_cpu_mem.yaml
@@ -1,0 +1,18 @@
+# Configuration Set3: CPU and memory with mixer disabled
+mixer_mode: "nomixer"
+conn:
+    - 16
+qps:
+    - 10
+    - 100
+    - 500
+    - 1000
+    - 2000
+    - 3000
+duration: 240
+metrics:
+    - cpu
+    - mem
+perf_record: false
+run_serversidecar: true
+run_baseline: true

--- a/perf/benchmark/configs/nomixer_latency.yaml
+++ b/perf/benchmark/configs/nomixer_latency.yaml
@@ -1,0 +1,21 @@
+# Configuration Set4: Latency Quantiles with mixer disabled
+mixer_mode: "nomixer"
+conn:
+    - 1
+    - 2
+    - 4
+    - 8
+    - 16
+    - 32
+    - 64
+qps:
+    - 1000
+duration: 240
+size: 1024
+metrics:
+    - p50
+    - p90
+    - p99
+perf_record: true
+run_serversidecar: true
+run_baseline: true

--- a/perf/benchmark/configs/telemetryv2_cpu_mem.yaml
+++ b/perf/benchmark/configs/telemetryv2_cpu_mem.yaml
@@ -1,0 +1,18 @@
+# Configuration Set5: CPU and memory with telemetryv2 using NullVM.
+mixer_mode: "v2_nullvm"
+conn:
+    - 16
+qps:
+    - 10
+    - 100
+    - 500
+    - 1000
+    - 2000
+    - 3000
+duration: 240
+metrics:
+    - cpu
+    - mem
+perf_record: false
+run_serversidecar: true
+run_baseline: true

--- a/perf/benchmark/configs/telemetryv2_latency.yaml
+++ b/perf/benchmark/configs/telemetryv2_latency.yaml
@@ -1,0 +1,20 @@
+# Configuration Set6: Latency Quantiles with telemetry v2 using NullVM.
+mixer_mode: "v2-nullvm"
+conn:
+    - 1
+    - 2
+    - 4
+    - 8
+    - 16
+    - 32
+    - 64
+qps:
+    - 1000
+duration: 240
+metrics:
+    - p50
+    - p90
+    - p99
+perf_record: true
+run_serversidecar: true
+run_baseline: true

--- a/perf/benchmark/run_benchmark_job.sh
+++ b/perf/benchmark/run_benchmark_job.sh
@@ -73,20 +73,19 @@ function generate_graph() {
 }
 
 function get_benchmark_data() {
-  # shellcheck disable=SC2086
-  pipenv run python3 runner.py ${CONN} ${QPS} ${DURATION} ${EXTRA_ARGS} ${FLAME_GRAGH_ARG} ${MIXER_MODE}
+  CONFIG_FILE="${1}"
+  pipenv run python3 runner.py --config_file ${CONFIG_FILE}
   collect_metrics
 
-  if [[ "${FLAME_GRAGH_ARG}" == "--perf=true" ]]; then
-    echo "collect flame graph ..."
-    collect_flame_graph
-  fi
+  echo "collect flame graph ..."
+  collect_flame_graph
 
-  for metric in "${METRICS[@]}"
-  do
-    generate_graph "${metric}"
-  done
-  gsutil -q cp -r "${LOCAL_OUTPUT_DIR}" "gs://$GCS_BUCKET/${OUTPUT_DIR}/graphs"
+#  TODO: replace with new graph generation code
+#  for metric in "${METRICS[@]}"
+#  do
+#    generate_graph "${metric}"
+#  done
+#  gsutil -q cp -r "${LOCAL_OUTPUT_DIR}" "gs://$GCS_BUCKET/${OUTPUT_DIR}/graphs"
 }
 
 function exit_handling() {
@@ -109,21 +108,35 @@ function enable_perf_record() {
   done
 }
 
+function prerun_v2_nullvm() {
+  kubectl -n istio-system apply -f https://raw.githubusercontent.com/istio/istio/master/tests/integration/telemetry/stats/prometheus/testdata/metadata_exchange_filter.yaml
+  kubectl -n istio-system apply -f https://raw.githubusercontent.com/istio/istio/master/tests/integration/telemetry/stats/prometheus/testdata/stats_filter.yaml
+}
+
+function prerun_nomixer() {
+  kubectl -n istio-system get cm istio -o yaml > /tmp/meshconfig.yaml
+  pipenv run python3 "${WD}"/update_mesh_config.py disable_mixer /tmp/meshconfig.yaml | kubectl -n istio-system apply -f -
+}
+
+# setup release info
 RELEASE_TYPE="dev"
 BRANCH="latest"
 if [ "${GIT_BRANCH}" != "master" ];then
   BRANCH_NUM=$(echo "$GIT_BRANCH" | cut -f2 -d-)
   BRANCH="${BRANCH_NUM}-dev"
 fi
+
 # different branch tag resides in dev release directory like /latest, /1.4-dev, /1.5-dev etc.
 TAG=$(curl "https://storage.googleapis.com/istio-build/dev/${BRANCH}")
 echo "Setup istio release: $TAG"
 pushd "${ROOT}/istio-install"
    ./setup_istio_release.sh "${TAG}" "${RELEASE_TYPE}"
 popd
+
 # install dependencies
 cd "${WD}/runner"
 pipenv install
+
 # setup test
 pushd "${WD}"
 ./setup_test.sh
@@ -148,64 +161,25 @@ echo "Start running perf benchmark test, data would be saved to GCS bucket: ${GC
 # For adding or modifying configurations, refer to perf/benchmark/README.md
 EXTRA_ARGS="--serversidecar --baseline"
 
+# enable flame graph
 enable_perf_record
 
-# Configuration Set1: CPU and memory with mixer enabled
-FLAME_GRAGH_ARG="--perf=false"
-MIXER_MODE="--mixer_mode mixer"
-CONN=16
-QPS=10,100,500,1000,2000,3000
-DURATION=240
-METRICS=(cpu mem)
-get_benchmark_data
+CONFIG_DIR="${WD}/configs"
 
-# Configuration Set2: Latency Quantiles with mixer enabled
-FLAME_GRAGH_ARG="--perf=true"
-CONN=1,2,4,8,16,32,64
-QPS=1000
-METRICS=(p50 p90 p99)
-get_benchmark_data
-# restart proxy after each group(two sets)
-kubectl exec -n twopods "${FORTIO_CLIENT_POD}" -c istio-proxy -- curl http://localhost:15000/quitquitquit -X POST
-kubectl exec -n twopods "${FORTIO_SERVER_POD}" -c istio-proxy -- curl http://localhost:15000/quitquitquit -X POST
+for f in "${CONFIG_DIR}"/*; do
+    fn=$(basename ${f})
+    if [[ "${fn}" =~ "nomixer" ]];then
+        prerun_nomixer
+    elif [[ "${fn}" =~ "telemetryv2" ]];then
+        prerun_v2_nullvm
+    fi
 
-# Configuration Set3: CPU and memory with mixer disabled
-kubectl -n istio-system get cm istio -o yaml > /tmp/meshconfig.yaml
-pipenv run python3 "${WD}"/update_mesh_config.py disable_mixer /tmp/meshconfig.yaml | kubectl -n istio-system apply -f -
-FLAME_GRAGH_ARG="--perf=false"
-MIXER_MODE="--mixer_mode nomixer"
-CONN=16
-QPS=10,100,500,1000,2000,3000
-DURATION=240
-METRICS=(cpu mem)
-get_benchmark_data
+    get_benchmark_data "${f}"
 
-# Configuration Set4: Latency Quantiles with mixer disabled
-CONN=1,2,4,8,16,32,64
-QPS=1000
-METRICS=(p50 p90 p99)
-get_benchmark_data
-# restart proxy after each group
-kubectl exec -it -n twopods "${FORTIO_CLIENT_POD}" -c istio-proxy -- curl http://localhost:15000/quitquitquit -X POST
-kubectl exec -it -n twopods "${FORTIO_SERVER_POD}" -c istio-proxy -- curl http://localhost:15000/quitquitquit -X POST
-
-# Configuration Set5: CPU and memory with telemetryv2 using NullVM.
-kubectl -n istio-system apply -f https://raw.githubusercontent.com/istio/istio/master/tests/integration/telemetry/stats/prometheus/testdata/metadata_exchange_filter.yaml
-kubectl -n istio-system apply -f https://raw.githubusercontent.com/istio/istio/master/tests/integration/telemetry/stats/prometheus/testdata/stats_filter.yaml
-MIXER_MODE="--mixer_mode telemetryv2-nullvm"
-CONN=16
-QPS=10,100,500,1000,2000,3000
-DURATION=240
-METRICS=(cpu mem)
-get_benchmark_data
-
-# Configuration Set6: Latency Quantiles with telemetry v2 using NullVM.
-CONN=1,2,4,8,16,32,64
-QPS=1000
-METRICS=(p50 p90 p99)
-get_benchmark_data
-# restart proxy after each group
-kubectl exec -it -n twopods "${FORTIO_CLIENT_POD}" -c istio-proxy -- curl http://localhost:15000/quitquitquit -X POST
-kubectl exec -it -n twopods "${FORTIO_SERVER_POD}" -c istio-proxy -- curl http://localhost:15000/quitquitquit -X POST
+    # post run
+    # restart proxy after each group
+    kubectl exec -n twopods "${FORTIO_CLIENT_POD}" -c istio-proxy -- curl http://localhost:15000/quitquitquit -X POST
+    kubectl exec -n twopods "${FORTIO_SERVER_POD}" -c istio-proxy -- curl http://localhost:15000/quitquitquit -X POST
+done
 
 echo "perf benchmark test is done."

--- a/perf/benchmark/run_benchmark_job.sh
+++ b/perf/benchmark/run_benchmark_job.sh
@@ -74,7 +74,7 @@ function generate_graph() {
 
 function get_benchmark_data() {
   CONFIG_FILE="${1}"
-  pipenv run python3 runner.py --config_file ${CONFIG_FILE}
+  pipenv run python3 runner.py --config_file "${CONFIG_FILE}"
   collect_metrics
 
   echo "collect flame graph ..."
@@ -158,16 +158,16 @@ trap exit_handling ERR
 trap exit_handling EXIT
 
 echo "Start running perf benchmark test, data would be saved to GCS bucket: ${GCS_BUCKET}/${OUTPUT_DIR}"
-# For adding or modifying configurations, refer to perf/benchmark/README.md
-EXTRA_ARGS="--serversidecar --baseline"
 
 # enable flame graph
 enable_perf_record
 
+# For adding or modifying configurations, refer to perf/benchmark/README.md
 CONFIG_DIR="${WD}/configs"
 
 for f in "${CONFIG_DIR}"/*; do
-    fn=$(basename ${f})
+    fn=$(basename "${f}")
+    # pre run
     if [[ "${fn}" =~ "nomixer" ]];then
         prerun_nomixer
     elif [[ "${fn}" =~ "telemetryv2" ]];then

--- a/perf/benchmark/runner/Pipfile
+++ b/perf/benchmark/runner/Pipfile
@@ -11,4 +11,5 @@ pytz = "*"
 bokeh = "*"
 pandas = "==0.24.2"
 numpy = "*"
+pyyaml = "*"
 

--- a/perf/benchmark/runner/runner.py
+++ b/perf/benchmark/runner/runner.py
@@ -21,6 +21,7 @@ import argparse
 import subprocess
 import shlex
 import uuid
+import yaml
 from fortio import METRICS_START_SKIP_DURATION, METRICS_END_SKIP_DURATION
 import sys
 
@@ -267,32 +268,63 @@ def rc(command):
     return process.poll()
 
 
+def fortio_from_config_file(args):
+    with open(args.config_file) as f:
+        job_config = yaml.safe_load(f)
+        # TODO: add validation of config file
+        # TODO: parse yaml into object directly
+        fortio = Fortio()
+        fortio.mixer_mode = job_config['mixer_mode']
+        fortio.conn = job_config['conn']
+        fortio.qps = job_config['qps']
+        fortio.duration = job_config['duration']
+        fortio.metrics = job_config['metrics']
+        fortio.size = job_config['size']
+        fortio.perf_record = job_config['perf_record']
+        fortio.run_serversidecar = job_config['run_serversidecar']
+        fortio.run_baseline = job_config['run_baseline']
+        # fill out default value
+        if "size" not in job_config:
+            fortio.size = 1024
+        if "mesh" not in job_config:
+            fortio.mesh = 'istio'
+        if "mode" not in job_config:
+            fortio.mode = 'http'
+        return fortio
+
+
 def run(args):
     min_duration = METRICS_START_SKIP_DURATION + METRICS_END_SKIP_DURATION
-    if args.duration <= min_duration:
+
+    # run with config files
+    if args.config_file is not None:
+        fortio = fortio_from_config_file(args)
+
+    else:
+        fortio = Fortio(
+            conn=args.conn,
+            qps=args.qps,
+            duration=args.duration,
+            size=args.size,
+            perf_record=args.perf,
+            labels=args.labels,
+            baseline=args.baseline,
+            serversidecar=args.serversidecar,
+            clientsidecar=args.clientsidecar,
+            ingress=args.ingress,
+            mode=args.mode,
+            mesh=args.mesh,
+            mixer_mode=args.mixer_mode)
+
+    if fortio.duration <= min_duration:
         print("Duration must be greater than {min_duration}".format(
             min_duration=min_duration))
         exit(1)
 
-    fortio = Fortio(
-        conn=args.conn,
-        qps=args.qps,
-        duration=args.duration,
-        size=args.size,
-        perf_record=args.perf,
-        labels=args.labels,
-        baseline=args.baseline,
-        serversidecar=args.serversidecar,
-        clientsidecar=args.clientsidecar,
-        ingress=args.ingress,
-        mode=args.mode,
-        mesh=args.mesh,
-        mixer_mode=args.mixer_mode)
-
-    for conn in args.conn:
-        for qps in args.qps:
+    for conn in fortio.conn:
+        for qps in fortio.qps:
             fortio.run(conn=conn, qps=qps,
-                       duration=args.duration, size=args.size)
+                       duration=fortio.duration, size=fortio.size)
 
 
 def csv_to_int(s):
@@ -302,15 +334,15 @@ def csv_to_int(s):
 def get_parser():
     parser = argparse.ArgumentParser("Run performance test")
     parser.add_argument(
-        "conn",
+        "--conn",
         help="number of connections, comma separated list",
         type=csv_to_int,)
     parser.add_argument(
-        "qps",
+        "--qps",
         help="qps, comma separated list",
         type=csv_to_int,)
     parser.add_argument(
-        "duration",
+        "--duration",
         help="duration in seconds of the extract",
         type=int)
     parser.add_argument(
@@ -350,6 +382,10 @@ def get_parser():
         "--mode",
         help="http or grpc",
         default="http")
+    parser.add_argument(
+        "--config_file",
+        help="config yaml file",
+        default=None)
 
     define_bool(parser, "baseline", "run baseline for all", False)
     define_bool(parser, "serversidecar",

--- a/perf/benchmark/runner/runner.py
+++ b/perf/benchmark/runner/runner.py
@@ -268,11 +268,25 @@ def rc(command):
     return process.poll()
 
 
+def validate(job_config):
+    required_fields = {"conn": list, "qps": list, "duration": int}
+    for k in required_fields:
+        if k not in job_config:
+            print("missing required parameter {}".format(k))
+            return False
+        exp_type = required_fields[k]
+        if type(job_config[k]) != exp_type:
+            print("expecting type of parameter {} to be {}, got {}".format(k, exp_type, type(job_config[k])))
+            return False
+    return True
+
+
 def fortio_from_config_file(args):
     with open(args.config_file) as f:
         job_config = yaml.safe_load(f)
-        # TODO: add validation of config file
-        # TODO: parse yaml into object directly
+        if not validate(job_config):
+            exit(1)
+        # TODO: hard to parse yaml into object directly because of existing constructor from CLI
         fortio = Fortio()
         fortio.mixer_mode = job_config['mixer_mode']
         fortio.conn = job_config['conn']


### PR DESCRIPTION
1. Move the configs defined in the script under ./configs as yaml file, added validation
2. Refactor the benchmark scripts
