### PR TITLE
fix typo service-graph## -> service-graph00

### DIFF
--- a/perf/load/README.md
+++ b/perf/load/README.md
@@ -13,6 +13,6 @@ It will also set up an instance of [Fortio](https://github.com/fortio/fortio#for
 
 To setup a service graph, run `./setup_large_test.sh NUM`, where num is the number of instances to run.
 
-Each instance will be created in a namespace `service-graph##`.
+Each instance will be created in a namespace `service-graph00`.
 
 Each instance requests roughly 6 vCPUs and 6Gi of memory with Istio defaults.


### PR DESCRIPTION
Signed-off-by: xichengliudui <1693291525@qq.com>

output:
```
[root@75 runner]# kubectl get ns
NAME                            STATUS   AGE
default                         Active   18d
istio-stability-http10          Active   3d20h
istio-stability-twopods-istio   Active   3d20h
istio-system                    Active   5d17h
kube-public                     Active   18d
kube-system                     Active   18d
service-graph00                 Active   2d23h
```