### PR TITLE
fix sidecar injection issue

### DIFF
--- a/perf/benchmark/README.md
+++ b/perf/benchmark/README.md
@@ -44,7 +44,7 @@ For instructions on how to run these scripts with Linkerd, see the [linkerd/](li
 1. Deploy the workloads to measure performance against. The test environment is two [Fortio](http://fortio.org/) pods (one client, one server), set to communicate over HTTP1, using mutual TLS authentication. By default, the client pod will make HTTP requests with a 1KB payload.
 
     ```bash
-    export NAMESPACE=twopods
+    export NAMESPACE=twopods-istio
     export DNS_DOMAIN=local
     export INTERCEPTION_MODE=REDIRECT
     export ISTIO_INJECT=true

--- a/perf/benchmark/linkerd/README.md
+++ b/perf/benchmark/linkerd/README.md
@@ -9,7 +9,7 @@ Sources:
 
 ## 1 - Create cluster and Install Istio
 
-Please follow this [Setup README](https://github.com/istio/tools/tree/master/perf/benchmark#setup), finish step 1 and 2.
+Please follow this [Setup README](https://github.com/istio/tools/tree/master/perf/benchmark#setup), finish step 1.
 
 ## 2 - Install Linkerd
 
@@ -27,7 +27,7 @@ kubectl -n linkerd get deploy
 ## 3. Deploy the fortio test environment
 
 ```bash
-export NAMESPACE="twopods"
+export NAMESPACE=twopods-linkerd
 export DNS_DOMAIN=local
 export LINKERD_INJECT=enabled
 cd ..

--- a/perf/benchmark/setup_test.sh
+++ b/perf/benchmark/setup_test.sh
@@ -74,7 +74,10 @@ done
 
 kubectl create ns "${NAMESPACE}" || true
 
-kubectl label namespace "${NAMESPACE}" istio-injection=enabled --overwrite || true
+if [[ "$ISTIO_INJECT" == "true" ]]
+then
+  kubectl label namespace "${NAMESPACE}" istio-injection=enabled --overwrite || true
+fi
 
 if [[ "$LINKERD_INJECT" == "enabled" ]]
 then

--- a/perf/benchmark/setup_test.sh
+++ b/perf/benchmark/setup_test.sh
@@ -73,4 +73,12 @@ for ((i=1; i<=$#; i++)); do
 done
 
 kubectl create ns "${NAMESPACE}" || true
+
+kubectl label namespace "${NAMESPACE}" istio-injection=enabled --overwrite || true
+
+if [[ "$LINKERD_INJECT" == "enabled" ]]
+then
+  kubectl annotate namespace "${NAMESPACE}" linkerd.io/inject=enabled || true
+fi
+
 run_test


### PR DESCRIPTION
According to this table https://istio.io/docs/ops/setup/injection-concepts/ only if namespaceSelector match is yes, and Pod override annotation sidecar.istio.io/inject=true, sidecar can be injected. Therefore, I should label/annotation sidecar inject in namespaces.