### PR TITLE
use fortio image from istio-testing container registry

### DIFF
--- a/perf/benchmark/setup_test.sh
+++ b/perf/benchmark/setup_test.sh
@@ -56,7 +56,7 @@ function run_test() {
       --set server.injectL="${LINKERD_INJECT}" \
       --set domain="${DNS_DOMAIN}" \
       --set interceptionMode="${INTERCEPTION_MODE}" \
-      --set fortioImage="gcr.io/carolyntestprj-262400/fortio:carolyn" \
+      --set fortioImage="gcr.io/istio-testing/fortio:latest" \
           . > "${TMPDIR}/${NAMESPACE}.yaml"
   echo "Wrote file ${TMPDIR}/${NAMESPACE}.yaml"
 


### PR DESCRIPTION
patch for this PR: https://github.com/istio/tools/pull/762

Previously I pushed fortio image to my own project, which we prefer to use image from `istio-testing`, so I pushed a fortio image with my changes to `istio-testing`.