### PR TITLE
Fix perf-dashboard deploy for helm2

### DIFF
--- a/perf_dashboard/Makefile
+++ b/perf_dashboard/Makefile
@@ -22,7 +22,7 @@ push:
 	@docker push "$(IMG_VERSION)"
 
 deploy_only: get-cluster-credentials
-	@helm template "perf-dashboard" --set version="$(VERSION)" deploy/perf-dashboard | kubectl apply -f -
+	@helm template --name "perf-dashboard" --set version="$(VERSION)" deploy/perf-dashboard | kubectl apply -f -
 	@echo "Deployed perf-dashboard:$(VERSION) to project:$(PROJECT) cluster:$(CLUSTER)"
 
 deploy: build push deploy_only


### PR DESCRIPTION
The `helm` available in the build-tools image is `helm@2`. This was written assuming `helm@3` which accepts a **name** parameter as the first positional parameter. So, updating accordingly.

fix: [deploy-perf-dashboard_tools_postsubmit](https://prow.istio.io/view/gcs/istio-prow/logs/deploy-perf-dashboard_tools_postsubmit/1)