### PR TITLE
disable perf flame graph record for debugging pipeline issue

### DIFF
--- a/perf/benchmark/run_benchmark_job.sh
+++ b/perf/benchmark/run_benchmark_job.sh
@@ -228,7 +228,7 @@ trap exit_handling EXIT
 echo "Start running perf benchmark test, data would be saved to GCS bucket: ${GCS_BUCKET}/${OUTPUT_DIR}"
 
 # enable flame graph
-enable_perf_record
+# enable_perf_record
 
 # For adding or modifying configurations, refer to perf/benchmark/README.md
 CONFIG_DIR="${WD}/configs/istio"
@@ -260,8 +260,8 @@ for f in "${CONFIG_DIR}"/*; do
     
 done
 
-echo "collect flame graph ..."
-collect_flame_graph
+#echo "collect flame graph ..."
+#collect_flame_graph
 
 echo "perf benchmark test for istio is done."
 

--- a/perf/benchmark/runner/runner.py
+++ b/perf/benchmark/runner/runner.py
@@ -332,7 +332,7 @@ def fortio_from_config_file(args):
         fortio.telemetry_mode = job_config.get('telemetry_mode', 'mixer')
         fortio.metrics = job_config.get('metrics', 'p90')
         fortio.size = job_config.get('size', 1024)
-        fortio.perf_record = job_config.get('perf_record', False)
+        fortio.perf_record = False
         fortio.run_serversidecar = job_config.get('run_serversidecar', False)
         fortio.run_clientsidecar = job_config.get('run_clientsidecar', False)
         fortio.run_bothsidecar = job_config.get('run_bothsidecar', True)


### PR DESCRIPTION
Debugging recent perf pipeline issues, cause only perf flag part ssh and interact with the nodes, Here we just want to check if this part has some affects on the node connections.