### PR TITLE
Remove perf dashboard qual host from ALLOWED_HOSTS

### DIFF
--- a/perf_dashboard/perf_dashboard/settings.py
+++ b/perf_dashboard/perf_dashboard/settings.py
@@ -42,7 +42,6 @@ DEBUG = True
 
 ALLOWED_HOSTS = [
     'localhost',
-    'perf.dashboard.qualistio.org',
     'perf.dashboard.istio.io',
     gethostname(),
     os.getenv('NODE_IP', gethostbyname(gethostname())),


### PR DESCRIPTION
As our site migration is stable right now, I'm going to delete the old supported host.