### PR TITLE
Add a build tools image for istio/proxy

### DIFF
--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -346,8 +346,6 @@ RUN apt-get -y install --no-install-recommends docker-ce="${DOCKER_VERSION}" doc
 
 # Clean up stuff we don't need in the final image
 RUN rm -rf /var/lib/apt/lists/*
-RUN rm -fr /usr/share/perl
-RUN rm -fr /usr/share/perl5
 RUN rm -fr /usr/share/python
 RUN rm -fr /usr/share/bash-completion
 RUN rm -fr /usr/share/bug
@@ -369,7 +367,7 @@ COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint
 ##############
 
 # Prepare final output image
-FROM scratch
+FROM scratch as build_tools
 
 # General
 ENV HOME=/home
@@ -428,6 +426,75 @@ RUN chmod 777 /go && \
     chmod 777 /home/.kube && \
     chmod 777 /home/.helm && \
     chmod 777 /home/.gsutil
+
+WORKDIR /
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint"]
+
+##############
+# Clang+LLVM
+##############
+
+FROM ubuntu:xenial as clang_context
+
+RUN apt-get update && apt-get install -y xz-utils
+
+ENV LLVM_VERSION=9.0.0
+ENV LLVM_TARGET=x86_64-linux-gnu-ubuntu-16.04
+
+ENV LLVM_BASE_URL=http://releases.llvm.org/${LLVM_VERSION}
+ENV LLVM_ARCHIVE=clang+llvm-${LLVM_VERSION}-${LLVM_TARGET}
+ENV LLVM_URL=${LLVM_BASE_URL}/${LLVM_ARCHIVE}.tar.xz
+ENV LLVM_DIRECTORY=/usr/lib/llvm
+
+ADD ${LLVM_URL} /tmp
+RUN tar -xJf /tmp/${LLVM_ARCHIVE}.tar.xz -C /tmp
+RUN mkdir -p ${LLVM_DIRECTORY}
+RUN mv /tmp/${LLVM_ARCHIVE}/* ${LLVM_DIRECTORY}/
+
+###########
+# Bazel
+###########
+
+FROM ubuntu:xenial as bazel_context
+
+ENV BAZELISK_VERSION="v1.0"
+ENV BAZELISK_BASE_URL="https://github.com/bazelbuild/bazelisk/releases/download"
+ENV BAZELISK_BIN="bazelisk-linux-amd64"
+ENV BAZELISK_URL="${BAZELISK_BASE_URL}/${BAZELISK_VERSION}/${BAZELISK_BIN}"
+
+ADD ${BAZELISK_URL} /tmp
+RUN chmod +x /tmp/${BAZELISK_BIN}
+RUN mv /tmp/${BAZELISK_BIN} /usr/local/bin/bazel
+
+########################
+# Final image for proxy
+########################
+
+FROM build_tools
+
+ENV LLVM_DIRECTORY=/usr/lib/llvm
+ENV PATH=${LLVM_DIRECTORY}/bin:$PATH
+
+# binary dependencies to build envoy at v1.12.0
+# https://github.com/envoyproxy/envoy/blob/v1.12.0/bazel/README.md
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    autoconf \
+    automake \
+    cmake \
+    libtool \
+    ninja-build \
+    python \
+    unzip \
+    virtualenv
+
+COPY --from=bazel_context /usr/local/bin /usr/local/bin
+COPY --from=clang_context ${LLVM_DIRECTORY}/lib ${LLVM_DIRECTORY}/lib
+COPY --from=clang_context ${LLVM_DIRECTORY}/bin ${LLVM_DIRECTORY}/bin
+COPY --from=clang_context ${LLVM_DIRECTORY}/include ${LLVM_DIRECTORY}/include
+
+RUN echo "${LLVM_DIRECTORY}/lib" | tee /etc/ld.so.conf.d/llvm.conf
+RUN ldconfig
 
 WORKDIR /
 

--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -435,9 +435,15 @@ ENTRYPOINT ["/usr/local/bin/docker-entrypoint"]
 # Clang+LLVM
 ##############
 
-FROM ubuntu:xenial as clang_context
+FROM ubuntu:bionic as clang_context
 
-RUN apt-get update && apt-get install -y xz-utils
+# hadolint ignore=DL3008
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    xz-utils \
+    wget \
+    ca-certificates \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
 
 ENV LLVM_VERSION=9.0.0
 ENV LLVM_TARGET=x86_64-linux-gnu-ubuntu-16.04
@@ -447,8 +453,8 @@ ENV LLVM_ARCHIVE=clang+llvm-${LLVM_VERSION}-${LLVM_TARGET}
 ENV LLVM_URL=${LLVM_BASE_URL}/${LLVM_ARCHIVE}.tar.xz
 ENV LLVM_DIRECTORY=/usr/lib/llvm
 
-ADD ${LLVM_URL} /tmp
-RUN tar -xJf /tmp/${LLVM_ARCHIVE}.tar.xz -C /tmp
+RUN wget ${LLVM_URL}
+RUN tar -xJf ${LLVM_ARCHIVE}.tar.xz -C /tmp
 RUN mkdir -p ${LLVM_DIRECTORY}
 RUN mv /tmp/${LLVM_ARCHIVE}/* ${LLVM_DIRECTORY}/
 
@@ -456,16 +462,23 @@ RUN mv /tmp/${LLVM_ARCHIVE}/* ${LLVM_DIRECTORY}/
 # Bazel
 ###########
 
-FROM ubuntu:xenial as bazel_context
+FROM ubuntu:bionic as bazel_context
 
 ENV BAZELISK_VERSION="v1.0"
 ENV BAZELISK_BASE_URL="https://github.com/bazelbuild/bazelisk/releases/download"
 ENV BAZELISK_BIN="bazelisk-linux-amd64"
 ENV BAZELISK_URL="${BAZELISK_BASE_URL}/${BAZELISK_VERSION}/${BAZELISK_BIN}"
 
-ADD ${BAZELISK_URL} /tmp
-RUN chmod +x /tmp/${BAZELISK_BIN}
-RUN mv /tmp/${BAZELISK_BIN} /usr/local/bin/bazel
+# hadolint ignore=DL3008
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    wget \
+    ca-certificates \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN wget ${BAZELISK_URL}
+RUN chmod +x ${BAZELISK_BIN}
+RUN mv ${BAZELISK_BIN} /usr/local/bin/bazel
 
 ########################
 # Final image for proxy
@@ -478,6 +491,7 @@ ENV PATH=${LLVM_DIRECTORY}/bin:$PATH
 
 # binary dependencies to build envoy at v1.12.0
 # https://github.com/envoyproxy/envoy/blob/v1.12.0/bazel/README.md
+# hadolint ignore=DL3008
 RUN apt-get update && apt-get install -y --no-install-recommends \
     autoconf \
     automake \
@@ -486,13 +500,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ninja-build \
     python \
     unzip \
-    virtualenv
+    virtualenv \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
 
 COPY --from=bazel_context /usr/local/bin /usr/local/bin
 COPY --from=clang_context ${LLVM_DIRECTORY}/lib ${LLVM_DIRECTORY}/lib
 COPY --from=clang_context ${LLVM_DIRECTORY}/bin ${LLVM_DIRECTORY}/bin
 COPY --from=clang_context ${LLVM_DIRECTORY}/include ${LLVM_DIRECTORY}/include
 
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN echo "${LLVM_DIRECTORY}/lib" | tee /etc/ld.so.conf.d/llvm.conf
 RUN ldconfig
 

--- a/docker/build-tools/build-and-push.sh
+++ b/docker/build-tools/build-and-push.sh
@@ -22,7 +22,10 @@ DATE=$(date +%Y-%m-%dT%H-%M-%S)
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
 VERSION="${BRANCH}-${DATE}"
 
-${CONTAINER_CLI} build --build-arg "ISTIO_TOOLS_BRANCH=${BRANCH}" -t "${HUB}/build-tools:${VERSION}" -t "${HUB}/build-tools:${BRANCH}-latest" .
+${CONTAINER_CLI} build --target build_tools --build-arg "ISTIO_TOOLS_BRANCH=${BRANCH}" -t "${HUB}/build-tools:${VERSION}" -t "${HUB}/build-tools:${BRANCH}-latest" .
+${CONTAINER_CLI} build --build-arg "ISTIO_TOOLS_BRANCH=${BRANCH}" -t "${HUB}/build-tools-proxy:${VERSION}" -t "${HUB}/build-tools-proxy:${BRANCH}-latest" .
 
 ${CONTAINER_CLI} push "${HUB}/build-tools:${VERSION}"
 ${CONTAINER_CLI} push "${HUB}/build-tools:${BRANCH}-latest"
+${CONTAINER_CLI} push "${HUB}/build-tools-proxy:${VERSION}"
+${CONTAINER_CLI} push "${HUB}/build-tools-proxy:${BRANCH}-latest"


### PR DESCRIPTION
Create a new builder image for proxy which is built from build-tools. This is to consolidate istio/proxy build image with other istio repos, so that it could benefit from the common targets like golang lint and make maintenance easier.