### PR TITLE
Force the branch to master.

### DIFF
--- a/docker/build-tools/build-and-push.sh
+++ b/docker/build-tools/build-and-push.sh
@@ -19,7 +19,7 @@ CONTAINER_CLI=${CONTAINER_CLI:-docker}
 
 HUB=${HUB:-gcr.io/istio-testing}
 DATE=$(date +%Y-%m-%dT%H-%M-%S)
-BRANCH=$(git rev-parse --abbrev-ref HEAD)
+BRANCH=master
 VERSION="${BRANCH}-${DATE}"
 
 ${CONTAINER_CLI} build --target build_tools --build-arg "ISTIO_TOOLS_BRANCH=${BRANCH}" -t "${HUB}/build-tools:${VERSION}" -t "${HUB}/build-tools:${BRANCH}-latest" .


### PR DESCRIPTION
We can't rely on the current repo's current branch name to decide
what we build against. It breaks if you have a branch with a non-official
name. When branching for a release, we'll need to update this branch name
atring in case we want to build a branched container image.