### PR TITLE
Remove hugo shortcode replacement in doc gen

### DIFF
--- a/cmd/protoc-gen-docs/htmlGenerator.go
+++ b/cmd/protoc-gen-docs/htmlGenerator.go
@@ -810,9 +810,6 @@ func (g *htmlGenerator) generateComment(loc protomodel.LocationDescriptor, name 
 	result = bytes.Replace(result, []byte("&amp;lt;"), []byte("&lt;"), -1)
 	result = bytes.Replace(result, []byte("&amp;gt;"), []byte("&gt;"), -1)
 
-	// prevent any { contained in the markdown from being interpreted as Hugo shortcodes
-	result = bytes.Replace(result, []byte("{"), []byte("&lbrace;"), -1)
-
 	g.buffer.Write(result)
 	g.buffer.WriteByte('\n')
 }


### PR DESCRIPTION
Hugo shortcode is only interpreted when double brackets `{{` presents. Our code samples in doc does not have `{{`. (if we do, separate them with whitespace should be sufficient to avoid shortcode interpretation)

Without such replacement, we are able to have hugo shortcode inside markdown for additional html rendering in API comments. As an immediate outcome, we are able to have tabs for configuration samples:
![image](https://user-images.githubusercontent.com/7304774/73497966-dc524a00-4370-11ea-858b-77ef4cc84828.png)
