### PR TITLE
Fix license lint on golang 1.14

### DIFF
--- a/cmd/license-lint/collector.go
+++ b/cmd/license-lint/collector.go
@@ -127,8 +127,13 @@ func getDependentModules() ([]module, error) {
 	cmd.Stderr = &stderr
 
 	err := cmd.Run()
+	errstr := stderr.String()
+	if strings.Contains(errstr, "not part of a module") {
+		// We are not in a module, return no dependencies
+		return nil, nil
+	}
 	if err != nil {
-		return nil, fmt.Errorf("%v: %v", err, stderr)
+		return nil, fmt.Errorf("%v: %v", err, errstr)
 	}
 
 	// Unmarshal json output


### PR DESCRIPTION
For https://github.com/istio/istio/issues/21567

In go 1.14, they change not being in a module from warning to error. We
should respond appropriately here