### PR TITLE
Write label without run information and read labels in graph

### DIFF
--- a/perf/benchmark/runner/runner.py
+++ b/perf/benchmark/runner/runner.py
@@ -152,16 +152,11 @@ class Fortio:
         if duration is None:
             duration = self.duration
 
-        labels = self.run_id
-        labels += "_qps_" + str(qps)
-        labels += "_c_" + str(conn)
-        labels += "_" + str(size)
+        labels = ""
         # Mixer label
         if self.mesh == "istio":
-            labels += "_"
             labels += self.mixer_mode
         elif self.mesh == "linkerd":
-            labels += "_"
             labels += "linkerd"
 
         if self.extra_labels is not None:


### PR DESCRIPTION
This PR writes for each run the same label (for the same type of run which allows to filter the result data based on the labels without any regex.

The only "drawback" of the current approach is that `mixer` is included in the label name (which is IMHO not a problem).

I added an example (I used `python runner/graph.py  tmpsf68xuxa.csv p90 --show_graph`):

<img width="1050" alt="Screenshot 2019-12-08 at 20 46 54" src="https://user-images.githubusercontent.com/9477533/70395153-3fbc9d00-19fc-11ea-8244-00f741f35460.png">
