### PR TITLE
Add data for ingress benchmark to generated graph

### DIFF
--- a/perf/benchmark/runner/graph.py
+++ b/perf/benchmark/runner/graph.py
@@ -92,6 +92,7 @@ def get_series(df, x_label, metric):
              ("nomix.*_serveronly", "nomixer_serveronly"),
              ("nomix.*_both", "nomixer_both"),
              ("base", "base"),
+             (".*_ingress", "ingress"),
              # Make sure this set of data is last, because both type always have data to make sure rows are not empty.
              ("^both", "both")]
 


### PR DESCRIPTION
This PR adds the data set for the ingress benchmark to the graph otherwise the values for the ingress test will be silently ignored.