### PR TITLE
fix perf test sidecar include/exclude outbound IP range issue

### DIFF
--- a/perf/benchmark/README.md
+++ b/perf/benchmark/README.md
@@ -136,6 +136,8 @@ optional arguments:
   --no_baseline         do not run baseline for all
   --serversidecar       run serversidecar-only for all
   --no_serversidecar    do not run serversidecar-only for all
+  --clientsidecar       run clientsidecar-only for all
+  --no_clientsidecar    do not run clientsidecar-only for all
   --bothsidecar         run clientsidecar and serversidecar for all
   --no_sidecar          do not run clientsidecar and serversidecar for all
 ```

--- a/perf/benchmark/runner/runner.py
+++ b/perf/benchmark/runner/runner.py
@@ -82,6 +82,7 @@ class Fortio:
             extra_labels=None,
             baseline=False,
             serversidecar=False,
+            clientsidecar=False,
             bothsidecar=True,
             ingress=None,
             mesh="istio",
@@ -104,6 +105,7 @@ class Fortio:
         self.extra_labels = extra_labels
         self.run_baseline = baseline
         self.run_serversidecar = serversidecar
+        self.run_clientsidecar = clientsidecar
         self.run_bothsidecar = bothsidecar
         self.run_ingress = ingress
         self.cacert = cacert
@@ -128,6 +130,13 @@ class Fortio:
             basestr = "-payload-size {size} {svc}:{port}"
         return fortio_cmd + "_serveronly " + basestr.format(
             svc=self.server.ip, port=self.ports[self.mode]["port"], size=self.size)
+
+    def clientsidecar(self, fortio_cmd):
+        basestr = "http://{svc}:{port}/echo?size={size}"
+        if self.mode == "grpc":
+            basestr = "-payload-size {size} {svc}:{port}"
+        return fortio_cmd + "_clientonly " + basestr.format(
+            svc=self.server.labels["app"], port=self.ports[self.mode]["direct_port"], size=self.size)
 
     def bothsidecar(self, fortio_cmd):
         basestr = "http://{svc}:{port}/echo?size={size}"
@@ -202,6 +211,16 @@ class Fortio:
                     self.mesh,
                     self.server.name,
                     labels + "_srv_serveronly",
+                    duration=40)
+
+        if self.run_clientsidecar:
+            print('-------------- Running in client sidecar mode --------------')
+            kubectl_exec(self.client.name, self.clientsidecar(fortio_cmd))
+            if self.perf_record:
+                run_perf(
+                    self.mesh,
+                    self.client.name,
+                    labels + "_srv_clientonly",
                     duration=40)
 
         if self.run_bothsidecar:
@@ -315,6 +334,7 @@ def fortio_from_config_file(args):
         fortio.size = job_config.get('size', 1024)
         fortio.perf_record = job_config.get('perf_record', False)
         fortio.run_serversidecar = job_config.get('run_serversidecar', False)
+        fortio.run_clientsidecar = job_config.get('run_clientsidecar', False)
         fortio.run_bothsidecar = job_config.get('run_bothsidecar', False)
         fortio.run_baseline = job_config.get('run_baseline', True)
         fortio.mesh = job_config.get('mesh', 'istio')
@@ -340,6 +360,7 @@ def run(args):
             extra_labels=args.extra_labels,
             baseline=args.baseline,
             serversidecar=args.serversidecar,
+            clientsidecar=args.clientsidecar,
             bothsidecar=args.bothsidecar,
             ingress=args.ingress,
             mode=args.mode,
@@ -425,6 +446,8 @@ def get_parser():
     define_bool(parser, "baseline", "run baseline for all", False)
     define_bool(parser, "serversidecar",
                 "run serversidecar-only for all", False)
+    define_bool(parser, "clientsidecar",
+                "run clientsidecar-only for all", False)
     define_bool(parser, "bothsidecar",
                 "run clientsiecar and serversidecar for all", True)
 

--- a/perf/benchmark/setup_test.sh
+++ b/perf/benchmark/setup_test.sh
@@ -48,6 +48,7 @@ function run_test() {
   helm -n "${NAMESPACE}" template \
       --set rbac.enabled="${RBAC_ENABLED}" \
       --set namespace="${NAMESPACE}" \
+      --set excludeOutboundIPRanges=$(pod_ip_range)\
       --set includeOutboundIPRanges=$(svc_ip_range) \
       --set client.inject="${ISTIO_INJECT}" \
       --set server.inject="${ISTIO_INJECT}"  \

--- a/perf/benchmark/templates/fortio.yaml
+++ b/perf/benchmark/templates/fortio.yaml
@@ -36,10 +36,10 @@ spec:
     port: 8079
     protocol: TCP
   - name: http-echoa
-    port: 8078
+    port: 8077
     protocol: TCP
   - name: grpc-pinga
-    port: 8077
+    port: 8076
     protocol: TCP
   selector:
     app: {{ $.name }}
@@ -82,11 +82,13 @@ spec:
         {{- if $.Values.interceptionMode }}
         sidecar.istio.io/interceptionMode: {{ $.Values.interceptionMode }}
         {{- end }}
-        {{- if $.Values.excludeOutboundIPRanges }}
+        {{- if eq $.name "fortioclient" }}
+        {{- if $.Values.excludeOutboundIPRanges}}
         traffic.sidecar.istio.io/excludeOutboundIPRanges: {{ $.Values.excludeOutboundIPRanges }}
         {{- end }}
         {{- if $.Values.includeOutboundIPRanges }}
         traffic.sidecar.istio.io/includeOutboundIPRanges: {{ $.Values.includeOutboundIPRanges }}
+        {{- end }}
         {{- end }}
         sidecar.istio.io/inject: "{{ $.V.inject }}"
         linkerd.io/inject: "{{ $.V.injectL }}"

--- a/perf/benchmark/templates/mtls.yaml
+++ b/perf/benchmark/templates/mtls.yaml
@@ -16,5 +16,13 @@ metadata:
 spec:
   host:  fortioserver
   trafficPolicy:
-    tls:
-      mode: ISTIO_MUTUAL
+    portLevelSettings:
+    - port:
+        number: 8080
+      tls:
+        mode: ISTIO_MUTUAL
+    - port:
+        number: 8077
+      tls:
+        mode: DISABLE
+

--- a/perf/benchmark/values.yaml
+++ b/perf/benchmark/values.yaml
@@ -1,5 +1,4 @@
-
-#excludeOutboundIPRanges exclude pod ips
+# for client side setting, IP Ranges is server side service or pod
 excludeOutboundIPRanges: ""
 includeOutboundIPRanges: ""
 


### PR DESCRIPTION
1. Add client only sidecar mode in our performance test runner.
2. fix perf test sidecar include/exclude outbound IP range issue:
ipranges is defined only at outbound: https://github.com/istio/istio/blob/master/pkg/kube/inject/inject.go#L178-L180