### PR TITLE
small clean up of benchmark script

### DIFF
--- a/perf/istio-install/setup_istio.sh
+++ b/perf/istio-install/setup_istio.sh
@@ -171,6 +171,10 @@ function install_istio() {
 
   export ISTIOCTL_PATH="${DIRNAME}/${release}"
 
+  if [[ -n "${SKIP_INSTALLATION}" ]];then
+    echo "skip installation step"
+    return
+  fi
   if [[ -z "${INSTALL_WITH_ISTIOCTL}" ]]; then
     echo "start installing istio using helm"
     install_istio_with_helm


### PR DESCRIPTION
The benchmark job succeeded last night, add more fixes/modification on top of that
1. remove unnecessary install istio step at the beginning, install should be done at prerun step
2. temporarily remove linkerd job now, let's get latency,cpu,mem for all istio configs work first

This code would be more clear after this PR: https://github.com/istio/tools/pull/738