### PR TITLE
Incorrect configmap name in create_cluster.sh

### DIFF
--- a/perf/istio-install/README.md
+++ b/perf/istio-install/README.md
@@ -6,7 +6,8 @@ Required environment:
 
 PROJECT_ID - GCP project id, for example istio-testing
 CLUSTER_NAME - name of the cluster to setup, for example istio14test1
-CLUSTER_ZONE - zone where the cluster will be setup, for example us-central1-a
+ZONE - zone where the cluster will be setup, for example us-central1-a
+REGION - region where a regional cluster will be set up, for example us-central1. Overrides ZONE.
 DNS_DOMAIN - domain to use for TLS cert testing.
 
 Optional:

--- a/perf/istio-install/create_cluster.sh
+++ b/perf/istio-install/create_cluster.sh
@@ -275,4 +275,4 @@ kubectl -n kube-system create secret generic google-cloud-key  --from-file key.j
 
 kubectl create ns istio-system
 kubectl -n istio-system create secret generic google-cloud-key  --from-file key.json="${CLUSTER_NAME}/google-cloud-key.json"
-kubectl -n istio-system apply -f "${CLUSTER_NAME}/configmap-galley.yaml"
+kubectl -n istio-system apply -f "${CLUSTER_NAME}/configmap-istiod-asm.yaml"

--- a/perf/istio-install/create_cluster.sh
+++ b/perf/istio-install/create_cluster.sh
@@ -159,7 +159,7 @@ if [[ -n "${USE_SUBNET}" ]];then
 fi
 set -u
 
-ADDONS="HorizontalPodAutoscaling,KubernetesDashboard"
+ADDONS="HorizontalPodAutoscaling"
 # shellcheck disable=SC2236
 set +u
 if [[ -n "${ISTIO_ADDON}" ]];then


### PR DESCRIPTION
This configmap was renamed during the work in https://github.com/istio/tools/pull/547, but the kubectl command was not updated to reflect the new name. Also fixing two nits that were not resolved before merge.

CC @costinm @howardjohn 