### PR TITLE
fix Unable to use a TTY - input is not a terminal or the right kind of file

### DIFF
--- a/perf/benchmark/run_benchmark_job.sh
+++ b/perf/benchmark/run_benchmark_job.sh
@@ -77,7 +77,8 @@ function get_benchmark_data() {
   pipenv run python3 runner.py ${CONN} ${QPS} ${DURATION} ${EXTRA_ARGS} ${FLAME_GRAGH_ARG} ${MIXER_MODE}
   collect_metrics
 
-  if ${FLAME_GRAGH_ARG} = "--perf=true"; then
+  if [[ "${FLAME_GRAGH_ARG}" == "--perf=true" ]]; then
+    echo "collect flame graph debugging........"
     collect_flame_graph
   fi
 
@@ -165,8 +166,8 @@ QPS=1000
 METRICS=(p50 p90 p99)
 get_benchmark_data
 # restart proxy after each group(two sets)
-kubectl exec -it -n twopods "${FORTIO_CLIENT_POD}" -c istio-proxy -- curl http://localhost:15000/quitquitquit -X POST
-kubectl exec -it -n twopods "${FORTIO_SERVER_POD}" -c istio-proxy -- curl http://localhost:15000/quitquitquit -X POST
+kubectl exec -it -n twopods "${FORTIO_CLIENT_POD}" -c istio-proxy -- curl http://localhost:15000/quitquitquit -X POST ./bin/sh
+kubectl exec -it -n twopods "${FORTIO_SERVER_POD}" -c istio-proxy -- curl http://localhost:15000/quitquitquit -X POST ./bin/sh
 
 # Configuration Set3: CPU and memory with mixer disabled
 kubectl -n istio-system get cm istio -o yaml > /tmp/meshconfig.yaml

--- a/perf/benchmark/run_benchmark_job.sh
+++ b/perf/benchmark/run_benchmark_job.sh
@@ -78,7 +78,7 @@ function get_benchmark_data() {
   collect_metrics
 
   if [[ "${FLAME_GRAGH_ARG}" == "--perf=true" ]]; then
-    echo "collect flame graph debugging........"
+    echo "collect flame graph ..."
     collect_flame_graph
   fi
 
@@ -166,8 +166,8 @@ QPS=1000
 METRICS=(p50 p90 p99)
 get_benchmark_data
 # restart proxy after each group(two sets)
-kubectl exec -it -n twopods "${FORTIO_CLIENT_POD}" -c istio-proxy -- curl http://localhost:15000/quitquitquit -X POST ./bin/sh
-kubectl exec -it -n twopods "${FORTIO_SERVER_POD}" -c istio-proxy -- curl http://localhost:15000/quitquitquit -X POST ./bin/sh
+kubectl exec -n twopods "${FORTIO_CLIENT_POD}" -c istio-proxy -- curl http://localhost:15000/quitquitquit -X POST
+kubectl exec -n twopods "${FORTIO_SERVER_POD}" -c istio-proxy -- curl http://localhost:15000/quitquitquit -X POST
 
 # Configuration Set3: CPU and memory with mixer disabled
 kubectl -n istio-system get cm istio -o yaml > /tmp/meshconfig.yaml

--- a/perf/benchmark/runner/runner.py
+++ b/perf/benchmark/runner/runner.py
@@ -247,7 +247,7 @@ def kubectl_exec(pod, remote_cmd, runfn=run_command, container=None):
     c = ""
     if container is not None:
         c = "-c " + container
-    cmd = "kubectl --namespace {namespace} exec -i -t {pod} {c} -- {remote_cmd}".format(
+    cmd = "kubectl --namespace {namespace} exec -i -t {pod} {c} -- {remote_cmd} ./bin/sh".format(
         pod=pod,
         remote_cmd=remote_cmd,
         c=c,

--- a/perf/benchmark/runner/runner.py
+++ b/perf/benchmark/runner/runner.py
@@ -247,7 +247,7 @@ def kubectl_exec(pod, remote_cmd, runfn=run_command, container=None):
     c = ""
     if container is not None:
         c = "-c " + container
-    cmd = "kubectl --namespace {namespace} exec -i -t {pod} {c} -- {remote_cmd} ./bin/sh".format(
+    cmd = "kubectl --namespace {namespace} exec {pod} {c} -- {remote_cmd}".format(
         pod=pod,
         remote_cmd=remote_cmd,
         c=c,


### PR DESCRIPTION
Error logs:
```
kubectl --namespace twopods exec -i -t fortioclient-6c4b79b7cd-kqzpg  -- fortio load -c 16 -qps 2000 -t 240s -a -r 0.00005  -httpbufferkb=128 -labels b4e95e48_qps_2000_c_16_1024_nomixer_both http://fortioserver:8080/echo?size=1024Defaulting container name to captured.
Use 'kubectl describe pod/fortioclient-6c4b79b7cd-kqzpg -n twopods' to see all of the containers in this pod.
Unable to use a TTY - input is not a terminal or the right kind of file
```
reference: https://github.com/docker/for-linux/issues/246