### PR TITLE
Add some debugging information to flame graph part

### DIFF
--- a/perf/benchmark/runner/runner.py
+++ b/perf/benchmark/runner/runner.py
@@ -33,7 +33,7 @@ else:
 POD = collections.namedtuple('Pod', ['name', 'namespace', 'ip', 'labels'])
 
 
-def pod_info(filterstr="", namespace="twopods", multi_ok=True):
+def pod_info(filterstr="", namespace=os.environ.get("NAMESPACE", "twopods"), multi_ok=True):
     cmd = "kubectl -n {namespace} get pod {filterstr}  -o json".format(
         namespace=namespace, filterstr=filterstr)
     op = getoutput(cmd)
@@ -159,6 +159,9 @@ class Fortio:
         if self.mesh == "istio":
             labels += "_"
             labels += self.mixer_mode
+        elif self.mesh == "linkerd":
+            labels += "_"
+            labels += "linkerd"
 
         if self.labels is not None:
             labels += "_" + self.labels

--- a/perf/benchmark/setup_test.sh
+++ b/perf/benchmark/setup_test.sh
@@ -59,8 +59,8 @@ function run_test() {
 
   # remove stdio rules
   kubectl apply -n "${NAMESPACE}" -f "${TMPDIR}/twopods.yaml"
-  kubectl rollout status deployment fortioclient -n twopods --timeout=1m
-  kubectl rollout status deployment fortioserver -n twopods --timeout=1m
+  kubectl rollout status deployment fortioclient -n "${NAMESPACE}" --timeout=1m
+  kubectl rollout status deployment fortioserver -n "${NAMESPACE}" --timeout=1m
   echo "${TMPDIR}/twopods.yaml"
 }
 


### PR DESCRIPTION
there are still error messages about flame graph: OCI runtime exec failed: exec failed: container_linux.go:345: starting container process caused "exec: \"/etc/istio/proxy/get_perfdata.sh\": stat /etc/istio/proxy/get_perfdata.sh: no such file or directory": unknown
command terminated with exit code 126.

It works locally so want to add some debugging information to see what actually happened.