### PR TITLE
fix headers keyerror issue in fortio cmd

### DIFF
--- a/perf/benchmark/runner/runner.py
+++ b/perf/benchmark/runner/runner.py
@@ -190,9 +190,9 @@ class Fortio:
                 headers_cmd += "-H=" + header_val + " "
 
         fortio_cmd = (
-            "fortio load {headers_cmd} -c {conn} -qps {qps} -t {duration}s -a -r {r} {cacert_arg} {grpc} -httpbufferkb=128 " +
+            "fortio load {headers} -c {conn} -qps {qps} -t {duration}s -a -r {r} {cacert_arg} {grpc} -httpbufferkb=128 " +
             "-labels {labels}").format(
-                headers=headers,
+                headers=headers_cmd,
                 conn=conn,
                 qps=qps,
                 duration=duration,


### PR DESCRIPTION
Fix this perf pipeline error:
```
Namespace(baseline=False, bothsidecar=True, cacert=None, client=None, clientsidecar=False, config_file='/home/prow/go/src/istio.io/tools/perf/benchmark/configs/istio/mixer/cpu_mem.yaml', conn=None, duration=None, extra_labels=None, headers=None, ingress=None, mesh='istio', mode='http', perf=False, qps=None, server=None, serversidecar=False, size=1024, telemetry_mode='mixer')
Traceback (most recent call last):
  File "runner.py", line 487, in <module>
    sys.exit(main(sys.argv[1:]))
  File "runner.py", line 483, in main
    return run(args)
  File "runner.py", line 389, in run
    duration=fortio.duration, size=fortio.size)
  File "runner.py", line 202, in run
    labels=labels)
KeyError: 'headers_cmd'
```