### PR TITLE
set debug=true otherwise static file is not accessible

### DIFF
--- a/perf_dashboard/README.md
+++ b/perf_dashboard/README.md
@@ -1,6 +1,6 @@
 # Istio Performance Dashboard
 
-## How to run this application locally
+## How to run and develop this application locally
 
 - Install Docker on your local machine.
     - [MacOS](https://docs.docker.com/docker-for-mac/install/)

--- a/perf_dashboard/perf_dashboard/settings.py
+++ b/perf_dashboard/perf_dashboard/settings.py
@@ -37,7 +37,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 SECRET_KEY = '0-k61x@nbmohu87^f!gql9ug1c*5(8k@ujeeme%cx4x=d@*=-f'
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = False
+DEBUG = True
 
 ALLOWED_HOSTS = ['localhost', 'perf.dashboard.qualistio.org']
 


### PR DESCRIPTION
We should set debug=True in order to access static files. Otherwise, we have to provide static files with the help of webserver.