### PR TITLE
update benchmark test nomixer and mixer label

### DIFF
--- a/perf/benchmark/README.md
+++ b/perf/benchmark/README.md
@@ -112,9 +112,9 @@ optional arguments:
   --duration DURATION   duration in seconds of the extract
   --size SIZE           size of the payload
   --mesh MESH           istio or linkerd
-  --mixer_mode MIXER_MODE
-                        run with different mixer configurations: mixer,
-                        nomixer, mixerv2
+  --telemetry_mode TELEMETRY_MODE
+                        run with different telemetry configurations: mixer,
+                        none, telemetryv2
   --client CLIENT       where to run the test from
   --server SERVER       pod ip of the server
   --perf PERF           also run perf and produce flame graph

--- a/perf/benchmark/configs/istio/mixer_cpu_mem.yaml
+++ b/perf/benchmark/configs/istio/mixer_cpu_mem.yaml
@@ -1,5 +1,5 @@
 # Configuration Set1: CPU and memory with mixer enabled
-mixer_mode: "mixer"
+telemetry_mode: "mixer"
 conn:
     - 16
 qps:

--- a/perf/benchmark/configs/istio/mixer_latency.yaml
+++ b/perf/benchmark/configs/istio/mixer_latency.yaml
@@ -1,5 +1,5 @@
 # Configuration Set2: Latency Quantiles with mixer enabled
-mixer_mode: "mixer"
+telemetry_mode: "mixer"
 conn:
     - 2
     - 4

--- a/perf/benchmark/configs/istio/none_cpu_mem.yaml
+++ b/perf/benchmark/configs/istio/none_cpu_mem.yaml
@@ -1,5 +1,5 @@
 # Configuration Set3: CPU and memory with mixer disabled
-mixer_mode: "nomixer"
+telemetry_mode: "none"
 conn:
     - 16
 qps:

--- a/perf/benchmark/configs/istio/none_latency.yaml
+++ b/perf/benchmark/configs/istio/none_latency.yaml
@@ -1,5 +1,5 @@
 # Configuration Set4: Latency Quantiles with mixer disabled
-mixer_mode: "nomixer"
+telemetry_mode: "none"
 conn:
     - 2
     - 4

--- a/perf/benchmark/configs/istio/telemetryv2_cpu_mem.yaml
+++ b/perf/benchmark/configs/istio/telemetryv2_cpu_mem.yaml
@@ -1,5 +1,5 @@
 # Configuration Set5: CPU and memory with telemetryv2 using NullVM.
-mixer_mode: "v2-nullvm"
+telemetry_mode: "v2-nullvm"
 conn:
     - 16
 qps:

--- a/perf/benchmark/configs/istio/telemetryv2_latency.yaml
+++ b/perf/benchmark/configs/istio/telemetryv2_latency.yaml
@@ -1,5 +1,5 @@
 # Configuration Set6: Latency Quantiles with telemetry v2 using NullVM.
-mixer_mode: "v2-nullvm"
+telemetry_mode: "v2-nullvm"
 conn:
     - 2
     - 4

--- a/perf/benchmark/run_benchmark_job.sh
+++ b/perf/benchmark/run_benchmark_job.sh
@@ -185,7 +185,7 @@ CONFIG_DIR="${WD}/configs/istio"
 for f in "${CONFIG_DIR}"/*; do
     fn=$(basename "${f}")
     # pre run
-    if [[ "${fn}" =~ "nomixer" ]];then
+    if [[ "${fn}" =~ "none" ]];then
         prerun_nomixer
     elif [[ "${fn}" =~ "telemetryv2" ]];then
         prerun_v2_nullvm

--- a/perf/benchmark/runner/runner.py
+++ b/perf/benchmark/runner/runner.py
@@ -73,7 +73,7 @@ class Fortio:
             duration=None,
             size=None,
             mode="http",
-            mixer_mode="mixer",
+            telemetry_mode="mixer",
             mixer_cache=True,
             perf_record=False,
             server="fortioserver",
@@ -96,7 +96,7 @@ class Fortio:
         self.ns = os.environ.get("NAMESPACE", "twopods")
         # bucket resolution in seconds
         self.r = "0.00005"
-        self.mixer_mode = mixer_mode
+        self.telemetry_mode = telemetry_mode
         self.mixer_cache = mixer_cache
         self.perf_record = perf_record
         self.server = pod_info("-lapp=" + server, namespace=self.ns)
@@ -159,7 +159,7 @@ class Fortio:
         # Mixer label
         if self.mesh == "istio":
             labels += "_"
-            labels += self.mixer_mode
+            labels += self.telemetry_mode
         elif self.mesh == "linkerd":
             labels += "_"
             labels += "linkerd"
@@ -308,7 +308,7 @@ def fortio_from_config_file(args):
         fortio.conn = job_config.get('conn', 16)
         fortio.qps = job_config.get('qps', 1000)
         fortio.duration = job_config.get('duration', 240)
-        fortio.mixer_mode = job_config.get('mixer_mode', 'mixer')
+        fortio.telemetry_mode = job_config.get('telemetry_mode', 'mixer')
         fortio.metrics = job_config.get('metrics', 'p90')
         fortio.size = job_config.get('size', 1024)
         fortio.perf_record = job_config.get('perf_record', False)
@@ -340,7 +340,7 @@ def run(args):
             ingress=args.ingress,
             mode=args.mode,
             mesh=args.mesh,
-            mixer_mode=args.mixer_mode,
+            telemetry_mode=args.telemetry_mode,
             cacert=args.cacert)
 
     if fortio.duration <= min_duration:
@@ -382,8 +382,8 @@ def get_parser():
         help="istio or linkerd",
         default="istio")
     parser.add_argument(
-        "--mixer_mode",
-        help="run with different mixer configurations: mixer, envoy, mixerv2",
+        "--telemetry_mode",
+        help="run with different mixer configurations: mixer, none, telemetryv2",
         default="mixer")
     parser.add_argument(
         "--client",

--- a/perf/benchmark/runner/runner.py
+++ b/perf/benchmark/runner/runner.py
@@ -383,7 +383,7 @@ def get_parser():
         default="istio")
     parser.add_argument(
         "--mixer_mode",
-        help="run with different mixer configurations: mixer, nomixer, mixerv2",
+        help="run with different mixer configurations: mixer, envoy, mixerv2",
         default="mixer")
     parser.add_argument(
         "--client",


### PR DESCRIPTION
This PR intend to modify the existing test labels on the our perf graphs, like the below.
<img width="465" alt="Screen Shot 2019-12-18 at 4 34 02 PM" src="https://user-images.githubusercontent.com/29208297/71135076-78efcc80-21b5-11ea-9243-f65ab7ab0564.png">

Proposal: 
(1) add "mixer" before "serveronly" and "both"
(2) change "nomixer" to "envoy"

@mandarjog  @howardjohn Please discuss under this PR about your opinion on the above proposal.