### PR TITLE
remove unnecessary get masonclient

### DIFF
--- a/bin/setup_cluster.sh
+++ b/bin/setup_cluster.sh
@@ -98,7 +98,6 @@ function setup_gcloud_credentials() {
 function get_resource() {
   # cd to tmp, otherwise the go.mod file may be updated
   # shellcheck disable=SC2164
-  (cd /tmp; go get istio.io/test-infra/boskos/cmd/mason_client)
   local type="${1}"
   local owner="${2}"
   local info_path="${3}"


### PR DESCRIPTION
we can just use the one with the build-tools image