### PR TITLE
add telemetry mode to config_dump name and fix upgrade job linux tar issue

### DIFF
--- a/perf/benchmark/run_benchmark_job.sh
+++ b/perf/benchmark/run_benchmark_job.sh
@@ -112,22 +112,23 @@ function setup_fortio_and_prometheus() {
 }
 
 function collect_envoy_info() {
-  POD_NAME=${1}
-  FILE_SUFFIX=${2}
+  CONFIG_NAME=${1}
+  POD_NAME=${2}
+  FILE_SUFFIX=${3}
 
-  ENVOY_DUMP_NAME="${POD_NAME}_${FILE_SUFFIX}.yaml"
+  ENVOY_DUMP_NAME="${POD_NAME}_${CONFIG_NAME}_${FILE_SUFFIX}.yaml"
   kubectl exec -n "${NAMESPACE}" "${POD_NAME}" -c istio-proxy -- curl http://localhost:15000/"${FILE_SUFFIX}" > "${ENVOY_DUMP_NAME}"
   gsutil -q cp -r "${ENVOY_DUMP_NAME}" "gs://${GCS_BUCKET}/${OUTPUT_DIR}/${FILE_SUFFIX}/${ENVOY_DUMP_NAME}"
 }
 
 function collect_config_dump() {
-  collect_envoy_info "${FORTIO_CLIENT_POD}" "config_dump"
-  collect_envoy_info "${FORTIO_SERVER_POD}" "config_dump"
+  collect_envoy_info ${1} "${FORTIO_CLIENT_POD}" "config_dump"
+  collect_envoy_info ${1} "${FORTIO_SERVER_POD}" "config_dump"
 }
 
 function collect_clusters_info() {
-  collect_envoy_info "${FORTIO_CLIENT_POD}" "clusters"
-  collect_envoy_info "${FORTIO_SERVER_POD}" "clusters"
+  collect_envoy_info ${1} "${FORTIO_CLIENT_POD}" "clusters"
+  collect_envoy_info ${1} "${FORTIO_SERVER_POD}" "clusters"
 }
 
 # install pipenv
@@ -208,8 +209,9 @@ for dir in "${CONFIG_DIR}"/*; do
        source prerun.sh
     fi
 
+    config_name=$(echo ${dir} | awk -F'/' '{print $NF}')
     # collect config dump after prerun.sh and before test run, to verify test setup is correct
-    collect_config_dump
+    collect_config_dump ${config_name}
 
     # run test and get data
     if [[ -e "./cpu_mem.yaml" ]]; then
@@ -220,7 +222,7 @@ for dir in "${CONFIG_DIR}"/*; do
     fi
 
     # collect clusters info after test run and before cleanup script postrun.sh
-    collect_clusters_info
+    collect_clusters_info ${config_name}
 
     # custom post run
     if [[ -e "./postrun.sh" ]]; then

--- a/perf/benchmark/run_benchmark_job.sh
+++ b/perf/benchmark/run_benchmark_job.sh
@@ -209,6 +209,7 @@ for dir in "${CONFIG_DIR}"/*; do
        source prerun.sh
     fi
 
+    # get the last directory name after splitting dir path by '/', which is the configuration dir name
     config_name=$(echo "${dir}" | awk -F'/' '{print $NF}')
     # collect config dump after prerun.sh and before test run, to verify test setup is correct
     collect_config_dump "${config_name}"

--- a/perf/benchmark/run_benchmark_job.sh
+++ b/perf/benchmark/run_benchmark_job.sh
@@ -122,13 +122,13 @@ function collect_envoy_info() {
 }
 
 function collect_config_dump() {
-  collect_envoy_info ${1} "${FORTIO_CLIENT_POD}" "config_dump"
-  collect_envoy_info ${1} "${FORTIO_SERVER_POD}" "config_dump"
+  collect_envoy_info "${1}" "${FORTIO_CLIENT_POD}" "config_dump"
+  collect_envoy_info "${1}" "${FORTIO_SERVER_POD}" "config_dump"
 }
 
 function collect_clusters_info() {
-  collect_envoy_info ${1} "${FORTIO_CLIENT_POD}" "clusters"
-  collect_envoy_info ${1} "${FORTIO_SERVER_POD}" "clusters"
+  collect_envoy_info "${1}" "${FORTIO_CLIENT_POD}" "clusters"
+  collect_envoy_info "${1}" "${FORTIO_SERVER_POD}" "clusters"
 }
 
 # install pipenv
@@ -209,9 +209,9 @@ for dir in "${CONFIG_DIR}"/*; do
        source prerun.sh
     fi
 
-    config_name=$(echo ${dir} | awk -F'/' '{print $NF}')
+    config_name=$(echo "${dir}" | awk -F'/' '{print $NF}')
     # collect config dump after prerun.sh and before test run, to verify test setup is correct
-    collect_config_dump ${config_name}
+    collect_config_dump "${config_name}"
 
     # run test and get data
     if [[ -e "./cpu_mem.yaml" ]]; then
@@ -222,7 +222,7 @@ for dir in "${CONFIG_DIR}"/*; do
     fi
 
     # collect clusters info after test run and before cleanup script postrun.sh
-    collect_clusters_info ${config_name}
+    collect_clusters_info "${config_name}"
 
     # custom post run
     if [[ -e "./postrun.sh" ]]; then

--- a/upgrade/run_upgrade_test.sh
+++ b/upgrade/run_upgrade_test.sh
@@ -38,6 +38,7 @@ export TARGET_RELEASE_PATH=${TAGET_RELEASE_PATH:-"https://storage.googleapis.com
 export INSTALL_OPTIONS=${INSTALL_OPTIONS:-"helm"}
 export FROM_PATH=${FROM_PATH:-"$(mktemp -d from_dir.XXXXXX)"}
 export TO_PATH=${TO_PATH:-"$(mktemp -d to_dir.XXXXXX)"}
+export LINUX_TAR_SUFFIX=${LINUX_TAR_SUFFIX:-"linux-amd64.tar.gz"}
 
 function get_git_sha() {
   local url_path=${1}
@@ -47,6 +48,9 @@ function get_git_sha() {
 
   if [[ "${tag}" =~ "latest" ]];then
     release_version=$(echo "${tag}" | cut -d'_' -f1)
+    if [[ ${release_version} < "1.6" ]]; then
+       export LINUX_TAR_SUFFIX="linux.tar.gz"
+    fi
     GIT_SHA=$(curl "${url_path}/${release_version}-dev")
   elif [ "${tag}" == "master" ];then
     GIT_SHA=$(curl "${url_path}/latest")
@@ -72,9 +76,9 @@ function download_untar_istio_release() {
   local dir=${3:-.}
 
   # Download artifacts
-  LINUX_DIST_URL="${url_path}/${tag}/istio-${tag}-linux-amd64.tar.gz"
+  LINUX_DIST_URL="${url_path}/${tag}/istio-${tag}-${LINUX_TAR_SUFFIX}"
   wget -q "${LINUX_DIST_URL}" -P "${dir}"
-  tar -xzf "${dir}/istio-${tag}-linux-amd64.tar.gz" -C "${dir}"
+  tar -xzf "${dir}/istio-${tag}-${LINUX_TAR_SUFFIX}" -C "${dir}"
 }
 
 # shellcheck disable=SC1090

--- a/upgrade/run_upgrade_test.sh
+++ b/upgrade/run_upgrade_test.sh
@@ -48,6 +48,7 @@ function get_git_sha() {
 
   if [[ "${tag}" =~ "latest" ]];then
     release_version=$(echo "${tag}" | cut -d'_' -f1)
+    # shellcheck disable=SC2072
     if [[ ${release_version} < "1.6" ]]; then
        export LINUX_TAR_SUFFIX="linux.tar.gz"
     fi


### PR DESCRIPTION
This PR is to fix:

1. config_dump file name should be based on different telemetry modes
2. fix upgrade job unfound linux release tar file, we start to using -linux.amd64.tar.gz since release-1.6, so, the previous versions should still using -linux.tar.gz.