### PR TITLE
Retain .proto ordering for protoc-gen-docs

### DIFF
--- a/cmd/protoc-gen-docs/htmlGenerator.go
+++ b/cmd/protoc-gen-docs/htmlGenerator.go
@@ -87,17 +87,10 @@ func (g *htmlGenerator) getFileContents(file *protomodel.FileDescriptor,
 	messages *[]*protomodel.MessageDescriptor,
 	enums *[]*protomodel.EnumDescriptor,
 	services *[]*protomodel.ServiceDescriptor) {
-	for _, m := range file.AllMessages {
-		*messages = append(*messages, m)
-	}
 
-	for _, e := range file.AllEnums {
-		*enums = append(*enums, e)
-	}
-
-	for _, s := range file.Services {
-		*services = append(*services, s)
-	}
+	*messages = append(*messages, file.AllMessages...)
+	*enums = append(*enums, file.AllEnums...)
+	*services = append(*services, file.Services...)
 
 	for _, m := range file.AllMessages {
 		g.includeUnsituatedDependencies(messages, enums, m)


### PR DESCRIPTION
Currently, fields are alphabetically sorted. For most protos, this is
not the ideal order - fields are ordered logically in the .proto file to
capture the mental flow a user will follow. For example, VirtualService
should be the first item, followed by subfields. If a deep subfield,
like CORSPolicy, is the first item, its quite confusing to understand,
as the field is meaningless without the context from top level fields
that reference it.

This change simply retains the ordering that is in the original .proto
file, giving authors the flexibility to order the doc as they please.