### PR TITLE
Fix unfound istio linux release tar.gz issue

### DIFF
--- a/isotope/runner/istio.py
+++ b/isotope/runner/istio.py
@@ -39,7 +39,7 @@ def convert_archive(archive_url: str) -> str:
 
     full_name = "{}-09-15".format(archive_url)
 
-    return "{daily}/{full_name}/istio-{full_name}-linux.tar.gz".format(
+    return "{daily}/{full_name}/istio-{full_name}-linux-amd64.tar.gz".format(
         daily=DAILY_BUILD_URL, full_name=full_name)
 
 

--- a/perf/istio-install/setup_istio.sh
+++ b/perf/istio-install/setup_istio.sh
@@ -42,7 +42,7 @@ function download() {
   local DIRNAME="$1"
   local release="$2"
 
-  local url="https://gcsweb.istio.io/gcs/istio-prerelease/daily-build/${release}/istio-${release}-linux.tar.gz"
+  local url="https://gcsweb.istio.io/gcs/istio-prerelease/daily-build/${release}/istio-${release}-linux-amd64.tar.gz"
   # shellcheck disable=SC2236
   if [[ -n "${RELEASE_URL}" ]];then
     url="${RELEASE_URL}"

--- a/perf/istio-install/setup_istio_release.sh
+++ b/perf/istio-install/setup_istio_release.sh
@@ -48,21 +48,21 @@ if [[ "${stream}" == "pre-release" ]];then
   export HELMREPO_URL=https://gcsweb.istio.io/gcs/istio-prerelease/prerelease/${release}/charts
   case "${OSTYPE}" in
     darwin*) export RELEASE_URL=https://gcsweb.istio.io/gcs/istio-prerelease/prerelease/${release}/istio-${release}-osx.tar.gz ;;
-    linux*) export RELEASE_URL=https://gcsweb.istio.io/gcs/istio-prerelease/prerelease/${release}/istio-${release}-linux.tar.gz ;;
+    linux*) export RELEASE_URL=https://gcsweb.istio.io/gcs/istio-prerelease/prerelease/${release}/istio-${release}-linux-amd64.tar.gz ;;
     *) echo "unsupported: ${OSTYPE}" ;;
   esac
 elif [[ "${stream}" == "dev" ]];then
   export HELMREPO_URL=https://gcsweb.istio.io/gcs/istio-build/dev/${release}/charts
   case "${OSTYPE}" in
     darwin*) export RELEASE_URL=https://gcsweb.istio.io/gcs/istio-build/dev/${release}/istio-${release}-osx.tar.gz ;;
-    linux*) export RELEASE_URL=https://gcsweb.istio.io/gcs/istio-build/dev/${release}/istio-${release}-linux.tar.gz ;;
+    linux*) export RELEASE_URL=https://gcsweb.istio.io/gcs/istio-build/dev/${release}/istio-${release}-linux-amd64.tar.gz ;;
     *) echo "unsupported: ${OSTYPE}" ;;
   esac
 else
   export HELMREPO_URL=https://storage.googleapis.com/istio-release/releases/${release}/charts
   case "${OSTYPE}" in
     darwin*) export RELEASE_URL=https://github.com/istio/istio/releases/download/${release}/istio-${release}-osx.tar.gz ;;
-    linux*) export RELEASE_URL=https://github.com/istio/istio/releases/download/${release}/istio-${release}-linux.tar.gz ;;
+    linux*) export RELEASE_URL=https://github.com/istio/istio/releases/download/${release}/istio-${release}-linux-amd64.tar.gz ;;
     *) echo "unsupported: ${OSTYPE}" ;;
   esac
 fi

--- a/upgrade/run_upgrade_test.sh
+++ b/upgrade/run_upgrade_test.sh
@@ -72,9 +72,9 @@ function download_untar_istio_release() {
   local dir=${3:-.}
 
   # Download artifacts
-  LINUX_DIST_URL="${url_path}/${tag}/istio-${tag}-linux.tar.gz"
+  LINUX_DIST_URL="${url_path}/${tag}/istio-${tag}-linux-amd64.tar.gz"
   wget -q "${LINUX_DIST_URL}" -P "${dir}"
-  tar -xzf "${dir}/istio-${tag}-linux.tar.gz" -C "${dir}"
+  tar -xzf "${dir}/istio-${tag}-linux-amd64.tar.gz" -C "${dir}"
 }
 
 # shellcheck disable=SC1090


### PR DESCRIPTION
Recently we changed the linux release name, which causes both perf job and upgrade job failure:

```
+++ curl -fJL -o /home/prow/go/src/istio.io/tools/perf/istio-install/tmp/istio-1.6-alpha.9cd853a8d17e8e36c3a0e0611f2b6256a995b8bf.tgz https://gcsweb.istio.io/gcs/istio-build/dev/1.6-alpha.9cd853a8d17e8e36c3a0e0611f2b6256a995b8bf/istio-1.6-alpha.9cd853a8d17e8e36c3a0e0611f2b6256a995b8bf-linux.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100   203  100   203    0     0   1301      0 --:--:-- --:--:-- --:--:--  1301

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (22) The requested URL returned error: 404 
++ [[ 22 -ne 0 ]]
```