### PR TITLE
Kill all docker containers as well

### DIFF
--- a/docker/build-tools/prow-entrypoint.sh
+++ b/docker/build-tools/prow-entrypoint.sh
@@ -50,6 +50,8 @@ EXIT_VALUE=$?
 set -x
 
 # We cleanup in the trap as well, but just in case try to clean up here as well
+# shellcheck disable=SC2046
+docker kill $(docker ps -q) || true
 docker system prune -af || true
 
 exit "${EXIT_VALUE}"


### PR DESCRIPTION
For https://github.com/istio/test-infra/issues/1988

We should kill running docker containers at the end of the job. Pruning
doesn't stop running containers.