### PR TITLE
Fix istio upgrade jobs

### DIFF
--- a/upgrade/run_upgrade_test.sh
+++ b/upgrade/run_upgrade_test.sh
@@ -38,48 +38,55 @@ export TARGET_RELEASE_PATH=${TAGET_RELEASE_PATH:-"https://storage.googleapis.com
 export INSTALL_OPTIONS=${INSTALL_OPTIONS:-"helm"}
 export FROM_PATH=${FROM_PATH:-"$(mktemp -d from_dir.XXXXXX)"}
 export TO_PATH=${TO_PATH:-"$(mktemp -d to_dir.XXXXXX)"}
-export LINUX_TAR_SUFFIX=${LINUX_TAR_SUFFIX:-"linux-amd64.tar.gz"}
+export SOURCE_LINUX_TAR_SUFFIX=${SOURCE_LINUX_TAR_SUFFIX:-"linux-amd64.tar.gz"}
+export TARGET_LINUX_TAR_SUFFIX=${TARGET_LINUX_TAR_SUFFIX:-"linux-amd64.tar.gz"}
 
 function get_git_sha() {
   local url_path=${1}
   local tag=${2}
 
-  GIT_SHA=""
+  GIT_SHA=
+  LINUX_TAR_SUFFIX=
 
   if [[ "${tag}" =~ "latest" ]];then
     release_version=$(echo "${tag}" | cut -d'_' -f1)
     # shellcheck disable=SC2072
     if [[ ${release_version} < "1.6" ]]; then
-       export LINUX_TAR_SUFFIX="linux.tar.gz"
+       LINUX_TAR_SUFFIX="linux.tar.gz"
     fi
     GIT_SHA=$(curl "${url_path}/${release_version}-dev")
   elif [ "${tag}" == "master" ];then
     GIT_SHA=$(curl "${url_path}/latest")
   fi
-  
-  echo "${GIT_SHA}"
 }
 
-GIT_SHA=$(get_git_sha "${SOURCE_RELEASE_PATH}" "${SOURCE_TAG}")
+get_git_sha "${SOURCE_RELEASE_PATH}" "${SOURCE_TAG}"
 if [[ -n "${GIT_SHA}" ]]; then
-  export SOURCE_TAG="${GIT_SHA}"
+  SOURCE_TAG="${GIT_SHA}"
+fi
+if [[ -n "${LINUX_TAR_SUFFIX}" ]]; then
+  SOURCE_LINUX_TAR_SUFFIX="${LINUX_TAR_SUFFIX}"
 fi
 
-GIT_SHA=$(get_git_sha "${TARGET_RELEASE_PATH}" "${TARGET_TAG}")
+get_git_sha "${TARGET_RELEASE_PATH}" "${TARGET_TAG}"
 if [[ -n "${GIT_SHA}" ]]; then
-  export TARGET_TAG="${GIT_SHA}"
+  TARGET_TAG="${GIT_SHA}"
+fi
+if [[ -n "${LINUX_TAR_SUFFIX}" ]]; then
+  TARGET_LINUX_TAR_SUFFIX="${LINUX_TAR_SUFFIX}"
 fi
 
 # Download and unpack istio release artifacts.
 function download_untar_istio_release() {
   local url_path=${1}
   local tag=${2}
-  local dir=${3:-.}
+  local suffix=${3}
+  local dir=${4:-.}
 
   # Download artifacts
-  LINUX_DIST_URL="${url_path}/${tag}/istio-${tag}-${LINUX_TAR_SUFFIX}"
+  LINUX_DIST_URL="${url_path}/${tag}/istio-${tag}-${suffix}"
   wget -q "${LINUX_DIST_URL}" -P "${dir}"
-  tar -xzf "${dir}/istio-${tag}-${LINUX_TAR_SUFFIX}" -C "${dir}"
+  tar -xzf "${dir}/istio-${tag}-${suffix}" -C "${dir}"
 }
 
 # shellcheck disable=SC1090
@@ -90,8 +97,8 @@ UPGRADE_TEST_LOCAL="${UPGRADE_TEST_LOCAL:-""}"
 echo "Testing upgrade and downgrade between ${SOURCE_HUB}/${SOURCE_TAG} and ${TARGET_HUB}/${TARGET_TAG}"
 
 # Download release artifacts.
-download_untar_istio_release "${SOURCE_RELEASE_PATH}" "${SOURCE_TAG}" "${FROM_PATH}"
-download_untar_istio_release "${TARGET_RELEASE_PATH}" "${TARGET_TAG}" "${TO_PATH}"
+download_untar_istio_release "${SOURCE_RELEASE_PATH}" "${SOURCE_TAG}" "${SOURCE_LINUX_TAR_SUFFIX}" "${FROM_PATH}"
+download_untar_istio_release "${TARGET_RELEASE_PATH}" "${TARGET_TAG}" "${TARGET_LINUX_TAR_SUFFIX}" "${TO_PATH}"
 
 # Check https://github.com/istio/test-infra/blob/master/boskos/resources.yaml
 # for existing resources types


### PR DESCRIPTION
This fixes two problems with the istio upgrade tests:
1. `LINUX_TAR_SUFFIX` was being set in a subshell (via command substitution) in `get_git_sha`, so the value was **never** being updated in the parent process ([ref](https://stackoverflow.com/questions/23564995/how-to-modify-a-global-variable-within-a-function-in-bash)).
2. The suffix for the _source_ and _target_ releases should be calculated **independently** as they are different versions.

**1** is why https://prow.istio.io/view/gcs/istio-prow/logs/istio-upgrade-using-istioctl-1.4_latest-1.5_latest/51 is failing.

**2** is why https://prow.istio.io/view/gcs/istio-prow/logs/istio-upgrade-using-istioctl-1.5_latest-master/51 is failing. 