### PR TITLE
add benchmark configs & measurements section and fix history page reference issue

### DIFF
--- a/perf/benchmark/README.md
+++ b/perf/benchmark/README.md
@@ -272,7 +272,7 @@ Once `runner.py` has completed, extract the results from Fortio and Prometheus.
 
 ## Visualize Results
 
-Please upload your generated .csv file to the [graph plotting](http://perf.dashboard.qualistio.org/graph_plotting/) section of our performance dashboard to visualize your graph.
+Please upload your generated .csv file to the [graph plotting](http://perf.dashboard.istio.io/graph_plotting/) section of our performance dashboard to visualize your graph.
 
 ## Add new config to benchmark pipeline
 

--- a/perf_dashboard/artifacts/templates/artifact.html
+++ b/perf_dashboard/artifacts/templates/artifact.html
@@ -7,6 +7,7 @@
     <li><a href="#dropDown" aria-expanded="false" data-toggle="collapse">
     <i class="fa fa-area-chart"></i>Benchmarks</a>
     <ul id="dropDown" class="collapse list-unstyled">
+        <li><a href="{% url 'benchmarks_overview' %}"><i class="fa fa-asterisk"></i>Configs & Measurements</a></li>
         <li><a href="{% url 'cpu_memory' %}"><i class="fa fa-asterisk"></i>CPU & Memory Usage</a></li>
         <li><a href="#dropDownLatency" aria-expanded="false" data-toggle="collapse">
             <i class="fa fa-asterisk"></i>Latency Quantiles</a>

--- a/perf_dashboard/benchmarks/templates/benchmarks_overview.html
+++ b/perf_dashboard/benchmarks/templates/benchmarks_overview.html
@@ -1,0 +1,96 @@
+{% extends 'base.html' %}
+{% load static from staticfiles %}
+
+{% block sidebar_active %}
+<ul id="side-main-menu" class="side-menu list-unstyled">
+    <li><a href="{% url 'index_page' %}"><i class="fa fa-home"></i>Overview</a></li>
+    <li class="active"><a href="#dropDown" aria-expanded="true" data-toggle="collapse">
+    <i class="fa fa-area-chart"></i>Benchmarks</a>
+    <ul id="dropDown" class="list-unstyled">
+        <li class="active"><a href="{% url 'benchmarks_overview' %}"><i class="fa fa-asterisk"></i>Configs & Measurements</a></li>
+        <li><a href="{% url 'cpu_memory' %}"><i class="fa fa-asterisk"></i>CPU & Memory Usage</a></li>
+        <li><a href="#dropDownLatency" aria-expanded="false" data-toggle="collapse">
+            <i class="fa fa-asterisk"></i>Latency Quantiles</a>
+            <ul id="dropDownLatency" class="collapse list-unstyled">
+                <li><a href="{% url 'latency_conn' %}"><i class="fa fa-chevron-right"></i>Latency vs. Connection</a></li>
+                <li><a href="{% url 'latency_qps' %}"><i class="fa fa-chevron-right"></i>Latency vs. QPS</a></li>
+            </ul>
+        <li><a href="{% url 'flame_graph' %}"><i class="fa fa-asterisk"></i>Flame Graph</a></li>
+        <li><a href="{% url 'micro_benchmarks' %}"><i class="fa fa-asterisk"></i>Micro Benchmarks</a></li>
+    </ul>
+    <li><a href="#alertDropDown" aria-expanded="false" data-toggle="collapse">
+    <i class="fa fa-bullhorn"></i>Regression Pattern</a>
+    <ul id="alertDropDown" class="collapse list-unstyled">
+        <li><a href="{% url 'cur_pattern' %}"><i class="fa fa-asterisk"></i>Current Release</a></li>
+        <li><a href="{% url 'master_pattern' %}"><i class="fa fa-asterisk"></i>Master</a></li>
+    </ul>
+    <li><a href="{% url 'graph_plotting' %}"> <i class="fa fa-edit"></i>Graph Plotting</a></li>
+    <li><a href="{% url 'artifact' %}"> <i class="fa fa-file-text"></i>Artifacts</a></li>
+    <li><a href="{% url 'history' %}"> <i class="fa fa-file-archive-o"></i>History</a></li>
+</ul>
+{% endblock sidebar_active %}
+
+{% block current_active %}
+<li class="breadcrumb-item">Benchmarks</li>
+{% endblock current_active %}
+
+{% block page_content %}
+<!-- Header Section-->
+<section class="dashboard-header section-padding">
+        <div class="container-fluid">
+          <div class="row d-flex align-items-md-stretch">
+            <!-- List-->
+            <div class="col-lg-12 col-md-3">
+              <div class="card">
+                <div class="card-header">
+                  <h2>Performance Test Configurations</h2>
+                </div>
+                <div class="card-body">
+                  <p>For testing Istio performance under different settings, there are multiple perf test configurations.</p>
+                    <ul>
+                    <li>Telemetry Modes:</li>
+                    <ul>
+                      <li><b>baseline</b>: Client pod directly calls the server pod, no sidecars are present.</li>
+                      <li><b>none-mtls</b>: Mutual TLS is enabled and Istio proxy with no Istio specific filters configured.</li>
+                      <li><b>none-plaintext</b>: Only plaintext and Istio proxy with no Istio specific filters configured.</li>
+                      <li><b>v2-stats-nullvm</b>: Generate Istio standard prometheus metrics using nullvmplugin.</li>
+                      <li><b>v2-sd-nologging-nullvm</b>: Export stackdriver metrics, accesslogs and edges using nullvmplugin.</li>
+                      <li><b>v2-sd-full-nullvm</b>: Same as above, but does not export accesslogs.</li>
+                      <li><b>mixer</b>: Client and server sidecars are present with mixer configured.</li>
+                    </ul>
+                    <li>Sidecar Injection Modes:</li>
+                    <ul>
+                      <li><b>both</b>: Both client and server sidecars are enabled.</li>
+                      <li><b>serveronly</b>: Only server sidecar is enabled.</li>
+                      <li><b>clientonly</b>: Only client sidecar is enabled.</li>
+                    </ul>
+                  </ul>
+                </div>
+              </div>
+            </div>
+
+            <div class="col-lg-12 col-md-3">
+              <div class="card">
+                <div class="card-header">
+                  <h2>Performance Test Benchmarks and Measurements</h2>
+                </div>
+                <div class="card-body">
+                  <p>These are the benchmarks we run on a daily basis and publish those measurements in the following sections.</p>
+                    <ul>
+                        <li><a href="{% url 'cpu_memory' %}" target="_blank">CPU and Memory Usage</a></li>
+                        <li><a href="{% url 'latency_conn' %}" target="_blank">Latency vs. Connections</a></li>
+                        <li><a href="{% url 'latency_qps' %}" target="_blank">Latency vs. QPS</a></li>
+                        <li><a href="{% url 'flame_graph' %}" target="_blank">Flame Graph</a></li>
+                        <li><a href="{% url 'micro_benchmarks' %}" target="_blank">Micro Benchmarks</a></li>
+                    </ul>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+{% endblock page_content %}
+
+{% block charts_js %}
+    <script src="{% static 'js/overview.js' %}"></script>
+{% endblock charts_js %}

--- a/perf_dashboard/benchmarks/templates/benchmarks_overview.html
+++ b/perf_dashboard/benchmarks/templates/benchmarks_overview.html
@@ -32,6 +32,7 @@
 
 {% block current_active %}
 <li class="breadcrumb-item">Benchmarks</li>
+<li class="breadcrumb-item active">Configs & Measurements</li>
 {% endblock current_active %}
 
 {% block page_content %}

--- a/perf_dashboard/benchmarks/templates/cpu_memory.html
+++ b/perf_dashboard/benchmarks/templates/cpu_memory.html
@@ -7,6 +7,7 @@
     <li><a href="#dropDown" aria-expanded="true" data-toggle="collapse">
     <i class="fa fa-area-chart"></i>Benchmarks</a>
     <ul id="dropDown" class="list-unstyled">
+        <li><a href="{% url 'benchmarks_overview' %}"><i class="fa fa-asterisk"></i>Configs & Measurements</a></li>
         <li class="active"><a href="{% url 'cpu_memory' %}"><i class="fa fa-asterisk"></i>CPU & Memory Usage</a></li>
         <li><a href="#dropDownLatency" aria-expanded="false" data-toggle="collapse">
             <i class="fa fa-asterisk"></i>Latency Quantiles</a>

--- a/perf_dashboard/benchmarks/templates/flame_graph.html
+++ b/perf_dashboard/benchmarks/templates/flame_graph.html
@@ -7,6 +7,7 @@
     <li><a href="#dropDown" aria-expanded="true" data-toggle="collapse">
     <i class="fa fa-area-chart"></i>Benchmarks</a>
     <ul id="dropDown" class="list-unstyled">
+        <li><a href="{% url 'benchmarks_overview' %}"><i class="fa fa-asterisk"></i>Configs & Measurements</a></li>
         <li><a href="{% url 'cpu_memory' %}"><i class="fa fa-asterisk"></i>CPU & Memory Usage</a></li>
         <li><a href="#dropDownLatency" aria-expanded="false" data-toggle="collapse">
             <i class="fa fa-asterisk"></i>Latency Quantiles</a>

--- a/perf_dashboard/benchmarks/templates/latency_vs_conn.html
+++ b/perf_dashboard/benchmarks/templates/latency_vs_conn.html
@@ -7,6 +7,7 @@
     <li><a href="#dropDown" aria-expanded="true" data-toggle="collapse">
     <i class="fa fa-area-chart"></i>Benchmarks</a>
     <ul id="dropDown" class="list-unstyled">
+        <li><a href="{% url 'benchmarks_overview' %}"><i class="fa fa-asterisk"></i>Configs & Measurements</a></li>
         <li><a href="{% url 'cpu_memory' %}"><i class="fa fa-asterisk"></i>CPU & Memory Usage</a></li>
         <li><a href="#dropDownLatency" aria-expanded="true" data-toggle="collapse">
             <i class="fa fa-asterisk"></i>Latency Quantiles</a>

--- a/perf_dashboard/benchmarks/templates/latency_vs_qps.html
+++ b/perf_dashboard/benchmarks/templates/latency_vs_qps.html
@@ -7,6 +7,7 @@
     <li><a href="#dropDown" aria-expanded="true" data-toggle="collapse">
     <i class="fa fa-area-chart"></i>Benchmarks</a>
     <ul id="dropDown" class="list-unstyled">
+        <li><a href="{% url 'benchmarks_overview' %}"><i class="fa fa-asterisk"></i>Configs & Measurements</a></li>
         <li><a href="{% url 'cpu_memory' %}"><i class="fa fa-asterisk"></i>CPU & Memory Usage</a></li>
         <li><a href="#dropDownLatency" aria-expanded="true" data-toggle="collapse">
             <i class="fa fa-asterisk"></i>Latency Quantiles</a>

--- a/perf_dashboard/benchmarks/templates/micro_benchmarks.html
+++ b/perf_dashboard/benchmarks/templates/micro_benchmarks.html
@@ -7,6 +7,7 @@
     <li><a href="#dropDown" aria-expanded="true" data-toggle="collapse">
     <i class="fa fa-area-chart"></i>Benchmarks</a>
     <ul id="dropDown" class="list-unstyled">
+        <li><a href="{% url 'benchmarks_overview' %}"><i class="fa fa-asterisk"></i>Configs & Measurements</a></li>
         <li><a href="{% url 'cpu_memory' %}"><i class="fa fa-asterisk"></i>CPU & Memory Usage</a></li>
         <li><a href="#dropDownLatency" aria-expanded="false" data-toggle="collapse">
             <i class="fa fa-asterisk"></i>Latency Quantiles</a>

--- a/perf_dashboard/benchmarks/urls.py
+++ b/perf_dashboard/benchmarks/urls.py
@@ -16,6 +16,7 @@ from django.conf.urls import url
 from . import views
 
 urlpatterns = [
+    url('configs_measurements/', views.benchmarks_overview, name="benchmarks_overview"),
     url('cpu_memory/', views.cpu_memory, name="cpu_memory"),
     url('latency_vs_connection/', views.latency_vs_conn, name="latency_conn"),
     url('latency_vs_qps/', views.latency_vs_qps, name="latency_qps"),

--- a/perf_dashboard/benchmarks/views.py
+++ b/perf_dashboard/benchmarks/views.py
@@ -27,6 +27,10 @@ cpu_master_selected_release = []
 current_release = [os.getenv('CUR_RELEASE')]
 
 
+def benchmarks_overview(request):
+    return render(request, "benchmarks_overview.html")
+
+
 # Create your views here.
 def latency_vs_conn(request, uploaded_csv_url=None):
     if uploaded_csv_url is not None:

--- a/perf_dashboard/graph_plotting/templates/graph_plotting.html
+++ b/perf_dashboard/graph_plotting/templates/graph_plotting.html
@@ -7,6 +7,7 @@
     <li><a href="#dropDown" aria-expanded="false" data-toggle="collapse">
     <i class="fa fa-area-chart"></i>Benchmarks</a>
     <ul id="dropDown" class="collapse list-unstyled">
+        <li><a href="{% url 'benchmarks_overview' %}"><i class="fa fa-asterisk"></i>Configs & Measurements</a></li>
         <li><a href="{% url 'cpu_memory' %}"><i class="fa fa-asterisk"></i>CPU & Memory Usage</a></li>
         <li><a href="#dropDownLatency" aria-expanded="false" data-toggle="collapse">
             <i class="fa fa-asterisk"></i>Latency Quantiles</a>

--- a/perf_dashboard/history/templates/history.html
+++ b/perf_dashboard/history/templates/history.html
@@ -35,30 +35,30 @@
 
 {% block page_content %}
 <section class="dashboard-header section-padding">
-        <div class="container-fluid">
-          <div class="row d-flex align-items-md-stretch">
-            <!-- List-->
-            <div class="col-lg-12 col-md-3">
-              <div class="card">
-                <div class="card-header">
-                  <h2>History of Istio Performance and Scalability</h2>
-                </div>
-                <div class="card-body">
-                  <p>Snapshots of performance and scalability page of the istio.io website for each release.</p>
-                  <ul>
-                      <li><a href="https://istio.io/docs/ops/deployment/performance-and-scalability/">Current Release</a></li>
-                      <li><a href="https://archive.istio.io/v1.4/docs/ops/deployment/performance-and-scalability/">v1.4</a></li>
-                      <li><a href="https://archive.istio.io/v1.3/docs/concepts/performance-and-scalability/">v1.3</a></li>
-                      <li><a href="https://archive.istio.io/v1.2/docs/concepts/performance-and-scalability/">v1.2</a></li>
-                      <li><a href="https://archive.istio.io/v1.1/docs/concepts/performance-and-scalability/">v1.1</a></li>
-                      <li><a href="https://archive.istio.io/v1.0/docs/concepts/performance-and-scalability/">v1.0</a></li>
-                  </ul>
-                </div>
-              </div>
+    <div class="container-fluid">
+      <div class="row d-flex align-items-md-stretch">
+        <!-- List-->
+        <div class="col-lg-12 col-md-3">
+          <div class="card">
+            <div class="card-header">
+              <h2>History of Istio Performance and Scalability</h2>
+            </div>
+            <div class="card-body">
+              <p>Snapshots of performance and scalability page of the istio.io website for each release.</p>
+              <ul>
+                  <li><a href="https://istio.io/docs/ops/deployment/performance-and-scalability/" target="_blank">Current Release</a></li>
+                  <li><a href="https://archive.istio.io/v1.4/docs/ops/deployment/performance-and-scalability/" target="_blank">v1.4</a></li>
+                  <li><a href="https://archive.istio.io/v1.3/docs/concepts/performance-and-scalability/" target="_blank">v1.3</a></li>
+                  <li><a href="https://archive.istio.io/v1.2/docs/concepts/performance-and-scalability/" target="_blank">v1.2</a></li>
+                  <li><a href="https://archive.istio.io/v1.1/docs/concepts/performance-and-scalability/" target="_blank">v1.1</a></li>
+                  <li><a href="https://archive.istio.io/v1.0/docs/concepts/performance-and-scalability/" target="_blank">v1.0</a></li>
+              </ul>
             </div>
           </div>
         </div>
-      </section>
+      </div>
+    </div>
+</section>
 {% endblock page_content %}
 
 

--- a/perf_dashboard/history/templates/history.html
+++ b/perf_dashboard/history/templates/history.html
@@ -46,7 +46,8 @@
                 <div class="card-body">
                   <p>Snapshots of performance and scalability page of the istio.io website for each release.</p>
                   <ul>
-                      <li><a href="https://istio.io/docs/ops/deployment/performance-and-scalability/">v1.4</a></li>
+                      <li><a href="https://istio.io/docs/ops/deployment/performance-and-scalability/">Current Release</a></li>
+                      <li><a href="https://archive.istio.io/v1.4/docs/ops/deployment/performance-and-scalability/">v1.4</a></li>
                       <li><a href="https://archive.istio.io/v1.3/docs/concepts/performance-and-scalability/">v1.3</a></li>
                       <li><a href="https://archive.istio.io/v1.2/docs/concepts/performance-and-scalability/">v1.2</a></li>
                       <li><a href="https://archive.istio.io/v1.1/docs/concepts/performance-and-scalability/">v1.1</a></li>

--- a/perf_dashboard/history/templates/history.html
+++ b/perf_dashboard/history/templates/history.html
@@ -7,6 +7,7 @@
     <li><a href="#dropDown" aria-expanded="false" data-toggle="collapse">
     <i class="fa fa-area-chart"></i>Benchmarks</a>
     <ul id="dropDown" class="collapse list-unstyled">
+        <li><a href="{% url 'benchmarks_overview' %}"><i class="fa fa-asterisk"></i>Configs & Measurements</a></li>
         <li><a href="{% url 'cpu_memory' %}"><i class="fa fa-asterisk"></i>CPU & Memory Usage</a></li>
         <li><a href="#dropDownLatency" aria-expanded="false" data-toggle="collapse">
             <i class="fa fa-asterisk"></i>Latency Quantiles</a>

--- a/perf_dashboard/regression_pattern/templates/cur_pattern.html
+++ b/perf_dashboard/regression_pattern/templates/cur_pattern.html
@@ -12,6 +12,7 @@
     <li><a href="#dropDown" aria-expanded="false" data-toggle="collapse">
     <i class="fa fa-area-chart"></i>Benchmarks</a>
     <ul id="dropDown" class="collapse list-unstyled">
+        <li><a href="{% url 'benchmarks_overview' %}"><i class="fa fa-asterisk"></i>Configs & Measurements</a></li>
         <li><a href="{% url 'cpu_memory' %}"><i class="fa fa-asterisk"></i>CPU & Memory Usage</a></li>
         <li><a href="#dropDownLatency" aria-expanded="false" data-toggle="collapse">
             <i class="fa fa-asterisk"></i>Latency Quantiles</a>

--- a/perf_dashboard/regression_pattern/templates/master_pattern.html
+++ b/perf_dashboard/regression_pattern/templates/master_pattern.html
@@ -12,6 +12,7 @@
     <li><a href="#dropDown" aria-expanded="false" data-toggle="collapse">
     <i class="fa fa-area-chart"></i>Benchmarks</a>
     <ul id="dropDown" class="collapse list-unstyled">
+        <li><a href="{% url 'benchmarks_overview' %}"><i class="fa fa-asterisk"></i>Configs & Measurements</a></li>
         <li><a href="{% url 'cpu_memory' %}"><i class="fa fa-asterisk"></i>CPU & Memory Usage</a></li>
         <li><a href="#dropDownLatency" aria-expanded="false" data-toggle="collapse">
             <i class="fa fa-asterisk"></i>Latency Quantiles</a>

--- a/perf_dashboard/static/js/pattern_common_func.js
+++ b/perf_dashboard/static/js/pattern_common_func.js
@@ -42,15 +42,16 @@ window.generateChart = function(chartID, modesData) {
       itemclick: toggleDataSeries
     },
     data: [
-        {
-        type: "line",
-        showInLegend: true,
-        name: "baseline",
-        markerType: "square",
-        xValueFormatString: "DD MMM, YYYY",
-        color: "rgba(236, 66, 53, 1)",
-        dataPoints: modesData[0]
-      }, {
+      //   {
+      //   type: "line",
+      //   showInLegend: true,
+      //   name: "baseline",
+      //   markerType: "square",
+      //   xValueFormatString: "DD MMM, YYYY",
+      //   color: "rgba(236, 66, 53, 1)",
+      //   dataPoints: modesData[0]
+      // },
+      {
         type: "line",
         showInLegend: true,
         name: "mixer_both - baseline",

--- a/perf_dashboard/static/js/pattern_common_func.js
+++ b/perf_dashboard/static/js/pattern_common_func.js
@@ -42,15 +42,6 @@ window.generateChart = function(chartID, modesData) {
       itemclick: toggleDataSeries
     },
     data: [
-      //   {
-      //   type: "line",
-      //   showInLegend: true,
-      //   name: "baseline",
-      //   markerType: "square",
-      //   xValueFormatString: "DD MMM, YYYY",
-      //   color: "rgba(236, 66, 53, 1)",
-      //   dataPoints: modesData[0]
-      // },
       {
         type: "line",
         showInLegend: true,

--- a/perf_dashboard/templates/index.html
+++ b/perf_dashboard/templates/index.html
@@ -7,7 +7,7 @@
     <li><a href="#dropDown" aria-expanded="false" data-toggle="collapse">
     <i class="fa fa-area-chart"></i>Benchmarks</a>
     <ul id="dropDown" class="collapse list-unstyled">
-        <li class="active"><a href="{% url 'cpu_memory' %}"><i class="fa fa-asterisk"></i>CPU & Memory Usage</a></li>
+        <li><a href="{% url 'cpu_memory' %}"><i class="fa fa-asterisk"></i>CPU & Memory Usage</a></li>
         <li><a href="#dropDownLatency" aria-expanded="false" data-toggle="collapse">
             <i class="fa fa-asterisk"></i>Latency Quantiles</a>
             <ul id="dropDownLatency" class="collapse list-unstyled">

--- a/perf_dashboard/templates/index.html
+++ b/perf_dashboard/templates/index.html
@@ -7,6 +7,7 @@
     <li><a href="#dropDown" aria-expanded="false" data-toggle="collapse">
     <i class="fa fa-area-chart"></i>Benchmarks</a>
     <ul id="dropDown" class="collapse list-unstyled">
+        <li><a href="{% url 'benchmarks_overview' %}"><i class="fa fa-asterisk"></i>Configs & Measurements</a></li>
         <li><a href="{% url 'cpu_memory' %}"><i class="fa fa-asterisk"></i>CPU & Memory Usage</a></li>
         <li><a href="#dropDownLatency" aria-expanded="false" data-toggle="collapse">
             <i class="fa fa-asterisk"></i>Latency Quantiles</a>


### PR DESCRIPTION
This PR is to fix two things:
1. add benchmarks/configs_measurements page, which is to describe the meanings of different test configurations and link to corresponding measurements sections. A followup for this: https://github.com/istio/tools/pull/811
2. fix history page reference issue