### PR TITLE
add extra_labels mtls for none telemetry mode

### DIFF
--- a/perf/benchmark/configs/istio/none/cpu_mem.yaml
+++ b/perf/benchmark/configs/istio/none/cpu_mem.yaml
@@ -19,3 +19,5 @@ run_bothsidecar: true
 run_serversidecar: false
 run_clientsidecar: false
 run_baseline: true
+
+extra_labels: "mtls"

--- a/perf/benchmark/configs/istio/none/latency.yaml
+++ b/perf/benchmark/configs/istio/none/latency.yaml
@@ -21,3 +21,5 @@ run_bothsidecar: true
 run_serversidecar: false
 run_clientsidecar: false
 run_baseline: true
+
+extra_labels: "mtls"


### PR DESCRIPTION
Since by default, we are enabling mtls, to be clear, we need to add extra_labels for the none mode.  This is a temp solution, I think we should add a `--mtls` flag, which indicates whether mtls is enabled or not. 