### PR TITLE
Revert "Update Golang to 1.14.0"

### DIFF
--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -25,7 +25,7 @@
 # Binary tools
 ################
 
-FROM golang:1.14.0 as binary_tools_context
+FROM golang:1.13.8 as binary_tools_context
 
 # Istio tools SHA that we use for this image
 ARG ISTIO_TOOLS_SHA


### PR DESCRIPTION
Reverts istio/tools#761

This breaks istio for a few reasons. We reverted the build-tools update, but then another PR pushed it through again -- the correct fix was to revert here