### PR TITLE
get rid of conn=1 since qps cannot reach 1000 which cause data point missing

### DIFF
--- a/perf/benchmark/configs/mixer_latency.yaml
+++ b/perf/benchmark/configs/mixer_latency.yaml
@@ -1,7 +1,6 @@
 # Configuration Set2: Latency Quantiles with mixer enabled
 mixer_mode: "mixer"
 conn:
-    - 1
     - 2
     - 4
     - 8

--- a/perf/benchmark/configs/nomixer_latency.yaml
+++ b/perf/benchmark/configs/nomixer_latency.yaml
@@ -1,7 +1,6 @@
 # Configuration Set4: Latency Quantiles with mixer disabled
 mixer_mode: "nomixer"
 conn:
-    - 1
     - 2
     - 4
     - 8

--- a/perf/benchmark/configs/telemetryv2_latency.yaml
+++ b/perf/benchmark/configs/telemetryv2_latency.yaml
@@ -1,7 +1,6 @@
 # Configuration Set6: Latency Quantiles with telemetry v2 using NullVM.
 mixer_mode: "v2-nullvm"
 conn:
-    - 1
     - 2
     - 4
     - 8


### PR DESCRIPTION
This PR to get rid of `_qps_1000_c_1_1024_mixer_serveronly` mode data point missing problem.