### PR TITLE
Fix flame output dir path issue

### DIFF
--- a/perf/benchmark/README.md
+++ b/perf/benchmark/README.md
@@ -39,7 +39,7 @@ For instructions on how to run these scripts with Linkerd, see the [linkerd/](li
 
    ```bash
    export ISTIO_RELEASE=1.4-alpha.0ef2cd46e2da64b9252c36ca4bf90aa474b73610
-   export DNS_DOMAIN=local 
+   export DNS_DOMAIN=local
    ./setup_istio_release.sh $ISTIO_RELEASE dev
    ```
 

--- a/perf/benchmark/README.md
+++ b/perf/benchmark/README.md
@@ -30,12 +30,22 @@ For instructions on how to run these scripts with Linkerd, see the [linkerd/](li
 1. Install Istio:
 
     ```bash
-    export ISTIO_RELEASE="release-1.2-latest"  # or any Istio release
+    export ISTIO_RELEASE=release-1.2-latest  # or any Istio release
     export DNS_DOMAIN=local
     ./setup_istio.sh $ISTIO_RELEASE
     ```
 
-    Wait for all Istio pods to be `Running` and `Ready`:
+   From Istio 1.4 later on, you should setup istio using the following commands:
+
+   ```bash
+   export ISTIO_RELEASE=1.4-alpha.0ef2cd46e2da64b9252c36ca4bf90aa474b73610
+   export DNS_DOMAIN=local 
+   ./setup_istio_release.sh $ISTIO_RELEASE dev
+   ```
+
+   Note: The latest ISTIO_RELEASE can be queried from [istio-release](https://storage.googleapis.com/istio-build/dev/latest)
+
+   Wait for all Istio pods to be `Running` and `Ready`:
 
     ```bash
     kubectl get pods -n istio-system
@@ -45,7 +55,6 @@ For instructions on how to run these scripts with Linkerd, see the [linkerd/](li
 
     ```bash
     export NAMESPACE=twopods-istio
-    export DNS_DOMAIN=local
     export INTERCEPTION_MODE=REDIRECT
     export ISTIO_INJECT=true
     cd ../benchmark

--- a/perf/benchmark/runner/runner.py
+++ b/perf/benchmark/runner/runner.py
@@ -212,10 +212,13 @@ class Fortio:
 
 
 PERFCMD = "/usr/lib/linux-tools/4.4.0-131-generic/perf"
+FLAMESH = "flame.sh"
 PERFSH = "get_perfdata.sh"
 PERFWD = "/etc/istio/proxy/"
 WD = os.getcwd()
+LOCAL_FLAMEPATH = os.path.join(WD, "../flame", FLAMESH)
 LOCAL_PERFPATH = os.path.join(WD, "../flame", PERFSH)
+LOCAL_FLAMEOUTPUT = os.path.join(WD, "../flame", "flameoutput/")
 
 
 def run_perf(mesh, pod, labels, duration=20):
@@ -226,21 +229,16 @@ def run_perf(mesh, pod, labels, duration=20):
     # copy executable over
     kubectl_cp(LOCAL_PERFPATH, pod + ":" + perfpath, mesh + "-proxy")
 
-    # debug information
-    kubectl_exec(pod,
-                 "ls {path}".format(path=PERFWD),
-                 container=mesh + "-proxy")
-
     kubectl_exec(
         pod,
-        "bash {perf_cmd} {filename} {duration}".format(
+        "{perf_cmd} {filename} {duration}".format(
             perf_cmd=perfpath,
             filename=filename,
             duration=duration),
         container=mesh + "-proxy")
 
-    kubectl_cp(pod + ":" + filepath + ".perf", filename + ".perf", mesh + "-proxy")
-    run_command_sync("../flame/flame.sh " + filename + ".perf")
+    kubectl_cp(pod + ":" + filepath + ".perf", LOCAL_FLAMEOUTPUT + filename + ".perf", mesh + "-proxy")
+    run_command_sync(LOCAL_FLAMEPATH + " " + filename + ".perf")
 
 
 def kubectl_cp(from_file, to_file, container):

--- a/perf/benchmark/runner/runner.py
+++ b/perf/benchmark/runner/runner.py
@@ -215,10 +215,12 @@ PERFCMD = "/usr/lib/linux-tools/4.4.0-131-generic/perf"
 FLAMESH = "flame.sh"
 PERFSH = "get_perfdata.sh"
 PERFWD = "/etc/istio/proxy/"
+
 WD = os.getcwd()
-LOCAL_FLAMEPATH = os.path.join(WD, "../flame", FLAMESH)
-LOCAL_PERFPATH = os.path.join(WD, "../flame", PERFSH)
-LOCAL_FLAMEOUTPUT = os.path.join(WD, "../flame", "flameoutput/")
+LOCAL_FLAMEDIR = os.path.join(WD, "../flame/")
+LOCAL_FLAMEPATH = LOCAL_FLAMEDIR + FLAMESH
+LOCAL_PERFPATH = LOCAL_FLAMEDIR + PERFSH
+LOCAL_FLAMEOUTPUT = LOCAL_FLAMEDIR + "flameoutput/"
 
 
 def run_perf(mesh, pod, labels, duration=20):


### PR DESCRIPTION
Based on this PR: https://github.com/istio/tools/pull/565 which fixed the perf pipeline issue: 
```
kubectl --namespace twopods cp get_perfdata.sh fortioserver-7c6b79856f-gm4h7:/etc/istio/proxy/get_perfdata.sh -c istio-proxy
kubectl --namespace twopods exec fortioserver-7c6b79856f-gm4h7 -c istio-proxy -- ls /etc/istio/proxy/
envoy-rev0.json
kubectl --namespace twopods exec fortioserver-7c6b79856f-gm4h7 -c istio-proxy -- bash /etc/istio/proxy/get_perfdata.sh f1e37099_qps_1000_c_2_1024_mixer_srv_serveronly_perf.data 40
bash: /etc/istio/proxy/get_perfdata.sh: No such file or directory
command terminated with exit code 127
```
There are related errors might happen when copying data from `flameoutput` folder. This PR is the fix.