### PR TITLE
Fix yaml file path error when executing command

### DIFF
--- a/perf/stability/setup_test.sh
+++ b/perf/stability/setup_test.sh
@@ -17,9 +17,7 @@
 set -ex
 
 # shellcheck disable=SC2086
-WD=$(dirname $0)
-# shellcheck disable=SC2086
-WD=$(cd $WD; pwd)
+WD=$(cd $(dirname $0); pwd)
 
 function setup_test() {
   local DIRNAME="${1:?"test directory"}"
@@ -27,7 +25,7 @@ function setup_test() {
   local HELM_ARGS="${2:-}"
 
   mkdir -p "${WD}/tmp"
-  local OUTFILE="${WD}/tmp/${DIRNAME}.yaml"
+  local OUTFILE="./perf/stability/tmp/${DIRNAME}.yaml"
 
   # shellcheck disable=SC2086
   helm --namespace "${NAMESPACE}" template "${WD}/${DIRNAME}" ${HELM_ARGS} > "${OUTFILE}"


### PR DESCRIPTION
Signe-off-by: xichengliudui <1693291525@qq.com>

: execute the make command under the root path. The path of the yaml file is incorrect.
output
```
+ kubectl create ns istio-stability-http10
+ true
+ kubectl label namespace istio-stability-http10 istio-injection=enabled
+ true
+ kubectl -n istio-stability-http10 apply -f /work/perf/stability/tmp/http10.yaml
```
perform alone
```
[root@75 tools]# kubectl -n istio-stability-http10 apply -f /work/perf/stability/tmp/http10.yaml
error: the path "/work/perf/stability/tmp/http10.yaml" does not exist
```
correct path is
```
[root@75 tools]# ls -al ./perf/stability/tmp/http10.yaml
-rw-r--r-- 1 root root 1382 Nov 28 14:51 ./perf/stability/tmp/http10.yaml
```