### PR TITLE
Unicode was removed in Python in favor of str

### DIFF
--- a/bin/update_dns.py
+++ b/bin/update_dns.py
@@ -20,6 +20,11 @@ import sys
 import argparse
 import ipaddress
 
+try:
+    unicode  # Python 2
+except NameError:
+    unicode = str  # Python 3
+
 
 class DNSException(Exception):
     pass


### PR DESCRIPTION
`unicode` was removed in Python 3 because all `str` are Unicode.