### PR TITLE
Fix mason_client fetch

### DIFF
--- a/bin/setup_cluster.sh
+++ b/bin/setup_cluster.sh
@@ -95,8 +95,8 @@ function setup_gcloud_credentials() {
 
 # use mason_client to get resources
 function get_resource() {
-  # Turn off modules, otherwise the go.mod file will be updated
-  GO111MODULE=off go get istio.io/test-infra/boskos/cmd/mason_client
+  # cd to tmp, otherwise the go.mod file may be updated
+  (cd /tmp; go get istio.io/test-infra/boskos/cmd/mason_client)
   local type="${1}"
   local owner="${2}"
   local info_path="${3}"

--- a/bin/setup_cluster.sh
+++ b/bin/setup_cluster.sh
@@ -96,6 +96,7 @@ function setup_gcloud_credentials() {
 # use mason_client to get resources
 function get_resource() {
   # cd to tmp, otherwise the go.mod file may be updated
+  # shellcheck disable=SC2164
   (cd /tmp; go get istio.io/test-infra/boskos/cmd/mason_client)
   local type="${1}"
   local owner="${2}"


### PR DESCRIPTION
Not using go modules breaks the `go get`