### PR TITLE
convert SOURCE/TARGET TAG to GIT_SHA if necessary for fixing upgrade job issues

### DIFF
--- a/upgrade/run_upgrade_test.sh
+++ b/upgrade/run_upgrade_test.sh
@@ -40,7 +40,9 @@ export FROM_PATH=${FROM_PATH:-"$(mktemp -d from_dir.XXXXXX)"}
 export TO_PATH=${TO_PATH:-"$(mktemp -d to_dir.XXXXXX)"}
 
 function get_git_sha() {
-  local tag=${1}
+  local url_path=${1}
+  local tag=${2}
+
   GIT_SHA=""
 
   if [[ "${tag}" =~ "latest" ]];then
@@ -53,12 +55,12 @@ function get_git_sha() {
   echo "${GIT_SHA}"
 }
 
-GIT_SHA=$(get_git_sha "${SOURCE_TAG}")
+GIT_SHA=$(get_git_sha "${SOURCE_RELEASE_PATH}" "${SOURCE_TAG}")
 if [[ -n "${GIT_SHA}" ]]; then
   export SOURCE_TAG="${GIT_SHA}"
 fi
 
-GIT_SHA=$(get_git_sha "${TARGET_TAG}")
+GIT_SHA=$(get_git_sha "${TARGET_RELEASE_PATH}" "${TARGET_TAG}")
 if [[ -n "${GIT_SHA}" ]]; then
   export TARGET_TAG="${GIT_SHA}"
 fi


### PR DESCRIPTION
This PR is to fix https://storage.googleapis.com/istio-prow/logs/istio-upgrade-using-istioctl-1.5_latest-master/17/build-log.txt: 
```
find: ‘from_dir.47miod/istio-1.5_latest/bin’: No such file or directory
/home/prow/go/src/istio.io/tools/upgrade/test_crossgrade.sh: line 249: from_dir.47miod/istio-1.5_latest/bin/istioctl: No such file or directory
Waiting for ingress-gateway addr...
```

This should be a unified fix for both `run_upgrade_test.sh` and `test_crossgrade.sh` upgrade job failures due to the some conversions required when SOURCE/TARGET_TAG contain either `latest` or `master` keyword.

This fix should be compatible with both SOURCE/TARGET_TAG which contain `lastest` or `master` keyword, or they are specified with a certain release version like `1.4.4`.
