### PR TITLE
fix mixer_mode label error for v2-nullvm

### DIFF
--- a/perf/benchmark/configs/telemetryv2_cpu_mem.yaml
+++ b/perf/benchmark/configs/telemetryv2_cpu_mem.yaml
@@ -1,5 +1,5 @@
 # Configuration Set5: CPU and memory with telemetryv2 using NullVM.
-mixer_mode: "v2_nullvm"
+mixer_mode: "v2-nullvm"
 conn:
     - 16
 qps:


### PR DESCRIPTION
we should all follow `v2-nullvm` lable.