### PR TITLE
Replacing defaultNamespace with meshConfig.rootNamespace

### DIFF
--- a/perf/istio-install/setup_istio.sh
+++ b/perf/istio-install/setup_istio.sh
@@ -172,7 +172,7 @@ function install_istio() {
   else
     echo "start installing istio using istioctl"
     pushd "${DIRNAME}/${release}"
-    export SET_OVERLAY="defaultNamespace=istio-system"
+    export SET_OVERLAY="meshConfig.rootNamespace=istio-system"
     export CR_FILENAME="default.yaml"
     export EXTRA_ARGS="--force=true"
     install_istio_with_istioctl

--- a/perf/istio-install/setup_istio_operator.sh
+++ b/perf/istio-install/setup_istio_operator.sh
@@ -59,7 +59,7 @@ function setup_admin_binding() {
 function install_istio() {
     local CR_FILENAME="${WD}/istioctl_profiles/${OPERATOR_PROFILE}"
     pushd "${ISTIO_OPERATOR_DIR}"
-    go run ./cmd/mesh.go manifest apply -f "${CR_FILENAME}" --force=true --set defaultNamespace=${defaultNamespace}
+    go run ./cmd/mesh.go manifest apply -f "${CR_FILENAME}" --force=true --set meshConfig.rootNamespace=${defaultNamespace}
     popd
     echo "installation is done"
 }


### PR DESCRIPTION
Fix perf pipeline error:
```
+ install_istio_with_istioctl
+ local CR_PATH=/home/prow/go/src/istio.io/tools/perf/istio-install/istioctl_profiles/default.yaml
+ ./istioctl manifest apply -f /home/prow/go/src/istio.io/tools/perf/istio-install/istioctl_profiles/default.yaml --set defaultNamespace=istio-system --force=true
Error: failed to generate and apply manifests, error: failed to generate tree from the set overlay, error: bad path=value: defaultNamespace=istio-system
+ cleanup
```