### PR TITLE
Update docs for cacert argument

### DIFF
--- a/perf/benchmark/README.md
+++ b/perf/benchmark/README.md
@@ -106,21 +106,32 @@ Required fields to specified via CLI or config file:
 
 ```bash
 optional arguments:
-  -h, --help          show this help message and exit
-  --size SIZE         size of the payload, default is 1024
-  --mesh MESH         istio or linkerd, default is istio
-  --client CLIENT     where to run the test from
-  --server SERVER     pod ip of the server
-  --mixer_mode mixer/nomixer/telemetryv2-nullvm  run with mixer enabled(default), mixer disabled and mixer v2
-  --perf              also run perf and produce flame graph, default is false
-  --baseline          run baseline for all
-  --no_baseline       do not run baseline for all
-  --serversidecar     run serversidecar-only for all
-  --no_serversidecar  do not run serversidecar-only for all
-  --clientsidecar     run clientsidecar and serversidecar for all, this is corresponding to the "both" mode, which will be executed by default
-  --no_clientsidecar  do not run clientsidecar and serversidecar for all
-  --ingress INGRESS   run traffic through ingress
-  --extra_labels      add extra labels
+  -h, --help            show this help message and exit
+  --conn CONN           number of connections, comma separated list
+  --qps QPS             qps, comma separated list
+  --duration DURATION   duration in seconds of the extract
+  --size SIZE           size of the payload
+  --mesh MESH           istio or linkerd
+  --mixer_mode MIXER_MODE
+                        run with different mixer configurations: mixer,
+                        nomixer, mixerv2
+  --client CLIENT       where to run the test from
+  --server SERVER       pod ip of the server
+  --perf PERF           also run perf and produce flame graph
+  --ingress INGRESS     run traffic through ingress, should be a valid URL
+  --extra_labels EXTRA_LABELS
+                        extra labels
+  --mode MODE           http or grpc
+  --config_file CONFIG_FILE
+                        config yaml file
+  --cacert CACERT       path to the cacert for the fortio client inside the
+                        container
+  --baseline            run baseline for all
+  --no_baseline         do not run baseline for all
+  --serversidecar       run serversidecar-only for all
+  --no_serversidecar    do not run serversidecar-only for all
+  --clientsidecar       run clientsidecar and serversidecar for all
+  --no_clientsidecar    do not run clientsidecar and serversidecar for all
 ```
 
 Note:

--- a/perf/benchmark/runner/runner.py
+++ b/perf/benchmark/runner/runner.py
@@ -171,19 +171,19 @@ class Fortio:
         if self.mode == "grpc":
             grpc = "-grpc -ping"
 
-        cacert_path = ""
+        cacert_arg = ""
         if self.cacert is not None:
-            cacert_path = "-cacert {cacert_path}".format(cacert_path=self.cacert)
+            cacert_arg = "-cacert {cacert_path}".format(cacert_path=self.cacert)
 
         fortio_cmd = (
-            "fortio load -c {conn} -qps {qps} -t {duration}s -a -r {r} {cacert_path} {grpc} -httpbufferkb=128 " +
+            "fortio load -c {conn} -qps {qps} -t {duration}s -a -r {r} {cacert_arg} {grpc} -httpbufferkb=128 " +
             "-labels {labels}").format(
                 conn=conn,
                 qps=qps,
                 duration=duration,
                 r=self.r,
                 grpc=grpc,
-                cacert_path=cacert_path,
+                cacert_arg=cacert_arg,
                 labels=labels)
 
         if self.run_ingress:


### PR DESCRIPTION
The PR https://github.com/istio/tools/pull/599 was merged faster than I could add the docs for the `cacert` argument. I replaced the old arguments with the output of `python runner.py --help`