### PR TITLE
Fix telemetry v2 filters path

### DIFF
--- a/perf/benchmark/README.md
+++ b/perf/benchmark/README.md
@@ -88,15 +88,15 @@ The test has three sidecar modes:
 
 1. run with CLI argument directly
 
-``
+```bash
 python runner.py --conn <conn> --qps <qps> --duration <duration> --OPTIONAL-FLAGS
-``
+```
 
-2. run with config yaml
+1. run with config yaml
 
-``
+```bash
 python runner.py --config_file ../configs/mixer_latency.yaml
-``
+```
 
 Required fields to specified via CLI or config file:
 
@@ -213,7 +213,8 @@ Calls to Istio's Mixer component (policy and telemetry) adds latency to the side
 
 1. Enable stats filter: kubectl -n istio-system apply -f <https://raw.githubusercontent.com/istio/istio/master/tests/integration/telemetry/stats/prometheus/testdata/stats_filter.yaml>
 
-# Note: the above config files is for `master` branch, please specify the corresponding branch for your installed istio-version, like `release-1.4`.
+Note: the above config files is for `master` branch, please specify the corresponding branch for your installed istio-version, like `release-1.4`.
+
 ## Gather Result Metrics
 
 Once `runner.py` has completed, extract the results from Fortio and Prometheus.

--- a/perf/benchmark/README.md
+++ b/perf/benchmark/README.md
@@ -92,7 +92,7 @@ The test has three sidecar modes:
 python runner.py --conn <conn> --qps <qps> --duration <duration> --OPTIONAL-FLAGS
 ``
 
-1. run with config yaml
+2. run with config yaml
 
 ``
 python runner.py --config_file ../configs/mixer_latency.yaml
@@ -213,6 +213,7 @@ Calls to Istio's Mixer component (policy and telemetry) adds latency to the side
 
 1. Enable stats filter: kubectl -n istio-system apply -f <https://raw.githubusercontent.com/istio/istio/master/tests/integration/telemetry/stats/prometheus/testdata/stats_filter.yaml>
 
+# Note: the above config files is for `master` branch, please specify the corresponding branch for your installed istio-version, like `release-1.4`.
 ## Gather Result Metrics
 
 Once `runner.py` has completed, extract the results from Fortio and Prometheus.

--- a/perf/benchmark/run_benchmark_job.sh
+++ b/perf/benchmark/run_benchmark_job.sh
@@ -108,8 +108,8 @@ function enable_perf_record() {
 }
 
 function prerun_v2_nullvm() {
-  kubectl -n istio-system apply -f https://raw.githubusercontent.com/istio/istio/master/tests/integration/telemetry/stats/prometheus/testdata/metadata_exchange_filter.yaml
-  kubectl -n istio-system apply -f https://raw.githubusercontent.com/istio/istio/master/tests/integration/telemetry/stats/prometheus/testdata/stats_filter.yaml
+  kubectl -n istio-system apply -f https://raw.githubusercontent.com/istio/istio/"${GIT_BRANCH}"/tests/integration/telemetry/stats/prometheus/testdata/metadata_exchange_filter.yaml
+  kubectl -n istio-system apply -f https://raw.githubusercontent.com/istio/istio/"${GIT_BRANCH}"/tests/integration/telemetry/stats/prometheus/testdata/stats_filter.yaml
 }
 
 function prerun_nomixer() {


### PR DESCRIPTION
Make telemetry v2 filters path consistent with GIT_BRANCH in order to apply the correct filter configs.