### PR TITLE
fixing upgrade job: should check "tag" not only TARGET_TAG

### DIFF
--- a/upgrade/run_upgrade_test.sh
+++ b/upgrade/run_upgrade_test.sh
@@ -47,19 +47,15 @@ function download_untar_istio_release() {
   local dir=${3:-.}
   # Download artifacts
   LINUX_DIST_URL="${url_path}/istio-${tag}-linux.tar.gz"
-  echo "${LINUX_DIST_URL}"
 
-  if [ "${TARGET_TAG}" == "master" ];then
+  if [ "${tag}" == "master" ];then
     GIT_SHA=$(curl "https://storage.googleapis.com/istio-build/dev/latest")
     tag="${GIT_SHA}"
     LINUX_DIST_URL="https://storage.googleapis.com/istio-build/dev/${tag}/istio-${tag}-linux.tar.gz"
   fi
 
   wget -q "${LINUX_DIST_URL}" -P "${dir}"
-
   tar -xzf "${dir}/istio-${tag}-linux.tar.gz" -C "${dir}"
-  find "${dir}" -maxdepth 1 -type f
-  find "${dir}/istio-${tag}" -maxdepth 1 -type f
 }
 
 # shellcheck disable=SC1090


### PR DESCRIPTION
Finally, I got the correct logic_(¦3」∠)_ I should check "tag" (any release tag SOURCE_TAG and TARGET_TAG), not only TARGET_TAG. 
Since if I only check TARGET_TAG, then SOURCE istio tar can never be downloaded and untar. That's why it hits: `find: ‘from_dir.ctoBlt/istio-1.4.3/bin’: No such file or directory` error.
