### PR TITLE
remove mixer mode from perf test run and dashboard

### DIFF
--- a/perf/benchmark/configs/README.md
+++ b/perf/benchmark/configs/README.md
@@ -12,4 +12,5 @@ To add a new config to this pipeline, we need to add a new directory under [conf
 
 An example of recently added new config: [plaintext](https://github.com/istio/tools/tree/master/perf/benchmark/configs/istio/plaintext)
 
-Note: we have a [perf_test.conf](./istio/run_perf_test.conf) file to control the disable and enable of the set of perf test configs. 
+Note: we have a [run_perf_test.conf](./istio/run_perf_test.conf) file to control the disable and enable of the set of perf test configs.
+

--- a/perf/benchmark/configs/README.md
+++ b/perf/benchmark/configs/README.md
@@ -11,3 +11,5 @@ To add a new config to this pipeline, we need to add a new directory under [conf
 - postrun.sh: postrun hook we want to run after test
 
 An example of recently added new config: [plaintext](https://github.com/istio/tools/tree/master/perf/benchmark/configs/istio/plaintext)
+
+Note: we have a [perf_test.conf](./istio/run_perf_test.conf) file to control the disable and enable of the set of perf test configs. 

--- a/perf/benchmark/configs/istio/run_perf_test.conf
+++ b/perf/benchmark/configs/istio/run_perf_test.conf
@@ -1,0 +1,6 @@
+mixer=false
+none=true
+plaintext=true
+telemetryv2_sd_full=true
+telemetryv2_sd_nologging=true
+telemetryv2_stats=true

--- a/perf/benchmark/run_benchmark_job.sh
+++ b/perf/benchmark/run_benchmark_job.sh
@@ -210,7 +210,7 @@ read_perf_test_conf "${CONFIG_DIR}/run_perf_test.conf"
 
 for dir in "${CONFIG_DIR}"/*; do
     # get the last directory name after splitting dir path by '/', which is the configuration dir name
-    config_name="$(basename ${dir})"
+    config_name="$(basename "${dir}")"
     # skip the test config that is disabled to run
     if (( !"${config_name}" )); then
         continue

--- a/perf/benchmark/run_benchmark_job.sh
+++ b/perf/benchmark/run_benchmark_job.sh
@@ -138,6 +138,7 @@ function read_perf_test_conf()
     case "$key" in
       '#'*) ;;
       *)
+        # shellcheck disable=SC2086
         export ${key}="${value}"
     esac
   done < "${perf_test_conf}"

--- a/perf/benchmark/run_benchmark_job.sh
+++ b/perf/benchmark/run_benchmark_job.sh
@@ -194,6 +194,9 @@ DEFAULT_CR_PATH="${ROOT}/istio-install/istioctl_profiles/default.yaml"
 CONFIG_DIR="${WD}/configs/istio"
 
 for dir in "${CONFIG_DIR}"/*; do
+    if [[ "${dir}" =~ "mixer" ]];then
+        continue
+    fi
     pushd "${dir}"
     # install istio with custom overlay
     if [[ -e "./installation.yaml" ]]; then

--- a/perf/benchmark/run_benchmark_job.sh
+++ b/perf/benchmark/run_benchmark_job.sh
@@ -205,7 +205,7 @@ DEFAULT_CR_PATH="${ROOT}/istio-install/istioctl_profiles/default.yaml"
 # For adding or modifying configurations, refer to perf/benchmark/README.md
 CONFIG_DIR="${WD}/configs/istio"
 
-read_perf_test_conf "${CONFIG_DIR}/perf_test.conf"
+read_perf_test_conf "${CONFIG_DIR}/run_perf_test.conf"
 
 for dir in "${CONFIG_DIR}"/*; do
     # get the last directory name after splitting dir path by '/', which is the configuration dir name

--- a/perf/benchmark/run_benchmark_job.sh
+++ b/perf/benchmark/run_benchmark_job.sh
@@ -210,7 +210,7 @@ read_perf_test_conf "${CONFIG_DIR}/run_perf_test.conf"
 
 for dir in "${CONFIG_DIR}"/*; do
     # get the last directory name after splitting dir path by '/', which is the configuration dir name
-    config_name=$(echo "${dir}" | awk -F'/' '{print $NF}')
+    config_name="$(basename ${dir})"
     # skip the test config that is disabled to run
     if (( !"${config_name}" )); then
         continue

--- a/perf/benchmark/run_benchmark_job.sh
+++ b/perf/benchmark/run_benchmark_job.sh
@@ -131,6 +131,18 @@ function collect_clusters_info() {
   collect_envoy_info "${1}" "${FORTIO_SERVER_POD}" "clusters"
 }
 
+function read_perf_test_conf()
+{
+  perf_test_conf="${1}"
+  while IFS="=" read -r key value; do
+    case "$key" in
+      '#'*) ;;
+      *)
+        export ${key}="${value}"
+    esac
+  done < "${perf_test_conf}"
+}
+
 # install pipenv
 if [[ $(command -v pipenv) == "" ]];then
   apt-get update && apt-get -y install python3-pip
@@ -193,10 +205,16 @@ DEFAULT_CR_PATH="${ROOT}/istio-install/istioctl_profiles/default.yaml"
 # For adding or modifying configurations, refer to perf/benchmark/README.md
 CONFIG_DIR="${WD}/configs/istio"
 
+read_perf_test_conf "${CONFIG_DIR}/perf_test.conf"
+
 for dir in "${CONFIG_DIR}"/*; do
-    if [[ "${dir}" =~ "mixer" ]];then
+    # get the last directory name after splitting dir path by '/', which is the configuration dir name
+    config_name=$(echo "${dir}" | awk -F'/' '{print $NF}')
+    # skip the test config that is disabled to run
+    if (( !"${config_name}" )); then
         continue
     fi
+
     pushd "${dir}"
     # install istio with custom overlay
     if [[ -e "./installation.yaml" ]]; then
@@ -212,8 +230,6 @@ for dir in "${CONFIG_DIR}"/*; do
        source prerun.sh
     fi
 
-    # get the last directory name after splitting dir path by '/', which is the configuration dir name
-    config_name=$(echo "${dir}" | awk -F'/' '{print $NF}')
     # collect config dump after prerun.sh and before test run, to verify test setup is correct
     collect_config_dump "${config_name}"
 

--- a/perf_dashboard/benchmarks/views.py
+++ b/perf_dashboard/benchmarks/views.py
@@ -453,12 +453,12 @@ def micro_benchmarks(request):
 
 
 # Helpers
-def get_latency_vs_conn_y_series(df, mixer_mode, quantiles):
+def get_latency_vs_conn_y_series(df, telemetry_mode, quantiles):
     y_series_data = []
-    if ("serveronly" in mixer_mode) or ("clientonly" in mixer_mode):
+    if "mixer" in telemetry_mode:
         return []
     for thread in [2, 4, 8, 16, 32, 64]:
-        data = df.query('ActualQPS == 1000 and NumThreads == @thread and Labels.str.endswith(@mixer_mode)')
+        data = df.query('ActualQPS == 1000 and NumThreads == @thread and Labels.str.endswith(@telemetry_mode)')
         if not data[quantiles].head().empty:
             y_series_data.append(data[quantiles].head(1).values[0]/1000)
         else:
@@ -466,12 +466,12 @@ def get_latency_vs_conn_y_series(df, mixer_mode, quantiles):
     return y_series_data
 
 
-def get_latency_vs_qps_y_series(df, mixer_mode, quantiles):
+def get_latency_vs_qps_y_series(df, telemetry_mode, quantiles):
     y_series_data = []
-    if ("serveronly" in mixer_mode) or ("clientonly" in mixer_mode):
+    if "mixer" in telemetry_mode:
         return []
     for qps in [10, 100, 500, 1000, 2000, 3000]:
-        data = df.query('ActualQPS == @qps and NumThreads == 16 and Labels.str.endswith(@mixer_mode)')
+        data = df.query('ActualQPS == @qps and NumThreads == 16 and Labels.str.endswith(@telemetry_mode)')
         if not data[quantiles].head().empty:
             y_series_data.append(data[quantiles].head(1).values[0]/1000)
         else:
@@ -479,13 +479,13 @@ def get_latency_vs_qps_y_series(df, mixer_mode, quantiles):
     return y_series_data
 
 
-def get_cpu_y_series(df, mixer_mode):
+def get_cpu_y_series(df, telemetry_mode):
     y_series_data = []
-    if ("serveronly" in mixer_mode) or ("clientonly" in mixer_mode):
+    if "mixer" in telemetry_mode:
         return []
     cpu_metric = 'cpu_mili_avg_fortioserver_deployment_proxy'
     for qps in [10, 100, 500, 1000, 2000, 3000]:
-        data = df.query('ActualQPS == @qps and NumThreads == 16 and Labels.str.endswith(@mixer_mode)')
+        data = df.query('ActualQPS == @qps and NumThreads == 16 and Labels.str.endswith(@telemetry_mode)')
         if not data[cpu_metric].head().empty:
             y_series_data.append(data[cpu_metric].head(1).values[0])
         else:
@@ -493,13 +493,13 @@ def get_cpu_y_series(df, mixer_mode):
     return y_series_data
 
 
-def get_mem_y_series(df, mixer_mode):
+def get_mem_y_series(df, telemetry_mode):
     y_series_data = []
-    if ("serveronly" in mixer_mode) or ("clientonly" in mixer_mode):
+    if "mixer" in telemetry_mode:
         return []
     mem_metric = 'mem_MB_max_fortioserver_deployment_proxy'
     for qps in [10, 100, 500, 1000, 2000, 3000]:
-        data = df.query('ActualQPS == @qps and NumThreads == 16 and Labels.str.endswith(@mixer_mode)')
+        data = df.query('ActualQPS == @qps and NumThreads == 16 and Labels.str.endswith(@telemetry_mode)')
         if not data[mem_metric].head().empty:
             y_series_data.append(data[mem_metric].head(1).values[0])
         else:

--- a/perf_dashboard/regression_pattern/views.py
+++ b/perf_dashboard/regression_pattern/views.py
@@ -77,9 +77,9 @@ def master_pattern(request):
 
 
 # Helpers
-def get_latency_y_data_point(df, mixer_mode, quantiles):
+def get_latency_y_data_point(df, telemetry_mode, quantiles):
     y_series_data = []
-    data = df.query('ActualQPS == 1000 and NumThreads == 16 and Labels.str.endswith(@mixer_mode)')
+    data = df.query('ActualQPS == 1000 and NumThreads == 16 and Labels.str.endswith(@telemetry_mode)')
     if not data[quantiles].head().empty:
         y_series_data.append(data[quantiles].head(1).values[0]/1000)
     else:
@@ -87,7 +87,7 @@ def get_latency_y_data_point(df, mixer_mode, quantiles):
     return y_series_data
 
 
-def get_telemetry_mode_y_series(release_names, release_dates, mixer_mode, quantiles):
+def get_telemetry_mode_y_series(release_names, release_dates, telemetry_mode, quantiles):
     pattern_data = [[]] * len(release_names)
     for i in range(len(release_names)):
         try:
@@ -96,5 +96,5 @@ def get_telemetry_mode_y_series(release_names, release_dates, mixer_mode, quanti
             print(e)
             pattern_data[i] = release_dates[i] + ["null"]
         else:
-            pattern_data[i] = release_dates[i] + get_latency_y_data_point(df, mixer_mode, quantiles)
+            pattern_data[i] = release_dates[i] + get_latency_y_data_point(df, telemetry_mode, quantiles)
     return pattern_data

--- a/perf_dashboard/static/js/cpu_memory.js
+++ b/perf_dashboard/static/js/cpu_memory.js
@@ -43,12 +43,6 @@ new Chart(document.getElementById("cpu-qps-release"), {
         labels: qpsNum,
         datasets: [
             {
-                label: "mixer_both",
-                backgroundColor: "rgba(66, 133, 246, 0.2)",
-                borderColor: "rgba(66, 133, 246, 1)",
-                data: cpu_mixer_both,
-                fill: false
-            }, {
                 label: "baseline",
                 backgroundColor: "rgba(236, 66, 53, 0.2)",
                 borderColor: "rgba(236, 66, 53, 1)",
@@ -98,12 +92,6 @@ new Chart(document.getElementById("mem-qps-release"), {
         labels: qpsNum,
         datasets: [
             {
-                label: "mixer_both",
-                backgroundColor: "rgba(66, 133, 246, 0.2)",
-                borderColor: "rgba(66, 133, 246, 1)",
-                data: mem_mixer_both,
-                fill: false
-            }, {
                 label: "baseline",
                 backgroundColor: "rgba(236, 66, 53, 0.2)",
                 borderColor: "rgba(236, 66, 53, 1)",
@@ -153,12 +141,6 @@ new Chart(document.getElementById("cpu-qps-master"), {
         labels: qpsNum,
         datasets: [
             {
-                label: "mixer_both",
-                backgroundColor: "rgba(66, 133, 246, 0.2)",
-                borderColor: "rgba(66, 133, 246, 1)",
-                data: cpu_mixer_both_master,
-                fill: false
-            }, {
                 label: "baseline",
                 backgroundColor: "rgba(236, 66, 53, 0.2)",
                 borderColor: "rgba(236, 66, 53, 1)",
@@ -208,12 +190,6 @@ new Chart(document.getElementById("mem-qps-master"), {
         labels: qpsNum,
         datasets: [
             {
-                label: "mixer_both",
-                backgroundColor: "rgba(66, 133, 246, 0.2)",
-                borderColor: "rgba(66, 133, 246, 1)",
-                data: mem_mixer_both_master,
-                fill: false
-            }, {
                 label: "baseline",
                 backgroundColor: "rgba(236, 66, 53, 0.2)",
                 borderColor: "rgba(236, 66, 53, 1)",

--- a/perf_dashboard/static/js/cur_pattern.js
+++ b/perf_dashboard/static/js/cur_pattern.js
@@ -1,25 +1,19 @@
 window.onload = function () {
   // p90
-  let chart_mixer_both_p90_pattern = constructDataSeries(mixer_both_p90_pattern, none_mtls_base_p90_pattern);
   let chart_none_mtls_both_p90_pattern = constructDataSeries(none_mtls_both_p90_pattern, none_mtls_base_p90_pattern);
   let chart_v2_sd_full_nullvm_both_p90_pattern = constructDataSeries(v2_sd_full_nullvm_both_p90_pattern, none_mtls_base_p90_pattern);
 
   p90ModesData = [];
-  p90ModesData.push(none_mtls_base_p90_pattern);
-  p90ModesData.push(chart_mixer_both_p90_pattern);
   p90ModesData.push(chart_none_mtls_both_p90_pattern);
   p90ModesData.push(chart_v2_sd_full_nullvm_both_p90_pattern);
 
   generateChart("chart_p90", p90ModesData);
 
   // p99
-  let chart_mixer_both_p99_pattern = constructDataSeries(mixer_both_p99_pattern, none_mtls_base_p99_pattern);
   let chart_none_mtls_both_p99_pattern = constructDataSeries(none_mtls_both_p99_pattern, none_mtls_base_p99_pattern);
   let chart_v2_sd_full_nullvm_both_p99_pattern = constructDataSeries(v2_sd_full_nullvm_both_p99_pattern, none_mtls_base_p99_pattern);
 
   p99ModesData = [];
-  p99ModesData.push(none_mtls_base_p99_pattern);
-  p99ModesData.push(chart_mixer_both_p99_pattern);
   p99ModesData.push(chart_none_mtls_both_p99_pattern);
   p99ModesData.push(chart_v2_sd_full_nullvm_both_p99_pattern);
 

--- a/perf_dashboard/static/js/latency_common_func.js
+++ b/perf_dashboard/static/js/latency_common_func.js
@@ -1,7 +1,6 @@
 window.generateLatencyChart = function(xNum, options) {
   // p50-release
   p50ReleaseModesData = [];
-  p50ReleaseModesData.push(latency_mixer_both_p50);
   p50ReleaseModesData.push(latency_none_mtls_base_p50);
   p50ReleaseModesData.push(latency_none_mtls_both_p50);
   p50ReleaseModesData.push(latency_none_plaintext_both_p50);
@@ -13,7 +12,6 @@ window.generateLatencyChart = function(xNum, options) {
 
   // p90-release
   p90ReleaseModesData = [];
-  p90ReleaseModesData.push(latency_mixer_both_p90);
   p90ReleaseModesData.push(latency_none_mtls_base_p90);
   p90ReleaseModesData.push(latency_none_mtls_both_p90);
   p90ReleaseModesData.push(latency_none_plaintext_both_p90);
@@ -26,7 +24,6 @@ window.generateLatencyChart = function(xNum, options) {
 
   // p99-release
   p99ReleaseModesData = [];
-  p99ReleaseModesData.push(latency_mixer_both_p99);
   p99ReleaseModesData.push(latency_none_mtls_base_p99);
   p99ReleaseModesData.push(latency_none_mtls_both_p99);
   p99ReleaseModesData.push(latency_none_plaintext_both_p99);
@@ -38,7 +35,6 @@ window.generateLatencyChart = function(xNum, options) {
 
   // p50-master
   p50ModesData = [];
-  p50ModesData.push(latency_mixer_both_p50_master);
   p50ModesData.push(latency_none_mtls_base_p50_master);
   p50ModesData.push(latency_none_mtls_both_p50_master);
   p50ModesData.push(latency_none_plaintext_both_p50_master);
@@ -50,7 +46,6 @@ window.generateLatencyChart = function(xNum, options) {
 
   // p90-master
   p90ModesData = [];
-  p90ModesData.push(latency_mixer_both_p90_master);
   p90ModesData.push(latency_none_mtls_base_p90_master);
   p90ModesData.push(latency_none_mtls_both_p90_master);
   p90ModesData.push(latency_none_plaintext_both_p90_master);
@@ -63,7 +58,6 @@ window.generateLatencyChart = function(xNum, options) {
 
   // p99-master
   p99ModesData = [];
-  p99ModesData.push(latency_mixer_both_p99_master);
   p99ModesData.push(latency_none_mtls_base_p99_master);
   p99ModesData.push(latency_none_mtls_both_p99_master);
   p99ModesData.push(latency_none_plaintext_both_p99_master);
@@ -81,47 +75,41 @@ window.generateLatencyChartByID = function(chartID, xNum, modesData, options) {
         labels: xNum,
         datasets: [
             {
-                label: "mixer_both",
-                backgroundColor: "rgba(66, 133, 246, 0.2)",
-                borderColor: "rgba(66, 133, 246, 1)",
-                data: modesData[0],
-                fill: false
-            }, {
                 label: "baseline",
                 backgroundColor: "rgba(236, 66, 53, 0.2)",
                 borderColor: "rgba(236, 66, 53, 1)",
-                data: modesData[1],
+                data: modesData[0],
                 fill: false
             }, {
                 label: "none-mtls_both",
                 backgroundColor: "rgba(0, 0, 0, 0.2)",
                 borderColor: "rgba(0, 0, 0, 1)",
-                data: modesData[2],
+                data: modesData[1],
                 fill: false
             }, {
                 label: "none-plaintext_both",
                 backgroundColor: "rgba(52, 235, 219, 0.2)",
                 borderColor: "rgba(52, 235, 219, 1)",
-                data: modesData[3],
+                data: modesData[2],
                 fill: false
             }, {
                 label: "v2-stats-nullvm_both",
                 backgroundColor: "rgba(252, 123, 3, 0.2)",
                 borderColor: "rgba(252, 123, 3, 1)",
-                data: modesData[4],
+                data: modesData[3],
                 fill: false
             }, {
                 label: "v2-sd-nologging-nullvm_both",
                 backgroundColor: "rgba(52, 168, 85, 0.2)",
                 borderColor: "rgba(52, 168, 85, 1)",
-                data: modesData[5],
+                data: modesData[4],
                 hidden: true,
                 fill: false
             }, {
                 label: "v2-sd-full-nullvm_both",
                 backgroundColor: "rgba(168, 50, 168, 0.2)",
                 borderColor: "rgba(168, 50, 168, 1)",
-                data: modesData[6],
+                data: modesData[5],
                 hidden: true,
                 fill: false
             }

--- a/perf_dashboard/static/js/master_pattern.js
+++ b/perf_dashboard/static/js/master_pattern.js
@@ -1,25 +1,19 @@
 window.onload = function () {
   // p90
-  let chart_mixer_both_p90_pattern_master = constructDataSeries(mixer_both_p90_pattern_master, none_mtls_base_p90_pattern_master);
   let chart_none_mtls_both_p90_pattern_master = constructDataSeries(none_mtls_both_p90_pattern_master, none_mtls_base_p90_pattern_master);
   let chart_v2_sd_full_nullvm_both_p90_pattern_master = constructDataSeries(v2_sd_full_nullvm_both_p90_pattern_master, none_mtls_base_p90_pattern_master);
 
   p90ModesData = [];
-  p90ModesData.push(none_mtls_base_p90_pattern_master);
-  p90ModesData.push(chart_mixer_both_p90_pattern_master);
   p90ModesData.push(chart_none_mtls_both_p90_pattern_master);
   p90ModesData.push(chart_v2_sd_full_nullvm_both_p90_pattern_master);
 
   generateChart("chart_p90_master", p90ModesData);
 
   // p99
-  let chart_mixer_both_p99_pattern_master = constructDataSeries(mixer_both_p99_pattern_master, none_mtls_base_p99_pattern_master);
   let chart_none_mtls_both_p99_pattern_master = constructDataSeries(none_mtls_both_p99_pattern_master, none_mtls_base_p99_pattern_master);
   let chart_v2_sd_full_nullvm_both_p99_pattern_master = constructDataSeries(v2_sd_full_nullvm_both_p99_pattern_master, none_mtls_base_p99_pattern_master);
 
   p99ModesData = [];
-  p99ModesData.push(none_mtls_base_p99_pattern_master);
-  p99ModesData.push(chart_mixer_both_p99_pattern_master);
   p99ModesData.push(chart_none_mtls_both_p99_pattern_master);
   p99ModesData.push(chart_v2_sd_full_nullvm_both_p99_pattern_master);
 


### PR DESCRIPTION
Since mixer is no longer changing, we may need to disable the perf test run for it. Also, disable it from the dashboard.  @mandarjog I'm not sure if totally disable it is fine or not? Or do we still need to run it sometime? If so, manually run is okay, I think.