### PR TITLE
Correct graph script to print mixer values

### DIFF
--- a/perf/benchmark/runner/graph.py
+++ b/perf/benchmark/runner/graph.py
@@ -93,7 +93,7 @@ def get_series(df, x_label, metric):
              ("nomix.*_both", "nomixer_both"),
              ("base", "base"),
              # Make sure this set of data is last, because both type always have data to make sure rows are not empty.
-             ("^both", "both")]
+             (".*mixer_both", "mixer_both")]
 
     # get y axis
     series = {}


### PR DESCRIPTION
Currently I'm using Istio `1.3.4` and the benchmark tool generates the following csv:

```bash
StartTime,ActualDuration,Labels,NumThreads,ActualQPS,p50,p90,p99,cpu_mili_avg_telemetry_mixer,cpu_mili_max_telemetry_mixer,mem_MB_max_telemetry_mixer,cpu_mili_avg_fortioserver_deployment_proxy,cpu_mili_max_fortioserver_deployment_proxy,mem_MB_max_fortioserver_deployment_proxy,cpu_mili_avg_ingressgateway_proxy,cpu_mili_max_ingressgateway_proxy,mem_MB_max_ingressgateway_proxy
2019-12-03T07:29:57.348637557Z,240,97b8ed3d_qps_1000_c_64_1024_mixer_base,64,1000,925,2321,3401,523,844,193,119,200,55,-,-,-
2019-12-03T07:27:56.36730831Z,240,97b8ed3d_qps_1000_c_64_1024_mixer_both,64,1000,8420,11915,14687,831,844,191,195,199,54,-,-,-
2019-12-03T07:23:56.048018374Z,240,97b8ed3d_qps_1000_c_16_1024_mixer_base,16,1000,555,942,1728,33,36,191,2,2,49,-,-,-
2019-12-03T07:19:55.46937612Z,240,97b8ed3d_qps_1000_c_16_1024_mixer_both,16,1000,2401,4042,6637,824,828,191,212,216,49,-,-,-
2019-12-03T07:15:55.281961471Z,240,97b8ed3d_qps_1000_c_4_1024_mixer_base,4,1000,508,670,833,30,33,191,2,2,47,-,-,-
2019-12-03T07:11:55.114655266Z,240,97b8ed3d_qps_1000_c_4_1024_mixer_both,4,1000,1096,1468,3393,740,836,191,255,259,46,-,-,-
StartTime,ActualDuration,Labels,NumThreads,ActualQPS,p50,p90,p99,cpu_mili_avg_telemetry_mixer,cpu_mili_max_telemetry_mixer,mem_MB_max_telemetry_mixer,cpu_mili_avg_fortioserver_deployment_proxy,cpu_mili_max_fortioserver_deployment_proxy,mem_MB_max_fortioserver_deployment_proxy,cpu_mili_avg_ingressgateway_proxy,cpu_mili_max_ingressgateway_proxy,mem_MB_max_ingressgateway_proxy
2019-12-03T07:29:57.348637557Z,240,97b8ed3d_qps_1000_c_64_1024_mixer_base,64,1000,925,2321,3401,523,844,193,119,200,55,-,-,-
2019-12-03T07:27:56.36730831Z,240,97b8ed3d_qps_1000_c_64_1024_mixer_both,64,1000,8420,11915,14687,831,844,191,195,199,54,-,-,-
2019-12-03T07:23:56.048018374Z,240,97b8ed3d_qps_1000_c_16_1024_mixer_base,16,1000,555,942,1728,33,36,191,2,2,49,-,-,-
2019-12-03T07:19:55.46937612Z,240,97b8ed3d_qps_1000_c_16_1024_mixer_both,16,1000,2401,4042,6637,824,828,191,212,216,49,-,-,-
2019-12-03T07:15:55.281961471Z,240,97b8ed3d_qps_1000_c_4_1024_mixer_base,4,1000,508,670,833,30,33,191,2,2,47,-,-,-
2019-12-03T07:11:55.114655266Z,240,97b8ed3d_qps_1000_c_4_1024_mixer_both,4,1000,1096,1468,3393,740,836,191,255,259,46,-,-,-
```
When I render the graph with `python runner/graph.py ./results/istio_single.csv p90 --show_graph` I get only the results for the baseline test. I tried to remote all `base` values and run the script again with the following error message:

```bash
python runner/graph.py ./results/istio_single.csv p90 --show_graph
Generating chart, x_label=connections, y_label=p90, csv=./results/istio_single.csv ...
warn: size of x axis dataframe is 0
Traceback (most recent call last):
  File "runner/graph.py", line 222, in <module>
    sys.exit(main(sys.argv[1:]))
  File "runner/graph.py", line 188, in main
    args.metric, args.charts_output_dir, args.show_graph)
  File "runner/graph.py", line 52, in generate_chart
    x_series, y_series = get_series(df, x_label, y_label)
  File "runner/graph.py", line 129, in get_series
    x = list(rows.NumThreads)
  File "/home/johannes/.local/share/virtualenvs/runner-QBiqBl8v/lib/python3.6/site-packages/pandas/core/generic.py", line 5067, in __getattr__
    return object.__getattribute__(self, name)
AttributeError: 'DataFrame' object has no attribute 'NumThreads'
```

This was probably introduced in the change of `mixer` and `nomixer` benchmarks. The patch provided here worked for me (currently I don't have a 1.4 Istio mesh to test it)
