### PR TITLE
Add host --headers flag to fortio command for perf test

### DIFF
--- a/perf/benchmark/README.md
+++ b/perf/benchmark/README.md
@@ -113,6 +113,7 @@ Required fields to specified via CLI or config file:
 ```bash
 optional arguments:
   -h, --help            show this help message and exit
+  --headers HEADERS     header:value, can be specified multiple times to add headers \(including Host:\)
   --conn CONN           number of connections, comma separated list
   --qps QPS             qps, comma separated list
   --duration DURATION   duration in seconds of the extract

--- a/perf/benchmark/README.md
+++ b/perf/benchmark/README.md
@@ -113,7 +113,7 @@ Required fields to specified via CLI or config file:
 ```bash
 optional arguments:
   -h, --help            show this help message and exit
-  --headers HEADERS     header:value, can be specified multiple times to add headers \(including Host:\)
+  --headers HEADERS     a list of `header:value` should be separated by comma, e.g. --headers="foo:bar,foo1:bar1,foo2:bar2"
   --conn CONN           number of connections, comma separated list
   --qps QPS             qps, comma separated list
   --duration DURATION   duration in seconds of the extract

--- a/perf/benchmark/runner/runner.py
+++ b/perf/benchmark/runner/runner.py
@@ -184,8 +184,12 @@ class Fortio:
         if self.cacert is not None:
             cacert_arg = "-cacert {cacert_path}".format(cacert_path=self.cacert)
 
+        headers_cmd = ""
+        for header_val in headers.split(","):
+            headers_cmd += "-H=" + header_val + " "
+
         fortio_cmd = (
-            "fortio load -H={headers} -c {conn} -qps {qps} -t {duration}s -a -r {r} {cacert_arg} {grpc} -httpbufferkb=128 " +
+            "fortio load {headers_cmd} -c {conn} -qps {qps} -t {duration}s -a -r {r} {cacert_arg} {grpc} -httpbufferkb=128 " +
             "-labels {labels}").format(
                 headers=headers,
                 conn=conn,
@@ -392,7 +396,7 @@ def get_parser():
     parser = argparse.ArgumentParser("Run performance test")
     parser.add_argument(
         "--headers",
-        help="header:value, can be specified multiple times to add headers (including Host:)",
+        help="a list of `header:value` should be separated by comma",
         default=None)
     parser.add_argument(
         "--conn",

--- a/perf/benchmark/runner/runner.py
+++ b/perf/benchmark/runner/runner.py
@@ -185,7 +185,7 @@ class Fortio:
             cacert_arg = "-cacert {cacert_path}".format(cacert_path=self.cacert)
 
         fortio_cmd = (
-            "fortio load -H={headers} -c {conn} -qps {qps} -t {duration}s -a -r {r} {grpc} -httpbufferkb=128 " +
+            "fortio load -H={headers} -c {conn} -qps {qps} -t {duration}s -a -r {r} {cacert_arg} {grpc} -httpbufferkb=128 " +
             "-labels {labels}").format(
                 headers=headers,
                 conn=conn,


### PR DESCRIPTION
https://github.com/istio/istio/issues/21687

In perf test we are passing the headers like: `--headers=foo:bar,foo1:bar1,foo2:bar2`, and in fortio, it will be like: `-H=foo:bar -H=foo1:bar1  -H=foo2:bar2`