### PR TITLE
Enable docker IPv6

### DIFF
--- a/docker/build-tools/prow-entrypoint.sh
+++ b/docker/build-tools/prow-entrypoint.sh
@@ -16,6 +16,26 @@
 
 set -x
 
+# optionally enable ipv6 docker
+export DOCKER_IN_DOCKER_IPV6_ENABLED=${DOCKER_IN_DOCKER_IPV6_ENABLED:-false}
+if [[ "${DOCKER_IN_DOCKER_IPV6_ENABLED}" == "true" ]]; then
+  echo "wrapper.sh] [SETUP] Enabling IPv6 in Docker config ..."
+  # configure the daemon with ipv6
+  mkdir -p /etc/docker/
+  cat <<EOF >/etc/docker/daemon.json
+{
+  "ipv6": true,
+  "fixed-cidr-v6": "fc00:db8:1::/64"
+}
+EOF
+  # enable ipv6
+  sysctl net.ipv6.conf.all.disable_ipv6=0
+  sysctl net.ipv6.conf.all.forwarding=1
+  # enable ipv6 iptables
+  modprobe -v ip6table_nat
+  echo "wrapper.sh] [SETUP] Done enabling IPv6 in Docker config."
+fi
+
 # Start docker daemon and wait for dockerd to start
 service docker start
 


### PR DESCRIPTION
Enable IPv6 in docker so it can be used to test IPv6 with kind

xref: https://github.com/istio/istio/issues/1756