### PR TITLE
explicit inject istio or linkerd via ISTIO_INJECT or LINKERD_INJECT

### DIFF
--- a/perf/benchmark/README.md
+++ b/perf/benchmark/README.md
@@ -47,6 +47,7 @@ For instructions on how to run these scripts with Linkerd, see the [linkerd/](li
     export NAMESPACE=twopods
     export DNS_DOMAIN=local
     export INTERCEPTION_MODE=REDIRECT
+    export ISTIO_INJECT=true
     cd ../benchmark
     ./setup_test.sh
     ```

--- a/perf/benchmark/runner/runner.py
+++ b/perf/benchmark/runner/runner.py
@@ -240,7 +240,7 @@ def kubectl_cp(from_file, to_file, container):
         from_file=from_file,
         to_file=to_file,
         container=container)
-    print(cmd, flust=True)
+    print(cmd, flush=True)
     run_command_sync(cmd)
 
 
@@ -310,7 +310,6 @@ def run(args):
     # run with config files
     if args.config_file is not None:
         fortio = fortio_from_config_file(args)
-
     else:
         fortio = Fortio(
             conn=args.conn,

--- a/perf/benchmark/setup_test.sh
+++ b/perf/benchmark/setup_test.sh
@@ -27,7 +27,8 @@ NAMESPACE=${NAMESPACE:-'twopods'}
 DNS_DOMAIN=${DNS_DOMAIN:?"DNS_DOMAIN should be like v104.qualistio.org or local"}
 TMPDIR=${TMPDIR:-${WD}/tmp}
 RBAC_ENABLED="false"
-LINKERD_INJECT="${LINKERD_INJECT:-'disabled'}"
+ISTIO_INJECT="${ISTIO_INJECT:-false}"
+LINKERD_INJECT="${LINKERD_INJECT:-disabled}"
 INTERCEPTION_MODE=${INTERCEPTION_MODE:-'REDIRECT'}
 echo "linkerd inject is ${LINKERD_INJECT}"
 
@@ -47,8 +48,10 @@ function run_test() {
   helm -n "${NAMESPACE}" template \
       --set rbac.enabled="${RBAC_ENABLED}" \
       --set includeOutboundIPRanges=$(svc_ip_range) \
+      --set client.inject="${ISTIO_INJECT}" \
+      --set server.inject="${ISTIO_INJECT}"  \
       --set client.injectL="${LINKERD_INJECT}" \
-      --set sever.injectL="${LINKERD_INJECT}" \
+      --set server.injectL="${LINKERD_INJECT}" \
       --set domain="${DNS_DOMAIN}" \
       --set interceptionMode="${INTERCEPTION_MODE}" \
           . > "${TMPDIR}"twopods.yaml

--- a/perf/benchmark/setup_test.sh
+++ b/perf/benchmark/setup_test.sh
@@ -73,12 +73,4 @@ for ((i=1; i<=$#; i++)); do
 done
 
 kubectl create ns "${NAMESPACE}" || true
-
-kubectl label namespace "${NAMESPACE}" istio-injection=enabled --overwrite || true
-
-if [[ "$LINKERD_INJECT" == "enabled" ]]
-then
-  kubectl annotate namespace "${NAMESPACE}" linkerd.io/inject=enabled || true
-fi
-
 run_test

--- a/perf/benchmark/values.yaml
+++ b/perf/benchmark/values.yaml
@@ -30,14 +30,14 @@ server:  # server overrides
   #tlsmode: DISABLE
   tlsmode: ISTIO_MUTUAL
   expose: false
-  inject: "true"
+  inject: "false"
   injectL: "disabled" # "enabled" or "disabled"
 
 client: # client overrides
   #tlsmode: DISABLE
   tlsmode: ISTIO_MUTUAL
   expose: true
-  inject: "true"
+  inject: "false"
   injectL: "disabled" # "enabled" or "disabled"
 
 cert: false


### PR DESCRIPTION
Add the ISTIO_INJECT variable to explicitly enable Istio sidecar injection. Since in the old way, if we enabled LINKERD_INJECT, both istio and linkerd will be enabled in the same namespace. Another solution is to enable them in different namespace, which requires more code changes.