### PR TITLE
Add groupName comment tag in kubetype-gen generated doc.go

### DIFF
--- a/cmd/kubetype-gen/generators/package.go
+++ b/cmd/kubetype-gen/generators/package.go
@@ -15,6 +15,8 @@
 package generators
 
 import (
+	"fmt"
+
 	"k8s.io/gengo/generator"
 	"k8s.io/gengo/types"
 
@@ -27,11 +29,12 @@ func NewPackageGenerator(source metadata.PackageMetadata, boilerplate []byte) ge
 		PackageName: source.TargetPackage().Name,
 		PackagePath: source.TargetPackage().Path,
 		HeaderText:  boilerplate,
-		PackageDocumentation: []byte(`
+		PackageDocumentation: []byte(fmt.Sprintf(`
 // Package has auto-generated kube type wrappers for raw types.
 // +k8s:openapi-gen=true
 // +k8s:deepcopy-gen=package
-`),
+// +groupName=%s
+`, source.GroupVersion().Group)),
 		FilterFunc: func(c *generator.Context, t *types.Type) bool {
 			for _, it := range source.RawTypes() {
 				if t == it {


### PR DESCRIPTION
Kubernetes code generator needs `// +groupName=group.istio.io` tag comment
to generate client set properly.

For example, currently we have[1]

  var gatewaysResource = schema.GroupVersionResource{Group: "networking", Version: "v1alpha3", Resource: "gateways"}

which should really be

  var gatewaysResource = schema.GroupVersionResource{Group: "networking.istio.io", Version: "v1alpha3", Resource: "gateways"}

after this change.

[1] https://github.com/istio/client-go/blob/21751e6cf0fea131872230940d95c40508aa0a4f/pkg/clientset/versioned/typed/networking/v1alpha3/fake/fake_gateway.gen.go#L21