### PR TITLE
Allow cue-gen to use user-specified schema name

### DIFF
--- a/cmd/cue-gen/genoapi.go
+++ b/cmd/cue-gen/genoapi.go
@@ -416,8 +416,13 @@ func (x *builder) genCRD() {
 
 		versionSchemas := map[string]*openapi.OrderedMap{}
 
-		for _, version := range v.Spec.Versions {
-			schemaName := fmt.Sprintf("%v.%v.%v", group, version.Name, tp)
+		for _, version := range v.CustomResourceDefinition.Spec.Versions {
+			var schemaName string
+			if n, ok := v.VersionToSchema[version.Name]; ok {
+				schemaName = n
+			} else {
+				schemaName = fmt.Sprintf("%v.%v.%v", group, version.Name, tp)
+			}
 			sc, ok := schemas[schemaName]
 			if !ok {
 				log.Fatalf("cannot find schema for %v", schemaName)
@@ -425,7 +430,7 @@ func (x *builder) genCRD() {
 			versionSchemas[version.Name] = sc
 		}
 
-		completeCRD(v, versionSchemas)
+		completeCRD(v.CustomResourceDefinition, versionSchemas)
 	}
 
 	x.writeCRDFiles()
@@ -689,7 +694,7 @@ func (x *builder) writeCRDFiles() {
 		log.Fatal(err)
 	}
 	for _, c := range x.Crd.CrdConfigs {
-		y, err := yaml.Marshal(c)
+		y, err := yaml.Marshal(c.CustomResourceDefinition)
 		if err != nil {
 			log.Fatalf("Error marsahling CRD to yaml: %v", err)
 		}


### PR DESCRIPTION
This is to accommodate some mixer APIs that don't follow Istio API [naming conventions](https://github.com/istio/api/blob/master/GUIDELINES.md#proto-guidelines). Namely, `QuotaSpecBinding`, `QuotaSpec`, `HTTPAPISpec` and `HTTPAPISpecBindings`. So that users can use an annotation `+cue-gen:HTTPAPISpec:schema:istio.mixer.v1.config.client.HTTPAPISpec` to specify a schema name they want to use for that CRD, instead of using the default `<package>.<version>.<name>` schema name.