### PR TITLE
Add linkerd label and make fortio yaml consistent with NAMESPACE

### DIFF
--- a/perf/benchmark/runner/runner.py
+++ b/perf/benchmark/runner/runner.py
@@ -159,6 +159,9 @@ class Fortio:
         if self.mesh == "istio":
             labels += "_"
             labels += self.mixer_mode
+        elif self.mesh == "linkerd":
+            labels += "_"
+            labels += "linkerd"
 
         if self.labels is not None:
             labels += "_" + self.labels

--- a/perf/benchmark/setup_test.sh
+++ b/perf/benchmark/setup_test.sh
@@ -54,14 +54,14 @@ function run_test() {
       --set server.injectL="${LINKERD_INJECT}" \
       --set domain="${DNS_DOMAIN}" \
       --set interceptionMode="${INTERCEPTION_MODE}" \
-          . > "${TMPDIR}"twopods.yaml
-  echo "Wrote file ${TMPDIR}twopods.yaml"
+          . > "${TMPDIR}""${NAMESPACE}".yaml
+  echo "Wrote file ${TMPDIR}${NAMESPACE}.yaml"
 
   # remove stdio rules
-  kubectl apply -n "${NAMESPACE}" -f "${TMPDIR}"twopods.yaml
-  kubectl rollout status deployment fortioclient -n twopods --timeout=1m
-  kubectl rollout status deployment fortioserver -n twopods --timeout=1m
-  echo "${TMPDIR}"twopods.yaml
+  kubectl apply -n "${NAMESPACE}" -f "${TMPDIR}""${NAMESPACE}".yaml
+  kubectl rollout status deployment fortioclient -n "${NAMESPACE}" --timeout=1m
+  kubectl rollout status deployment fortioserver -n "${NAMESPACE}" --timeout=1m
+  echo "${TMPDIR}""${NAMESPACE}".yaml
 }
 
 for ((i=1; i<=$#; i++)); do


### PR DESCRIPTION
When mesh="linkerd", we should add "linkerd" label for each test, it will be like: `run_id_qps_1000_c_16_1024_linkerd_both`