### PR TITLE
fixing mtls enabling issue in twopods test

### DIFF
--- a/perf/benchmark/setup_test.sh
+++ b/perf/benchmark/setup_test.sh
@@ -47,6 +47,7 @@ function run_test() {
   # shellcheck disable=SC2046
   helm -n "${NAMESPACE}" template \
       --set rbac.enabled="${RBAC_ENABLED}" \
+      --set namespace="${NAMESPACE}" \
       --set includeOutboundIPRanges=$(svc_ip_range) \
       --set client.inject="${ISTIO_INJECT}" \
       --set server.inject="${ISTIO_INJECT}"  \

--- a/perf/benchmark/templates/fortio.yaml
+++ b/perf/benchmark/templates/fortio.yaml
@@ -170,29 +170,6 @@ spec:
 {{ toYaml $.Values.appresources1 | indent 10 }}
 {{- end }}
 ---
-{{- if eq $.name "fortioserver" }}
-apiVersion: authentication.istio.io/v1alpha1
-kind: Policy
-metadata:
-  name: "default"
-  namespace: {{ $.Values.namespace }}
-spec:
-  peers:
-  - mtls:
-      mode: PERMISSIVE
----
-apiVersion: networking.istio.io/v1alpha3
-kind: DestinationRule
-metadata:
-  name: {{ $.name }}
-  namespace: {{ $.Values.namespace }}
-spec:
-  host:  {{ $.name }}
-  trafficPolicy:
-    tls:
-      mode: {{ $.V.tlsmode }}
----
-{{- end }}
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:

--- a/perf/benchmark/templates/fortio.yaml
+++ b/perf/benchmark/templates/fortio.yaml
@@ -170,14 +170,13 @@ spec:
 {{ toYaml $.Values.appresources1 | indent 10 }}
 {{- end }}
 ---
-{{- if $.V.inject }}
+{{- if eq $.name "fortioserver" }}
 apiVersion: authentication.istio.io/v1alpha1
 kind: Policy
 metadata:
-  name: {{ $.name }}
+  name: "default"
+  namespace: {{ $.Values.namespace }}
 spec:
-  targets:
-  - name: {{ $.name }}
   peers:
   - mtls:
       mode: PERMISSIVE
@@ -186,12 +185,14 @@ apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
   name: {{ $.name }}
+  namespace: {{ $.Values.namespace }}
 spec:
   host:  {{ $.name }}
   trafficPolicy:
     tls:
       mode: {{ $.V.tlsmode }}
 ---
+{{- end }}
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
@@ -207,8 +208,6 @@ spec:
         host: {{ $.name }}
         port:
           number: 8080
----
-{{- end }}
 {{- end }}
 
 {{- $fortioserver := dict "name" "fortioserver" "Values" .Values "V" .Values.server}}

--- a/perf/benchmark/templates/mtls.yaml
+++ b/perf/benchmark/templates/mtls.yaml
@@ -1,0 +1,20 @@
+apiVersion: authentication.istio.io/v1alpha1
+kind: Policy
+metadata:
+  name: "default"
+  namespace: {{ $.Values.namespace }}
+spec:
+  peers:
+  - mtls:
+      mode: PERMISSIVE
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: fortioserver
+  namespace: {{ $.Values.namespace }}
+spec:
+  host:  fortioserver
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL

--- a/perf/benchmark/values.yaml
+++ b/perf/benchmark/values.yaml
@@ -42,3 +42,5 @@ client: # client overrides
 
 cert: false
 interceptionMode: REDIRECT
+
+namespace: ""


### PR DESCRIPTION
We should only set "authentication.istio.io/v1alpha1" Policy and "networking.istio.io/v1alpha3" DestinationRule for `fortioclient` pod only. Since in our twopods test, the traffic direction is always from `fortioclient` to `fortioserver`

Here is the generated yaml file:

[twopods-istio.txt](https://github.com/istio/tools/files/4028769/twopods-istio.txt)
