### PR TITLE
Add "pr-creator" to build-tools image

### DIFF
--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -174,6 +174,11 @@ WORKDIR /tmp/su-exec-${SU_EXEC_VERSION}
 RUN make
 RUN cp -a su-exec ${OUTDIR}/usr/bin
 
+# Install pr-creator
+RUN git clone --depth=1 https://github.com/kubernetes/test-infra.git /tmp/test-infra/
+WORKDIR /tmp/test-infra
+RUN GO111MODULE=on go build -ldflags="-s -w" -o ${OUTDIR}/usr/bin ./robots/pr-creator/
+
 # Cleanup stuff we don't need in the final image
 RUN rm -fr /usr/local/go/doc
 RUN rm -fr /usr/local/go/test


### PR DESCRIPTION
This adds a handy utility to create (or update) pull requests: [`pr-creator`](https://github.com/kubernetes/test-infra/tree/master/robots/pr-creator). Unfortunately this tool is not `go get`-able due to the current state of the `kubernetes/test-infra` dependencies (e.g. https://github.com/kubernetes/test-infra/issues/14070) hence the `git clone`.

The `pr-creator` will be used in standard automation workflows such as, https://github.com/istio/test-infra/pull/2172, to simplify the PR process.