### PR TITLE
add mtls in none_both label to make it clearer

### DIFF
--- a/perf_dashboard/static/js/alert_common_func.js
+++ b/perf_dashboard/static/js/alert_common_func.js
@@ -71,7 +71,7 @@ window.generateChart = function(chartID, modesData) {
       {
         type: "line",
         showInLegend: true,
-        name: "none_both-baseline",
+        name: "none_mtls_both-baseline",
         markerType: "square",
         xValueFormatString: "DD MMM, YYYY",
         color: "rgba(0, 0, 0, 1)",

--- a/perf_dashboard/static/js/cpu_memory.js
+++ b/perf_dashboard/static/js/cpu_memory.js
@@ -81,7 +81,7 @@ new Chart(document.getElementById("cpu-qps-release"), {
                 hidden: true,
                 fill: false
             }, {
-                label: "none-both",
+                label: "none-mtls-both",
                 backgroundColor: "rgba(0, 0, 0, 0.2)",
                 borderColor: "rgba(0, 0, 0, 1)",
                 data: cpu_none_both,
@@ -164,7 +164,7 @@ new Chart(document.getElementById("mem-qps-release"), {
                 hidden: true,
                 fill: false
             }, {
-                label: "none-both",
+                label: "none-mtls-both",
                 backgroundColor: "rgba(0, 0, 0, 0.2)",
                 borderColor: "rgba(0, 0, 0, 1)",
                 data: mem_none_both,
@@ -247,7 +247,7 @@ new Chart(document.getElementById("cpu-qps-master"), {
                 hidden: true,
                 fill: false
             }, {
-                label: "none-both",
+                label: "none-mtls-both",
                 backgroundColor: "rgba(0, 0, 0, 0.2)",
                 borderColor: "rgba(0, 0, 0, 1)",
                 data: cpu_none_both_master,
@@ -330,7 +330,7 @@ new Chart(document.getElementById("mem-qps-master"), {
                 hidden: true,
                 fill: false
             }, {
-                label: "none-both",
+                label: "none-mtls-both",
                 backgroundColor: "rgba(0, 0, 0, 0.2)",
                 borderColor: "rgba(0, 0, 0, 1)",
                 data: mem_none_both_master,

--- a/perf_dashboard/static/js/latency_common_func.js
+++ b/perf_dashboard/static/js/latency_common_func.js
@@ -145,7 +145,7 @@ window.generateLatencyChartByID = function(chartID, connNum, modesData, options)
                 hidden: true,
                 fill: false
             }, {
-                label: "none-both",
+                label: "none-mtls-both",
                 backgroundColor: "rgba(0,0,0,0.2)",
                 borderColor: "rgba(0,0,0,1)",
                 data: modesData[6],


### PR DESCRIPTION
by default we enabled mtls, so to make much clearer, I'm adding mtls in none_both label