### PR TITLE
Allow kubetype gen to register scheme in lower case

### DIFF
--- a/cmd/kubetype-gen/generators/naming.go
+++ b/cmd/kubetype-gen/generators/naming.go
@@ -15,6 +15,8 @@
 package generators
 
 import (
+	"strings"
+
 	"k8s.io/gengo/namer"
 )
 
@@ -24,10 +26,23 @@ func NameSystems(generatedPackage string, tracker namer.ImportTracker) namer.Nam
 		"public":       namer.NewPublicNamer(0),
 		"raw":          namer.NewRawNamer(generatedPackage, tracker),
 		"publicPlural": namer.NewPublicPluralNamer(map[string]string{}),
+		"lower":        newLowerCaseNamer(0),
 	}
 }
 
 // DefaultNameSystem to use if none is specified
 func DefaultNameSystem() string {
 	return "public"
+}
+
+func newLowerCaseNamer(prependPackageNames int, ignoreWords ...string) *namer.NameStrategy {
+	n := &namer.NameStrategy{
+		Join:                namer.Joiner(namer.IL, strings.ToLower),
+		IgnoreWords:         map[string]bool{},
+		PrependPackageNames: prependPackageNames,
+	}
+	for _, w := range ignoreWords {
+		n.IgnoreWords[w] = true
+	}
+	return n
 }

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/spf13/cobra v0.0.4
 	github.com/spf13/viper v1.4.0
 	golang.org/x/crypto v0.0.0-20190923035154-9ee001bba392 // indirect
-	golang.org/x/net v0.0.0-20190923162816-aa69164e4478 // indirect
+	golang.org/x/net v0.0.0-20191004110552-13f9640d40b9 // indirect
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45 // indirect
 	golang.org/x/sys v0.0.0-20190924154521-2837fb4f24fe // indirect
 	golang.org/x/time v0.0.0-20190921001708-c4c64cad1fd0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -306,8 +306,8 @@ golang.org/x/net v0.0.0-20190522155817-f3200d17e092/go.mod h1:HSz+uSET+XFnRR8LxR
 golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
 golang.org/x/net v0.0.0-20190812203447-cdfb69ac37fc h1:gkKoSkUmnU6bpS/VhkuO27bzQeSA51uaEfbOW5dNb68=
 golang.org/x/net v0.0.0-20190812203447-cdfb69ac37fc/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
-golang.org/x/net v0.0.0-20190923162816-aa69164e4478 h1:l5EDrHhldLYb3ZRHDUhXF7Om7MvYXnkV9/iQNo1lX6g=
-golang.org/x/net v0.0.0-20190923162816-aa69164e4478/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20191004110552-13f9640d40b9 h1:rjwSpXsdiK0dV8/Naq3kAw9ymfAeJIyd0upUIElB+lI=
+golang.org/x/net v0.0.0-20191004110552-13f9640d40b9/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45 h1:SVwTIAaPC2U/AvvLNZ2a7OVsmBpC8L5BlwK1whH3hm0=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=


### PR DESCRIPTION
when pushed and used in client-go gen, it will fix https://github.com/istio/istio/issues/19638

This is more of a workaround for some of the Istio APIs that use lower case in CRD names, e.g. instance, template, etc. They should be CamelCased according to Kubernetes convention. So we are registering those APIs with lower case names in the client. 

Need `kubetype-gen:lowerCaseScheme` annotation for the APIs and once those mixer APIs are deprecated, we can remove the annotation.