### PR TITLE
fix plaintext config

### DIFF
--- a/perf/benchmark/configs/istio/plaintext/installation.yaml
+++ b/perf/benchmark/configs/istio/plaintext/installation.yaml
@@ -3,11 +3,7 @@ kind: IstioOperator
 spec:
   components:
     telemetry:
-      enabled: true
+      enabled: false
   values:
     telemetry:
-      enabled: true
-      v2:
-        enabled: false
-      v1:
-        enabled: true
+      enabled: false


### PR DESCRIPTION
The test configuration should be compared to `none` case