### PR TITLE
Add v2 telemetry with v1 tcp SD configs

### DIFF
--- a/perf/istio-install/create_sa.sh
+++ b/perf/istio-install/create_sa.sh
@@ -43,6 +43,6 @@ GCP_SA=${1:?"Name of the gcp service account to bind"}
 
 gc iam service-accounts create "${GCP_SA}"
 
-for role in compute.networkViewer logging.logWriter monitoring.metricWriter storage.objectViewer cloudtrace.agent; do
+for role in compute.networkViewer logging.logWriter monitoring.metricWriter storage.objectViewer cloudtrace.agent meshtelemetry.reporter; do
 	gc projects add-iam-policy-binding "${PROJECT_ID}" --role "roles/${role}" --member "serviceAccount:${GCP_SA}@${PROJECT_ID}.iam.gserviceaccount.com"
 done

--- a/perf/istio-install/telemetry/metadata_exchange_filter.yaml
+++ b/perf/istio-install/telemetry/metadata_exchange_filter.yaml
@@ -1,0 +1,24 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: metadata-exchange
+spec:
+  configPatches:
+    - applyTo: HTTP_FILTER
+      match:
+        context: ANY # inbound, outbound, and gateway
+        listener:
+          filterChain:
+            filter:
+              name: "envoy.http_connection_manager"
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: envoy.filters.http.wasm
+          config:
+            config:
+              configuration: envoy.wasm.metadata_exchange
+              vm_config:
+                runtime: envoy.wasm.runtime.null
+                code:
+                  inline_string: envoy.wasm.metadata_exchange

--- a/perf/istio-install/telemetry/stackdriver_filter.yaml
+++ b/perf/istio-install/telemetry/stackdriver_filter.yaml
@@ -1,0 +1,75 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: stackdriver-filter
+spec:
+  configPatches:
+    - applyTo: HTTP_FILTER
+      match:
+        context: SIDECAR_OUTBOUND
+        listener:
+          filterChain:
+            filter:
+              name: "envoy.http_connection_manager"
+              subFilter:
+                name: "envoy.router"
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: envoy.filters.http.wasm
+          config:
+            config:
+              root_id: stackdriver_outbound
+              configuration: |
+                {"enable_mesh_edges_reporting": true, "meshEdgesReportingDuration": "47s"}
+              vm_config:
+                vm_id: stackdriver_outbound
+                runtime: envoy.wasm.runtime.null
+                code:
+                  inline_string: envoy.wasm.null.stackdriver
+    - applyTo: HTTP_FILTER
+      match:
+        context: SIDECAR_INBOUND
+        listener:
+          filterChain:
+            filter:
+              name: "envoy.http_connection_manager"
+              subFilter:
+                name: "envoy.router"
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: envoy.filters.http.wasm
+          config:
+            config:
+              root_id: stackdriver_inbound
+              configuration: |
+                {"enable_mesh_edges_reporting": true, "meshEdgesReportingDuration": "47s"}
+              vm_config:
+                vm_id: stackdriver_inbound
+                runtime: envoy.wasm.runtime.null
+                code:
+                  inline_string: envoy.wasm.null.stackdriver
+    - applyTo: HTTP_FILTER
+      match:
+        context: GATEWAY
+        listener:
+          filterChain:
+            filter:
+              name: "envoy.http_connection_manager"
+              subFilter:
+                name: "envoy.router"
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: envoy.filters.http.wasm
+          config:
+            config:
+              root_id: stackdriver_outbound
+              configuration: |
+                {"enable_mesh_edges_reporting": true, "meshEdgesReportingDuration": "47s"}
+              vm_config:
+                vm_id: stackdriver_outbound
+                runtime: envoy.wasm.runtime.null
+                code:
+                  inline_string: envoy.wasm.null.stackdriver

--- a/perf/istio-install/telemetry/stackdriver_tcp_v1.yaml
+++ b/perf/istio-install/telemetry/stackdriver_tcp_v1.yaml
@@ -1,0 +1,815 @@
+# Source: mixer-telemetry/templates/stackdriver.yaml
+
+apiVersion: "config.istio.io/v1alpha2"
+kind: handler
+metadata:
+  name: stackdriver
+  labels:
+    app: istio-telemetry
+    release: release-name
+spec:
+  compiledAdapter: stackdriver
+  params:
+    pushInterval: 10s
+    metricInfo:
+      server-request-count.instance.service-graph00:
+        # Due to a bug in gogoproto deserialization, Enums in maps must be
+        # specified by their integer value, not variant name. See
+        # https://github.com/googleapis/googleapis/blob/master/google/api/metric.proto
+        # MetricKind and ValueType for the values to provide.
+        kind: 3 # CUMULATIVE
+        value: 2 # INT64
+        metric_type: "istio.io/service/server/request_count"
+      server-request-bytes.instance.service-graph00:
+        kind: 3 # CUMULATIVE
+        value: 5 # DISTRIBUTION
+        buckets:
+          exponentialBuckets:
+            numFiniteBuckets: 20
+            scale: 1
+            growthFactor: 2
+        metric_type: "istio.io/service/server/request_bytes"
+      server-response-bytes.instance.service-graph00:
+        kind: 3 # CUMULATIVE
+        value: 5 # DISTRIBUTION
+        buckets:
+          exponentialBuckets:
+            numFiniteBuckets: 20
+            scale: 1
+            growthFactor: 2
+        metric_type: "istio.io/service/server/response_bytes"
+      server-response-latencies.instance.service-graph00:
+        kind: 3 # CUMULATIVE
+        value: 5 # DISTRIBUTION
+        buckets:
+          exponentialBuckets:
+            numFiniteBuckets: 20
+            scale: 1
+            growthFactor: 2
+        metric_type: "istio.io/service/server/response_latencies"
+      server-received-bytes-count.instance.service-graph00:
+        kind: 3 # CUMULATIVE
+        value: 2 # INT64
+        metric_type: "istio.io/service/server/received_bytes_count"
+      server-sent-bytes-count.instance.service-graph00:
+        kind: 3 # CUMULATIVE
+        value: 2 # INT64
+        metric_type: "istio.io/service/server/sent_bytes_count"
+      client-request-count.instance.service-graph00:
+        kind: 3 # CUMULATIVE
+        value: 2 # INT64
+        metric_type: "istio.io/service/client/request_count"
+      client-request-bytes.instance.service-graph00:
+        kind: 3 # CUMULATIVE
+        value: 5 # DISTRIBUTION
+        buckets:
+          exponentialBuckets:
+            numFiniteBuckets: 20
+            scale: 1
+            growthFactor: 2
+        metric_type: "istio.io/service/client/request_bytes"
+      client-response-bytes.instance.service-graph00:
+        kind: 3 # CUMULATIVE
+        value: 5 # DISTRIBUTION
+        buckets:
+          exponentialBuckets:
+            numFiniteBuckets: 20
+            scale: 1
+            growthFactor: 2
+        metric_type: "istio.io/service/client/response_bytes"
+      client-roundtrip-latencies.instance.service-graph00:
+        kind: 3 # CUMULATIVE
+        value: 5 # DISTRIBUTION
+        buckets:
+          exponentialBuckets:
+            numFiniteBuckets: 20
+            scale: 1
+            growthFactor: 2
+        metric_type: "istio.io/service/client/roundtrip_latencies"
+      client-received-bytes-count.instance.service-graph00:
+        kind: 3 # CUMULATIVE
+        value: 2 # INT64
+        metric_type: "istio.io/service/client/received_bytes_count"
+      client-sent-bytes-count.instance.service-graph00:
+        kind: 3 # CUMULATIVE
+        value: 2 # INT64
+        metric_type: "istio.io/service/client/sent_bytes_count"
+    logInfo:
+      server-accesslog-stackdriver.instance.service-graph00:
+        labelNames:
+        - mesh_uid
+        - source_uid
+        - source_ip
+        - source_app
+        - source_principal
+        - source_name
+        - source_workload
+        - source_namespace
+        - source_owner
+        - destination_uid
+        - destination_app
+        - destination_ip
+        - destination_service_host
+        - destination_workload
+        - destination_name
+        - destination_namespace
+        - destination_owner
+        - destination_principal
+        - api_name
+        - api_version
+        - api_claims
+        - api_key
+        - request_operation
+        - protocol
+        - method
+        - url
+        - response_code
+        - response_size
+        - request_size
+        - request_id
+        - latency
+        - service_authentication_policy
+        - user_agent
+        - response_timestamp
+        - received_bytes
+        - sent_bytes
+        - referer
+      server-tcp-accesslog-stackdriver.instance.service-graph00:
+        labelNames:
+        - mesh_uid
+        - connection_id
+        - connection_event
+        - source_uid
+        - source_ip
+        - source_app
+        - source_principal
+        - source_name
+        - source_workload
+        - source_namespace
+        - source_owner
+        - destination_uid
+        - destination_app
+        - destination_ip
+        - destination_service_host
+        - destination_workload
+        - destination_name
+        - destination_namespace
+        - destination_owner
+        - destination_principal
+        - protocol
+        - connction_duration
+        - service_authentication_policy
+        - received_bytes
+        - sent_bytes
+        - total_received_bytes
+        - total_sent_bytes
+---
+#################################################
+############## Metric Config ####################
+#################################################
+apiVersion: "config.istio.io/v1alpha2"
+kind: rule
+metadata:
+  name: stackdriver-server
+  labels:
+    app: istio-telemetry
+    release: release-name
+spec:
+  match: (context.protocol == "http" || context.protocol == "grpc") && (context.reporter.kind | "inbound" == "inbound")
+  actions:
+  - handler: stackdriver
+    instances:
+    - server-request-count
+    - server-request-bytes
+    - server-response-bytes
+    - server-response-latencies
+---
+apiVersion: "config.istio.io/v1alpha2"
+kind: rule
+metadata:
+  name: stackdriver-client
+  labels:
+    app: istio-telemetry
+    release: release-name
+spec:
+  match: (context.protocol == "http" || context.protocol == "grpc") && (context.reporter.kind | "inbound" == "outbound")
+  actions:
+  - handler: stackdriver
+    instances:
+    - client-request-count
+    - client-request-bytes
+    - client-response-bytes
+    - client-roundtrip-latencies
+---
+apiVersion: "config.istio.io/v1alpha2"
+kind: rule
+metadata:
+  name: stackdriver-tcp-server
+  labels:
+    app: istio-telemetry
+    release: release-name
+spec:
+  match: context.protocol == "tcp" && (context.reporter.kind | "inbound" == "inbound")
+  actions:
+  - handler: stackdriver
+    instances:
+    - server-received-bytes-count
+    - server-sent-bytes-count
+---
+apiVersion: "config.istio.io/v1alpha2"
+kind: rule
+metadata:
+  name: stackdriver-tcp-client
+  labels:
+    app: istio-telemetry
+    release: release-name
+spec:
+  match: context.protocol == "tcp" && (context.reporter.kind | "inbound" == "outbound")
+  actions:
+  - handler: stackdriver
+    instances:
+    - client-received-bytes-count
+    - client-sent-bytes-count
+---
+apiVersion: "config.istio.io/v1alpha2"
+kind: instance
+metadata:
+  name: server-request-count
+  labels:
+    app: istio-telemetry
+    release: release-name
+spec:
+  compiledTemplate: metric
+  params:
+    value: "1"
+    dimensions:
+      mesh_uid: '""'
+      destination_service_name: destination.service.name | "unknown"
+      destination_service_namespace: destination.service.namespace | "unknown"
+      destination_port: destination.port | 0
+      request_operation: conditional((context.protocol | "unknown") == "grpc", request.path | "unknown", request.method | "unknown")
+      request_protocol: context.protocol | "unknown"
+      api_version: api.version | "unknown"
+      api_name: api.service | "unknown"
+      response_code: response.code | 0
+      service_authentication_policy: conditional((context.reporter.kind | "inbound") == "outbound", "unknown", conditional(connection.mtls | false, "mutual_tls", "none"))
+      source_workload_namespace: source.workload.namespace | "unknown"
+      source_workload_name: source.workload.name | "unknown"
+      source_owner: source.owner | "unknown"
+      destination_workload_namespace: destination.workload.namespace | "unknown"
+      destination_workload_name: destination.workload.name | "unknown"
+      destination_owner: destination.owner | "unknown"
+      destination_principal: destination.principal | "unknown"
+      source_principal: source.principal | "unknown"
+    monitoredResourceType: '"k8s_container"'
+    monitoredResourceDimensions:
+      project_id: '""'
+      cluster_name: '""'
+      namespace_name: destination.workload.namespace | "unknown"
+      location: '""'
+      container_name: conditional((destination.name | "unknown").startsWith("istio-telemetry") || (destination.name | "unknown").startsWith("istio-policy"), "mixer", destination.container.name | "unknown")
+      pod_name: destination.name | "unknown"
+---
+apiVersion: "config.istio.io/v1alpha2"
+kind: instance
+metadata:
+  name: client-request-count
+  labels:
+    app: istio-telemetry
+    release: release-name
+spec:
+  compiledTemplate: metric
+  params:
+    value: "1"
+    dimensions:
+      mesh_uid: '""'
+      destination_service_name: destination.service.name | "unknown"
+      destination_service_namespace: destination.service.namespace | "unknown"
+      destination_port: destination.port | 0
+      request_operation: conditional((context.protocol | "unknown") == "grpc", request.path | "unknown", request.method | "unknown")
+      request_protocol: context.protocol | "unknown"
+      api_version: api.version | "unknown"
+      api_name: api.service | "unknown"
+      response_code: response.code | 0
+      service_authentication_policy: conditional((context.reporter.kind | "inbound") == "outbound", "unknown", conditional(connection.mtls | false, "mutual_tls", "none"))
+      source_workload_namespace: source.workload.namespace | "unknown"
+      source_workload_name: source.workload.name | "unknown"
+      source_owner: source.owner | "unknown"
+      destination_workload_namespace: destination.workload.namespace | "unknown"
+      destination_workload_name: destination.workload.name | "unknown"
+      destination_owner: destination.owner | "unknown"
+      destination_principal: destination.principal | "unknown"
+      source_principal: source.principal | "unknown"
+    monitoredResourceType: '"k8s_pod"'
+    monitoredResourceDimensions:
+      project_id: '""'
+      cluster_name: '""'
+      namespace_name: source.workload.namespace | "unknown"
+      location: '""'
+      pod_name: source.name | "unknown"
+---
+apiVersion: "config.istio.io/v1alpha2"
+kind: instance
+metadata:
+  name: server-request-bytes
+  labels:
+    app: istio-telemetry
+    release: release-name
+spec:
+  compiledTemplate: metric
+  params:
+    value: request.total_size
+    dimensions:
+      mesh_uid: '""'
+      destination_service_name: destination.service.name | "unknown"
+      destination_service_namespace: destination.service.namespace | "unknown"
+      destination_port: destination.port | 0
+      request_operation: conditional((context.protocol | "unknown") == "grpc", request.path | "unknown", request.method | "unknown")
+      request_protocol: context.protocol | "unknown"
+      api_version: api.version | "unknown"
+      api_name: api.service | "unknown"
+      response_code: response.code | 0
+      service_authentication_policy: conditional((context.reporter.kind | "inbound") == "outbound", "unknown", conditional(connection.mtls | false, "mutual_tls", "none"))
+      source_workload_namespace: source.workload.namespace | "unknown"
+      source_workload_name: source.workload.name | "unknown"
+      source_owner: source.owner | "unknown"
+      destination_workload_namespace: destination.workload.namespace | "unknown"
+      destination_workload_name: destination.workload.name | "unknown"
+      destination_owner: destination.owner | "unknown"
+      destination_principal: destination.principal | "unknown"
+      source_principal: source.principal | "unknown"
+    monitoredResourceType: '"k8s_container"'
+    monitoredResourceDimensions:
+      project_id: '""'
+      cluster_name: '""'
+      namespace_name: destination.workload.namespace | "unknown"
+      location: '""'
+      container_name: conditional((destination.name | "unknown").startsWith("istio-telemetry") || (destination.name | "unknown").startsWith("istio-policy"), "mixer", destination.container.name | "unknown")
+      pod_name: destination.name | "unknown"
+---
+apiVersion: "config.istio.io/v1alpha2"
+kind: instance
+metadata:
+  name: client-request-bytes
+  labels:
+    app: istio-telemetry
+    release: release-name
+spec:
+  compiledTemplate: metric
+  params:
+    value: request.total_size
+    dimensions:
+      mesh_uid: '""'
+      destination_service_name: destination.service.name | "unknown"
+      destination_service_namespace: destination.service.namespace | "unknown"
+      destination_port: destination.port | 0
+      request_operation: conditional((context.protocol | "unknown") == "grpc", request.path | "unknown", request.method | "unknown")
+      request_protocol: context.protocol | "unknown"
+      api_version: api.version | "unknown"
+      api_name: api.service | "unknown"
+      response_code: response.code | 0
+      service_authentication_policy: conditional((context.reporter.kind | "inbound") == "outbound", "unknown", conditional(connection.mtls | false, "mutual_tls", "none"))
+      source_workload_namespace: source.workload.namespace | "unknown"
+      source_workload_name: source.workload.name | "unknown"
+      source_owner: source.owner | "unknown"
+      destination_workload_namespace: destination.workload.namespace | "unknown"
+      destination_workload_name: destination.workload.name | "unknown"
+      destination_owner: destination.owner | "unknown"
+      destination_principal: destination.principal | "unknown"
+      source_principal: source.principal | "unknown"
+    monitoredResourceType: '"k8s_pod"'
+    monitoredResourceDimensions:
+      project_id: '""'
+      cluster_name: '""'
+      namespace_name: source.workload.namespace | "unknown"
+      location: '""'
+      pod_name: source.name | "unknown"
+---
+apiVersion: "config.istio.io/v1alpha2"
+kind: instance
+metadata:
+  name: server-response-bytes
+  labels:
+    app: istio-telemetry
+    release: release-name
+spec:
+  compiledTemplate: metric
+  params:
+    value: response.total_size
+    dimensions:
+      mesh_uid: '""'
+      destination_service_name: destination.service.name | "unknown"
+      destination_service_namespace: destination.service.namespace | "unknown"
+      destination_port: destination.port | 0
+      request_operation: conditional((context.protocol | "unknown") == "grpc", request.path | "unknown", request.method | "unknown")
+      request_protocol: context.protocol | "unknown"
+      api_version: api.version | "unknown"
+      api_name: api.service | "unknown"
+      response_code: response.code | 0
+      service_authentication_policy: conditional((context.reporter.kind | "inbound") == "outbound", "unknown", conditional(connection.mtls | false, "mutual_tls", "none"))
+      source_workload_namespace: source.workload.namespace | "unknown"
+      source_workload_name: source.workload.name | "unknown"
+      source_owner: source.owner | "unknown"
+      destination_workload_namespace: destination.workload.namespace | "unknown"
+      destination_workload_name: destination.workload.name | "unknown"
+      destination_owner: destination.owner | "unknown"
+      destination_principal: destination.principal | "unknown"
+      source_principal: source.principal | "unknown"
+    monitoredResourceType: '"k8s_container"'
+    monitoredResourceDimensions:
+      project_id: '""'
+      cluster_name: '""'
+      namespace_name: destination.workload.namespace | "unknown"
+      location: '""'
+      container_name: conditional((destination.name | "unknown").startsWith("istio-telemetry") || (destination.name | "unknown").startsWith("istio-policy"), "mixer", destination.container.name | "unknown")
+      pod_name: destination.name | "unknown"
+---
+apiVersion: "config.istio.io/v1alpha2"
+kind: instance
+metadata:
+  name: client-response-bytes
+  labels:
+    app: istio-telemetry
+    release: release-name
+spec:
+  compiledTemplate: metric
+  params:
+    value: response.total_size
+    dimensions:
+      mesh_uid: '""'
+      destination_service_name: destination.service.name | "unknown"
+      destination_service_namespace: destination.service.namespace | "unknown"
+      destination_port: destination.port | 0
+      request_operation: conditional((context.protocol | "unknown") == "grpc", request.path | "unknown", request.method | "unknown")
+      request_protocol: context.protocol | "unknown"
+      api_version: api.version | "unknown"
+      api_name: api.service | "unknown"
+      response_code: response.code | 0
+      service_authentication_policy: conditional((context.reporter.kind | "inbound") == "outbound", "unknown", conditional(connection.mtls | false, "mutual_tls", "none"))
+      source_workload_namespace: source.workload.namespace | "unknown"
+      source_workload_name: source.workload.name | "unknown"
+      source_owner: source.owner | "unknown"
+      destination_workload_namespace: destination.workload.namespace | "unknown"
+      destination_workload_name: destination.workload.name | "unknown"
+      destination_owner: destination.owner | "unknown"
+      destination_principal: destination.principal | "unknown"
+      source_principal: source.principal | "unknown"
+    monitoredResourceType: '"k8s_pod"'
+    monitoredResourceDimensions:
+      project_id: '""'
+      cluster_name: '""'
+      namespace_name: source.workload.namespace | "unknown"
+      location: '""'
+      pod_name: source.name | "unknown"
+---
+apiVersion: "config.istio.io/v1alpha2"
+kind: instance
+metadata:
+  name: server-response-latencies
+  labels:
+    app: istio-telemetry
+    release: release-name
+spec:
+  compiledTemplate: metric
+  params:
+    value: response.duration
+    dimensions:
+      mesh_uid: '""'
+      destination_service_name: destination.service.name | "unknown"
+      destination_service_namespace: destination.service.namespace | "unknown"
+      destination_port: destination.port | 0
+      request_operation: conditional((context.protocol | "unknown") == "grpc", request.path | "unknown", request.method | "unknown")
+      request_protocol: context.protocol | "unknown"
+      api_version: api.version | "unknown"
+      api_name: api.service | "unknown"
+      response_code: response.code | 0
+      service_authentication_policy: conditional((context.reporter.kind | "inbound") == "outbound", "unknown", conditional(connection.mtls | false, "mutual_tls", "none"))
+      source_workload_namespace: source.workload.namespace | "unknown"
+      source_workload_name: source.workload.name | "unknown"
+      source_owner: source.owner | "unknown"
+      destination_workload_namespace: destination.workload.namespace | "unknown"
+      destination_workload_name: destination.workload.name | "unknown"
+      destination_owner: destination.owner | "unknown"
+      destination_principal: destination.principal | "unknown"
+      source_principal: source.principal | "unknown"
+    monitoredResourceType: '"k8s_container"'
+    monitoredResourceDimensions:
+      project_id: '""'
+      cluster_name: '""'
+      namespace_name: destination.workload.namespace | "unknown"
+      location: '""'
+      container_name: conditional((destination.name | "unknown").startsWith("istio-telemetry") || (destination.name | "unknown").startsWith("istio-policy"), "mixer", destination.container.name | "unknown")
+      pod_name: destination.name | "unknown"
+---
+apiVersion: "config.istio.io/v1alpha2"
+kind: instance
+metadata:
+  name: client-roundtrip-latencies
+  labels:
+    app: istio-telemetry
+    release: release-name
+spec:
+  compiledTemplate: metric
+  params:
+    value: response.duration
+    dimensions:
+      mesh_uid: '""'
+      destination_service_name: destination.service.name | "unknown"
+      destination_service_namespace: destination.service.namespace | "unknown"
+      destination_port: destination.port | 0
+      request_operation: conditional((context.protocol | "unknown") == "grpc", request.path | "unknown", request.method | "unknown")
+      request_protocol: context.protocol | "unknown"
+      api_version: api.version | "unknown"
+      api_name: api.service | "unknown"
+      response_code: response.code | 0
+      service_authentication_policy: conditional((context.reporter.kind | "inbound") == "outbound", "unknown", conditional(connection.mtls | false, "mutual_tls", "none"))
+      source_workload_namespace: source.workload.namespace | "unknown"
+      source_workload_name: source.workload.name | "unknown"
+      source_owner: source.owner | "unknown"
+      destination_workload_namespace: destination.workload.namespace | "unknown"
+      destination_workload_name: destination.workload.name | "unknown"
+      destination_owner: destination.owner | "unknown"
+      destination_principal: destination.principal | "unknown"
+      source_principal: source.principal | "unknown"
+    monitoredResourceType: '"k8s_pod"'
+    monitoredResourceDimensions:
+      project_id: '""'
+      cluster_name: '""'
+      namespace_name: source.workload.namespace | "unknown"
+      location: '""'
+      pod_name: source.name | "unknown"
+---
+apiVersion: "config.istio.io/v1alpha2"
+kind: instance
+metadata:
+  name: server-received-bytes-count
+  labels:
+    app: istio-telemetry
+    release: release-name
+spec:
+  compiledTemplate: metric
+  params:
+    value: connection.received.bytes | 0
+    dimensions:
+      mesh_uid: '""'
+      destination_service_name: destination.service.name | "unknown"
+      destination_service_namespace: destination.service.namespace | "unknown"
+      destination_port: destination.port | 0
+      request_protocol: context.protocol | "unknown"
+      service_authentication_policy: conditional((context.reporter.kind | "inbound") == "outbound", "unknown", conditional(connection.mtls | false, "mutual_tls", "none"))
+      source_workload_namespace: source.workload.namespace | "unknown"
+      source_workload_name: source.workload.name | "unknown"
+      source_owner: source.owner | "unknown"
+      destination_workload_namespace: destination.workload.namespace | "unknown"
+      destination_workload_name: destination.workload.name | "unknown"
+      destination_owner: destination.owner | "unknown"
+      destination_principal: destination.principal | "unknown"
+      source_principal: source.principal | "unknown"
+    monitoredResourceType: '"k8s_container"'
+    monitoredResourceDimensions:
+      project_id: '""'
+      cluster_name: '""'
+      namespace_name: destination.workload.namespace | "unknown"
+      location: '""'
+      container_name: conditional((destination.name | "unknown").startsWith("istio-telemetry") || (destination.name | "unknown").startsWith("istio-policy"), "mixer", destination.container.name | "unknown")
+      pod_name: destination.name | "unknown"
+---
+apiVersion: "config.istio.io/v1alpha2"
+kind: instance
+metadata:
+  name: client-received-bytes-count
+  labels:
+    app: istio-telemetry
+    release: release-name
+spec:
+  compiledTemplate: metric
+  params:
+    value: connection.received.bytes | 0
+    dimensions:
+      mesh_uid: '""'
+      destination_service_name: destination.service.name | "unknown"
+      destination_service_namespace: destination.service.namespace | "unknown"
+      destination_port: destination.port | 0
+      request_protocol: context.protocol | "unknown"
+      service_authentication_policy: conditional((context.reporter.kind | "inbound") == "outbound", "unknown", conditional(connection.mtls | false, "mutual_tls", "none"))
+      source_workload_namespace: source.workload.namespace | "unknown"
+      source_workload_name: source.workload.name | "unknown"
+      source_owner: source.owner | "unknown"
+      destination_workload_namespace: destination.workload.namespace | "unknown"
+      destination_workload_name: destination.workload.name | "unknown"
+      destination_owner: destination.owner | "unknown"
+      destination_principal: destination.principal | "unknown"
+      source_principal: source.principal | "unknown"
+    monitoredResourceType: '"k8s_pod"'
+    monitoredResourceDimensions:
+      project_id: '""'
+      cluster_name: '""'
+      namespace_name: source.workload.namespace | "unknown"
+      location: '""'
+      pod_name: source.name | "unknown"
+---
+apiVersion: "config.istio.io/v1alpha2"
+kind: instance
+metadata:
+  name: server-sent-bytes-count
+  labels:
+    app: istio-telemetry
+    release: release-name
+spec:
+  compiledTemplate: metric
+  params:
+    value: connection.sent.bytes | 0
+    dimensions:
+      mesh_uid: '""'
+      destination_service_name: destination.service.name | "unknown"
+      destination_service_namespace: destination.service.namespace | "unknown"
+      destination_port: destination.port | 0
+      request_protocol: context.protocol | "unknown"
+      service_authentication_policy: conditional((context.reporter.kind | "inbound") == "outbound", "unknown", conditional(connection.mtls | false, "mutual_tls", "none"))
+      source_workload_namespace: source.workload.namespace | "unknown"
+      source_workload_name: source.workload.name | "unknown"
+      source_owner: source.owner | "unknown"
+      destination_workload_namespace: destination.workload.namespace | "unknown"
+      destination_workload_name: destination.workload.name | "unknown"
+      destination_owner: destination.owner | "unknown"
+      destination_principal: destination.principal | "unknown"
+      source_principal: source.principal | "unknown"
+    monitoredResourceType: '"k8s_container"'
+    monitoredResourceDimensions:
+      project_id: '""'
+      cluster_name: '""'
+      namespace_name: destination.workload.namespace | "unknown"
+      location: '""'
+      container_name: conditional((destination.name | "unknown").startsWith("istio-telemetry") || (destination.name | "unknown").startsWith("istio-policy"), "mixer", destination.container.name | "unknown")
+      pod_name: destination.name | "unknown"
+---
+apiVersion: "config.istio.io/v1alpha2"
+kind: instance
+metadata:
+  name: client-sent-bytes-count
+  labels:
+    app: istio-telemetry
+    release: release-name
+spec:
+  compiledTemplate: metric
+  params:
+    value: connection.sent.bytes | 0
+    dimensions:
+      mesh_uid: '""'
+      destination_service_name: destination.service.name | "unknown"
+      destination_service_namespace: destination.service.namespace | "unknown"
+      destination_port: destination.port | 0
+      request_protocol: context.protocol | "unknown"
+      service_authentication_policy: conditional((context.reporter.kind | "inbound") == "outbound", "unknown", conditional(connection.mtls | false, "mutual_tls", "none"))
+      source_workload_namespace: source.workload.namespace | "unknown"
+      source_workload_name: source.workload.name | "unknown"
+      source_owner: source.owner | "unknown"
+      destination_workload_namespace: destination.workload.namespace | "unknown"
+      destination_workload_name: destination.workload.name | "unknown"
+      destination_owner: destination.owner | "unknown"
+      destination_principal: destination.principal | "unknown"
+      source_principal: source.principal | "unknown"
+    monitoredResourceType: '"k8s_pod"'
+    monitoredResourceDimensions:
+      project_id: '""'
+      cluster_name: '""'
+      namespace_name: source.workload.namespace | "unknown"
+      location: '""'
+      pod_name: source.name | "unknown"
+---
+apiVersion: "config.istio.io/v1alpha2"
+kind: instance
+metadata:
+  name: server-accesslog-stackdriver
+  labels:
+    app: istio-telemetry
+    release: release-name
+spec:
+  compiledTemplate: logentry
+  params:
+    severity: '"Info"'
+    timestamp: request.time
+    variables:
+      mesh_uid: '""'
+      source_uid: source.uid | ""
+      source_ip: source.ip | ip("0.0.0.0")
+      source_app: source.labels["app"] | ""
+      source_principal: source.principal | ""
+      source_name: source.name | ""
+      source_workload: source.workload.name | ""
+      source_namespace: source.namespace | ""
+      source_owner: source.owner | ""
+      destination_uid: destination.uid | ""
+      destination_app: destination.labels["app"] | ""
+      destination_ip: destination.ip | ip("0.0.0.0")
+      destination_service_host: destination.service.host | ""
+      destination_workload: destination.workload.name | ""
+      destination_name: destination.name | ""
+      destination_namespace: destination.namespace | ""
+      destination_owner: destination.owner | ""
+      destination_principal: destination.principal | ""
+      api_name: api.service | ""
+      api_version: api.version | ""
+      api_claims: request.auth.raw_claims | ""
+      api_key: request.api_key | request.headers["x-api-key"] | ""
+      request_operation: conditional((context.protocol | "unknown") == "grpc", request.path | "unknown", request.method | "unknown")
+      protocol: request.scheme | context.protocol | "http"
+      method: request.method | ""
+      url: request.path | ""
+      response_code: response.code | 0
+      response_size: response.size | 0
+      request_size: request.size | 0
+      request_id: request.headers["x-request-id"] | ""
+      latency: response.duration | "0ms"
+      service_authentication_policy: conditional((context.reporter.kind | "inbound") == "outbound", "unknown", conditional(connection.mtls | false, "mutual_tls", "none"))
+      user_agent: request.useragent | ""
+      response_timestamp: response.time
+      received_bytes: request.total_size | 0
+      sent_bytes: response.total_size | 0
+      referer: request.referer | ""
+    monitored_resource_type: '"k8s_container"'
+    monitoredResourceDimensions:
+      project_id: '""'
+      cluster_name: '""'
+      namespace_name: destination.namespace | "unknown"
+      location: '""'
+      container_name: conditional((destination.name | "unknown").startsWith("istio-telemetry") || (destination.name | "unknown").startsWith("istio-policy"), "mixer", destination.container.name | "unknown")
+      pod_name: destination.name | "unknown"
+---
+apiVersion: "config.istio.io/v1alpha2"
+kind: instance
+metadata:
+  name: server-tcp-accesslog-stackdriver
+  labels:
+    app: istio-telemetry
+    release: release-name
+spec:
+  compiledTemplate: logentry
+  params:
+    severity: '"Info"'
+    timestamp: context.time | timestamp("2017-01-01T00:00:00Z")
+    variables:
+      mesh_uid: '""'
+      source_uid: source.uid | ""
+      connection_id: connection.id | ""
+      connection_event: connection.event | ""
+      source_ip: source.ip | ip("0.0.0.0")
+      source_app: source.labels["app"] | ""
+      source_principal: source.principal | ""
+      source_name: source.name | ""
+      source_workload: source.workload.name | ""
+      source_namespace: source.namespace | ""
+      source_owner: source.owner | ""
+      destination_uid: destination.uid | ""
+      destination_app: destination.labels["app"] | ""
+      destination_ip: destination.ip | ip("0.0.0.0")
+      destination_service_host: destination.service.host | ""
+      destination_workload: destination.workload.name | ""
+      destination_name: destination.name | ""
+      destination_namespace: destination.namespace | ""
+      destination_owner: destination.owner | ""
+      destination_principal: destination.principal | ""
+      protocol: context.protocol | "tcp"
+      connction_duration: connection.duration | "0ms"
+      service_authentication_policy: conditional((context.reporter.kind | "inbound") == "outbound", "unknown", conditional(connection.mtls | false, "mutual_tls", "none"))
+      received_bytes: connection.received.bytes | 0
+      sent_bytes: connection.sent.bytes | 0
+      total_received_bytes: connection.received.bytes_total | 0
+      total_sent_bytes: connection.sent.bytes_total | 0
+    monitored_resource_type: '"k8s_container"'
+    monitoredResourceDimensions:
+      project_id: '""'
+      cluster_name: '""'
+      namespace_name: destination.namespace | "unknown"
+      location: '""'
+      container_name: conditional((destination.name | "unknown").startsWith("istio-telemetry") || (destination.name | "unknown").startsWith("istio-policy"), "mixer", destination.container.name | "unknown")
+      pod_name: destination.name | "unknown"
+---
+apiVersion: "config.istio.io/v1alpha2"
+kind: rule
+metadata:
+  name: stackdriver-log
+  labels:
+    app: istio-telemetry
+    release: release-name
+spec:
+  match: (context.protocol == "http" || context.protocol == "grpc") && (context.reporter.kind | "inbound" == "inbound")
+  actions:
+  - handler: stackdriver
+    instances:
+    - server-accesslog-stackdriver
+---
+apiVersion: "config.istio.io/v1alpha2"
+kind: rule
+metadata:
+  name: stackdriver-log-tcp
+  labels:
+    app: istio-telemetry
+    release: release-name
+spec:
+  match: (context.protocol == "tcp") && (context.reporter.kind | "inbound" == "inbound")
+  actions:
+  - handler: stackdriver
+    instances:
+    - server-tcp-accesslog-stackdriver
+---

--- a/perf/istio-install/telemetry/stackdriver_tcp_v1.yaml
+++ b/perf/istio-install/telemetry/stackdriver_tcp_v1.yaml
@@ -12,7 +12,7 @@ spec:
   params:
     pushInterval: 10s
     metricInfo:
-      server-request-count.instance.service-graph00:
+      server-request-count.instance.istio-system:
         # Due to a bug in gogoproto deserialization, Enums in maps must be
         # specified by their integer value, not variant name. See
         # https://github.com/googleapis/googleapis/blob/master/google/api/metric.proto
@@ -20,7 +20,7 @@ spec:
         kind: 3 # CUMULATIVE
         value: 2 # INT64
         metric_type: "istio.io/service/server/request_count"
-      server-request-bytes.instance.service-graph00:
+      server-request-bytes.instance.istio-system:
         kind: 3 # CUMULATIVE
         value: 5 # DISTRIBUTION
         buckets:
@@ -29,7 +29,7 @@ spec:
             scale: 1
             growthFactor: 2
         metric_type: "istio.io/service/server/request_bytes"
-      server-response-bytes.instance.service-graph00:
+      server-response-bytes.instance.istio-system:
         kind: 3 # CUMULATIVE
         value: 5 # DISTRIBUTION
         buckets:
@@ -38,7 +38,7 @@ spec:
             scale: 1
             growthFactor: 2
         metric_type: "istio.io/service/server/response_bytes"
-      server-response-latencies.instance.service-graph00:
+      server-response-latencies.instance.istio-system:
         kind: 3 # CUMULATIVE
         value: 5 # DISTRIBUTION
         buckets:
@@ -47,19 +47,19 @@ spec:
             scale: 1
             growthFactor: 2
         metric_type: "istio.io/service/server/response_latencies"
-      server-received-bytes-count.instance.service-graph00:
+      server-received-bytes-count.instance.istio-system:
         kind: 3 # CUMULATIVE
         value: 2 # INT64
         metric_type: "istio.io/service/server/received_bytes_count"
-      server-sent-bytes-count.instance.service-graph00:
+      server-sent-bytes-count.instance.istio-system:
         kind: 3 # CUMULATIVE
         value: 2 # INT64
         metric_type: "istio.io/service/server/sent_bytes_count"
-      client-request-count.instance.service-graph00:
+      client-request-count.instance.istio-system:
         kind: 3 # CUMULATIVE
         value: 2 # INT64
         metric_type: "istio.io/service/client/request_count"
-      client-request-bytes.instance.service-graph00:
+      client-request-bytes.instance.istio-system:
         kind: 3 # CUMULATIVE
         value: 5 # DISTRIBUTION
         buckets:
@@ -68,7 +68,7 @@ spec:
             scale: 1
             growthFactor: 2
         metric_type: "istio.io/service/client/request_bytes"
-      client-response-bytes.instance.service-graph00:
+      client-response-bytes.instance.istio-system:
         kind: 3 # CUMULATIVE
         value: 5 # DISTRIBUTION
         buckets:
@@ -77,7 +77,7 @@ spec:
             scale: 1
             growthFactor: 2
         metric_type: "istio.io/service/client/response_bytes"
-      client-roundtrip-latencies.instance.service-graph00:
+      client-roundtrip-latencies.instance.istio-system:
         kind: 3 # CUMULATIVE
         value: 5 # DISTRIBUTION
         buckets:
@@ -86,16 +86,16 @@ spec:
             scale: 1
             growthFactor: 2
         metric_type: "istio.io/service/client/roundtrip_latencies"
-      client-received-bytes-count.instance.service-graph00:
+      client-received-bytes-count.instance.istio-system:
         kind: 3 # CUMULATIVE
         value: 2 # INT64
         metric_type: "istio.io/service/client/received_bytes_count"
-      client-sent-bytes-count.instance.service-graph00:
+      client-sent-bytes-count.instance.istio-system:
         kind: 3 # CUMULATIVE
         value: 2 # INT64
         metric_type: "istio.io/service/client/sent_bytes_count"
     logInfo:
-      server-accesslog-stackdriver.instance.service-graph00:
+      server-accesslog-stackdriver.instance.istio-system:
         labelNames:
         - mesh_uid
         - source_uid
@@ -134,7 +134,7 @@ spec:
         - received_bytes
         - sent_bytes
         - referer
-      server-tcp-accesslog-stackdriver.instance.service-graph00:
+      server-tcp-accesslog-stackdriver.instance.istio-system:
         labelNames:
         - mesh_uid
         - connection_id

--- a/perf/istio-install/telemetry/stats_filter.yaml
+++ b/perf/istio-install/telemetry/stats_filter.yaml
@@ -1,0 +1,84 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: stats-filter
+spec:
+  configPatches:
+    - applyTo: HTTP_FILTER
+      match:
+        context: SIDECAR_OUTBOUND
+        listener:
+          filterChain:
+            filter:
+              name: "envoy.http_connection_manager"
+              subFilter:
+                name: "envoy.router"
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: envoy.filters.http.wasm
+          config:
+            config:
+              root_id: stats_outbound
+              configuration: |
+                {
+                  "debug": "false",
+                  "stat_prefix": "istio",
+                }
+              vm_config:
+                vm_id: stats_outbound
+                runtime: envoy.wasm.runtime.null
+                code:
+                  inline_string: envoy.wasm.stats
+    - applyTo: HTTP_FILTER
+      match:
+        context: SIDECAR_INBOUND
+        listener:
+          filterChain:
+            filter:
+              name: "envoy.http_connection_manager"
+              subFilter:
+                name: "envoy.router"
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: envoy.filters.http.wasm
+          config:
+            config:
+              root_id: stats_inbound
+              configuration: |
+                {
+                  "debug": "false",
+                  "stat_prefix": "istio",
+                }
+              vm_config:
+                vm_id: stats_inbound
+                runtime: envoy.wasm.runtime.null
+                code:
+                  inline_string: envoy.wasm.stats
+    - applyTo: HTTP_FILTER
+      match:
+        context: GATEWAY
+        listener:
+          filterChain:
+            filter:
+              name: "envoy.http_connection_manager"
+              subFilter:
+                name: "envoy.router"
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: envoy.filters.http.wasm
+          config:
+            config:
+              root_id: stats_outbound
+              configuration: |
+                {
+                  "debug": "false",
+                  "stat_prefix": "istio",
+                }
+              vm_config:
+                vm_id: stats_outbound
+                runtime: envoy.wasm.runtime.null
+                code:
+                  inline_string: envoy.wasm.stats


### PR DESCRIPTION
1. Add v2 telemetry for stats, metadata exchange and stackdriver.
2. Add V1 tcp telemetry for stack driver.
TODO: This is not integrated with charts yet.