### PR TITLE
add configs for stackdriver filter in benchmark

### DIFF
--- a/perf/benchmark/configs/istio/telemetryv2_sd_cpu_mem.yaml
+++ b/perf/benchmark/configs/istio/telemetryv2_sd_cpu_mem.yaml
@@ -1,0 +1,19 @@
+# Configuration Set10: CPU and memory with telemetryv2 using NullVM with
+# Stackdriver filter with metrics/topology on.
+telemetry_mode: "v2-stackdriver-nologging-nullvm"
+conn:
+  - 16
+qps:
+  - 10
+  - 100
+  - 500
+  - 1000
+  - 2000
+  - 3000
+duration: 240
+metrics:
+  - cpu
+  - mem
+perf_record: false
+run_serversidecar: true
+run_baseline: true

--- a/perf/benchmark/configs/istio/telemetryv2_sd_latency.yaml
+++ b/perf/benchmark/configs/istio/telemetryv2_sd_latency.yaml
@@ -1,0 +1,20 @@
+# Configuration Set9: Latency Quantiles with telemetry v2 using NullVM with
+# Stackdriver filter with metrics/topology on.
+telemetry_mode: "v2-stackdriver-nologging-nullvm"
+conn:
+  - 2
+  - 4
+  - 8
+  - 16
+  - 32
+  - 64
+qps:
+  - 1000
+duration: 240
+metrics:
+  - p50
+  - p90
+  - p99
+perf_record: true
+run_serversidecar: true
+run_baseline: true

--- a/perf/benchmark/configs/istio/telemetryv2_sdfull_cpu_mem.yaml
+++ b/perf/benchmark/configs/istio/telemetryv2_sdfull_cpu_mem.yaml
@@ -1,0 +1,19 @@
+# Configuration Set8: CPU and memory with telemetryv2 using NullVM with
+# Stackdriver filter with metrics/logging/topology on.
+telemetry_mode: "v2-stackdriver-nullvm"
+conn:
+  - 16
+qps:
+  - 10
+  - 100
+  - 500
+  - 1000
+  - 2000
+  - 3000
+duration: 240
+metrics:
+  - cpu
+  - mem
+perf_record: false
+run_serversidecar: true
+run_baseline: true

--- a/perf/benchmark/configs/istio/telemetryv2_sdfull_latency.yaml
+++ b/perf/benchmark/configs/istio/telemetryv2_sdfull_latency.yaml
@@ -1,0 +1,20 @@
+# Configuration Set7: Latency Quantiles with telemetry v2 using NullVM with
+# Stackdriver filter with metrics/logging/topology on.
+telemetry_mode: "v2-stackdriver-nullvm"
+conn:
+  - 2
+  - 4
+  - 8
+  - 16
+  - 32
+  - 64
+qps:
+  - 1000
+duration: 240
+metrics:
+  - p50
+  - p90
+  - p99
+perf_record: true
+run_serversidecar: true
+run_baseline: true

--- a/perf/benchmark/configs/istio/telemetryv2_stats_cpu_mem.yaml
+++ b/perf/benchmark/configs/istio/telemetryv2_stats_cpu_mem.yaml
@@ -1,5 +1,5 @@
-# Configuration Set5: CPU and memory with telemetryv2 using NullVM.
-telemetry_mode: "v2-nullvm"
+# Configuration Set5: CPU and memory with telemetryv2 using NullVM with stats envoyfilter.
+telemetry_mode: "v2-stats-nullvm"
 conn:
     - 16
 qps:

--- a/perf/benchmark/configs/istio/telemetryv2_stats_latency.yaml
+++ b/perf/benchmark/configs/istio/telemetryv2_stats_latency.yaml
@@ -1,5 +1,5 @@
-# Configuration Set6: Latency Quantiles with telemetry v2 using NullVM.
-telemetry_mode: "v2-nullvm"
+# Configuration Set6: Latency Quantiles with telemetry v2 using NullVM with stats envoyfilter.
+telemetry_mode: "v2-stats-nullvm"
 conn:
     - 2
     - 4


### PR DESCRIPTION
Temporary solution, would be easier and cleaner to add these configs after refactoring of the benchmark test config setup part.