### PR TITLE
fix release tar path of latest master build for upgrade job

### DIFF
--- a/upgrade/run_upgrade_test.sh
+++ b/upgrade/run_upgrade_test.sh
@@ -48,9 +48,16 @@ function download_untar_istio_release() {
   # Download artifacts
   LINUX_DIST_URL="${url_path}/istio-${tag}-linux.tar.gz"
 
+  if [ "${TARGET_TAG}" == "master" ];then
+    GIT_SHA=$(curl "https://storage.googleapis.com/istio-build/dev/latest")
+    tag="istio-${GIT_SHA}"
+    LINUX_DIST_URL="https://storage.googleapis.com/istio-build/dev/${GIT_SHA}/istio-${GIT_SHA}-linux.tar.gz"
+  fi
+
   wget  -q "${LINUX_DIST_URL}" -P "${dir}"
   tar -xzf "${dir}/istio-${tag}-linux.tar.gz" -C "${dir}"
 }
+
 # shellcheck disable=SC1090
 source "${ROOT}/bin/setup_cluster.sh"
 # Set to any non-empty value to use kubectl configured cluster instead of mason provisioned cluster.


### PR DESCRIPTION
Here is the error log:

```
LINUX_DIST_URL=https://github.com/istio/istio/releases/download/master/istio-master-linux.tar.gz
+ wget -q https://github.com/istio/istio/releases/download/master/istio-master-linux.tar.gz -P to_dir.1oPVJ7
+ EXIT_VALUE=8
+ docker ps -aq
+ xargs -r docker rm -f
+ exit 8
```