### PR TITLE
add istioctl installation option and use for perf install

### DIFF
--- a/perf/benchmark/run_benchmark_job.sh
+++ b/perf/benchmark/run_benchmark_job.sh
@@ -121,6 +121,7 @@ fi
 TAG=$(curl "https://storage.googleapis.com/istio-build/dev/${BRANCH}")
 echo "Setup istio release: $TAG"
 pushd "${ROOT}/istio-install"
+   export INSTALL_WITH_ISTIOCTL="true"
    ./setup_istio_release.sh "${TAG}" "${RELEASE_TYPE}"
 popd
 

--- a/perf/istio-install/operator_default.yaml
+++ b/perf/istio-install/operator_default.yaml
@@ -9,8 +9,8 @@ spec:
   configManagement:
     components:
       galley:
-        enabled: false
-    enabled: false
+        enabled: true
+    enabled: true
   gateways:
     components:
       egressGateway:
@@ -22,6 +22,13 @@ spec:
       ingressGateway:
         enabled: true
         k8s:
+          hpaSpec:
+            maxReplicas: 5
+            minReplicas: 3
+            scaleTargetRef:
+              apiVersion: apps/v1
+              kind: Deployment
+              name: istio-ingressgateway
           resources:
             limits:
               cpu: 6000m
@@ -40,9 +47,9 @@ spec:
       certManager:
         enabled: false
       citadel:
-        enabled: false
-      nodeAgent:
         enabled: true
+      nodeAgent:
+        enabled: false
         k8s:
           env:
             - name: SECRET_GRACE_DURATION
@@ -74,7 +81,7 @@ spec:
             scaleTargetRef:
               apiVersion: apps/v1
               kind: Deployment
-              name: istio-mixer.telemetry
+              name: istio-telemetry
           resources:
             limits:
               cpu: 5800m
@@ -88,6 +95,13 @@ spec:
       pilot:
         enabled: true
         k8s:
+          hpaSpec:
+            maxReplicas: 10
+            minReplicas: 2
+            scaleTargetRef:
+              apiVersion: apps/v1
+              kind: Deployment
+              name: istio-pilot
           resources:
             limits:
               cpu: 5800m
@@ -106,11 +120,6 @@ spec:
       istio-ilbgateway:
         type: NodePort
       istio-ingressgateway:
-        labels:
-          app: istio-ingressgateway
-          istio: ingressgateway
-          name: gateway
-          ver: ingress10
         meshExpansion: true
         replicas: 3
         secretVolumes:
@@ -130,25 +139,34 @@ spec:
       podDNSSearchNamespaces:
         - global
         - '{{ valueOrDefault .DeploymentMeta.Namespace "default" }}.global'
+      #      TODO: sds not working with istioctl yet.
+      proxy:
+        enableCoreDump: true
+        resources:
+          requests:
+            cpu: 250m
+            memory: 256Mi
+          limits:
+            memory: 256Mi
       sds:
-        enabled: true
-        udsPath: unix:/var/run/sds/uds_path
-        useNormalJwt: true
+        enabled: false
+        udsPath: ""
+        token:
+          aud: istio-ca
     grafana:
       datasources:
-        datasources:
-          yaml:
-            apiVersion: 1
-            datasources:
-            - access: proxy
-              editable: true
-              isDefault: true
-              jsonData:
-                timeInterval: 5s
-              name: Prometheus
-              orgId: 1
-              type: prometheus
-              url: http://istio-prometheus.istio-prometheus:9090
+        datasources.yaml:
+          apiVersion: 1
+          datasources:
+          - access: proxy
+            editable: true
+            isDefault: true
+            jsonData:
+              timeInterval: 5s
+            name: Prometheus
+            orgId: 1
+            type: prometheus
+            url: http://istio-prometheus.istio-prometheus:9090
       enabled: true
     istiocoredns:
       enabled: true
@@ -163,21 +181,7 @@ spec:
       sidecar: true
     prometheus:
       enabled: false
-    proxy:
-      accessLogFile: ""
-      concurrency: 2
-      enableCoreDump: true
-      envoyAccessLogService:
-        enabled: false
-        host: accesslog-grpc.istio-system.svc.cluster.local
-        port: 18090
-      resources:
-        limits:
-          memory: 256Mi
-        requests:
-          cpu: 250m
-          memory: 256Mi
     tracing:
-      enabled: false
+      enabled: true
       jaeger:
         enabled: true

--- a/perf/istio-install/setup_istio.sh
+++ b/perf/istio-install/setup_istio.sh
@@ -171,7 +171,7 @@ function install_istio() {
 
   if [[ -z "${INSTALL_WITH_ISTIOCTL}" ]]; then
     echo "start installing istio using helm"
-    install_istio_helm
+    install_istio_with_helm
   else
     echo "start installing istio using istioctl"
     pushd "${DIRNAME}/${release}"

--- a/perf/istio-install/setup_istio.sh
+++ b/perf/istio-install/setup_istio.sh
@@ -144,7 +144,7 @@ function install_istio_with_istioctl() {
   if [[ ${EXTRA_ARGS} != "" ]];then
     args+=${EXTRA_ARGS}
   fi
-  istioctl manifest apply -f "${CR_FILENAME}" --force=true --set "${SET_OVERLAY}" "${EXTRA_ARGS}"
+  ./istioctl manifest apply -f "${CR_FILENAME}" --set "${SET_OVERLAY}" "${EXTRA_ARGS}"
 }
 
 function install_istio() {
@@ -165,8 +165,8 @@ function install_istio() {
       DN=$(mktemp -d)
       tar -xzf "${outfile}" -C "${DN}" --strip-components 1
       mv "${DN}/install/kubernetes/helm" "${DIRNAME}/${release}"
-      # shellcheck disable=SC2086
-      rm -rf ${DN}
+      mv "${DN}/bin/istioctl" "${DIRNAME}/${release}"
+      rm -rf "${DN}"
   fi
 
   if [[ -z "${INSTALL_WITH_ISTIOCTL}" ]]; then
@@ -174,10 +174,12 @@ function install_istio() {
     install_istio_helm
   else
     echo "start installing istio using istioctl"
+    pushd "${DIRNAME}/${release}"
     SET_OVERLAY="defaultNamespace=istio-system"
     CR_FILENAME="${WD}/operator_default.yaml"
     EXTRA_ARGS="--force=true"
     install_istio_with_istioctl
+    popd
   fi
 }
 

--- a/perf/istio-install/setup_istio_operator.sh
+++ b/perf/istio-install/setup_istio_operator.sh
@@ -38,7 +38,6 @@ popd
 defaultNamespace=istio-system
 defaultCR="${WD}/operator_default.yaml"
 
-
 function setup_admin_binding() {
   kubectl create clusterrolebinding cluster-admin-binding \
     --clusterrole=cluster-admin \


### PR DESCRIPTION
1. update the setup_istio.sh to take two approaches for installation: 1. istioctl(the binary would come from release) 2. helm(currently exist)
2. use the istioctl to install for performance benchmark testing

TODO:
we should update the other helm base installation part in the whole tools repo to use istioctl installation.

/CC @mandarjog @carolynhu 