### PR TITLE
make trace back days configurable on perf site

### DIFF
--- a/perf_dashboard/benchmarks/templates/cpu_memory.html
+++ b/perf_dashboard/benchmarks/templates/cpu_memory.html
@@ -43,6 +43,28 @@
         <h1 class="h3 display">Average CPU Usage vs. QPS</h1>
       </header>
       <div class="row">
+        <div class="col-lg-12">
+                <form class="form-horizontal" action="" method="post">
+                    {% csrf_token %}
+                      <div class="form-group row">
+                          <label class="col-sm-3 form-control-label">Choose the number of days you want to trace back (default is 30 days)</label>
+                          <div class="col-sm-9">
+                            <select name="release_days" class="form-control mb-3">
+                            {% for day in release_days %}
+                                {% if day == cur_selected_days|last %}
+                                <option selected>{{ day }}</option>
+                                {% else %}
+                                <option>{{ day }}</option>
+                                {% endif %}
+                            {% endfor %}
+                            </select>
+                            <small class="help-block-none">Note: Depend on the number of days you've chosen, downloading those release files might take amount of time.</small>
+                            <input type="submit">
+                           </div>
+                      </div>
+                    <div class="line"></div>
+                </form>
+            </div>
         <div class="col-lg-6">
           <form class="form-horizontal" action="" method="post">
                     {% csrf_token %}
@@ -141,6 +163,8 @@
 
 {% block page_data %}
     <script>
+        release_days = {{ release_days|safe }}
+        cur_selected_days = {{ cur_selected_days|safe }}
         current_release = {{ current_release|safe }}
         cpu_cur_selected_release = {{ cpu_cur_selected_release|safe }}
         cpu_master_selected_release = {{  cpu_master_selected_release|safe }}

--- a/perf_dashboard/benchmarks/templates/latency_vs_conn.html
+++ b/perf_dashboard/benchmarks/templates/latency_vs_conn.html
@@ -43,6 +43,29 @@
             <h1 class="h3 display">Latency vs. Client Connections</h1>
         </header>
         <div class="row">
+            <div class="col-lg-12">
+                <form class="form-horizontal" action="" method="post">
+                    {% csrf_token %}
+                      <div class="form-group row">
+                          <label class="col-sm-3 form-control-label">Choose the number of days you want to trace back (default: 30 days)</label>
+                          <div class="col-sm-9">
+                            <select name="release_days" class="form-control mb-3">
+                            {% for day in release_days %}
+                                {% if day == cur_selected_days|last %}
+                                <option selected>{{ day }}</option>
+                                {% else %}
+                                <option>{{ day }}</option>
+                                {% endif %}
+                            {% endfor %}
+                            </select>
+                            <small class="help-block-none">Note: depending on the number of days you've chosen, downloading those release files might take amount of time.</small>
+                            <input type="submit">
+                           </div>
+                      </div>
+                    <div class="line"></div>
+                </form>
+            </div>
+
             <div class="col-lg-6">
               <form class="form-horizontal" action="" method="post">
                     {% csrf_token %}
@@ -150,6 +173,8 @@
 
 {% block page_data %}
     <script>
+        release_days = {{ release_days|safe }}
+        cur_selected_days = {{ cur_selected_days|safe }}
         current_release = {{ current_release|safe }}
         cur_selected_release = {{ cur_selected_release|safe }}
         master_selected_release = {{  master_selected_release|safe }}

--- a/perf_dashboard/benchmarks/templates/latency_vs_conn.html
+++ b/perf_dashboard/benchmarks/templates/latency_vs_conn.html
@@ -47,7 +47,7 @@
                 <form class="form-horizontal" action="" method="post">
                     {% csrf_token %}
                       <div class="form-group row">
-                          <label class="col-sm-3 form-control-label">Choose the number of days you want to trace back (default: 30 days)</label>
+                          <label class="col-sm-3 form-control-label">Choose the number of days you want to trace back (default is 30 days)</label>
                           <div class="col-sm-9">
                             <select name="release_days" class="form-control mb-3">
                             {% for day in release_days %}
@@ -58,14 +58,13 @@
                                 {% endif %}
                             {% endfor %}
                             </select>
-                            <small class="help-block-none">Note: depending on the number of days you've chosen, downloading those release files might take amount of time.</small>
+                            <small class="help-block-none">Note: Depend on the number of days you've chosen, downloading those release files might take amount of time.</small>
                             <input type="submit">
                            </div>
                       </div>
                     <div class="line"></div>
                 </form>
             </div>
-
             <div class="col-lg-6">
               <form class="form-horizontal" action="" method="post">
                     {% csrf_token %}

--- a/perf_dashboard/benchmarks/templates/latency_vs_qps.html
+++ b/perf_dashboard/benchmarks/templates/latency_vs_qps.html
@@ -43,6 +43,28 @@
             <h1 class="h3 display">Latency vs. QPS</h1>
         </header>
         <div class="row">
+            <div class="col-lg-12">
+                <form class="form-horizontal" action="" method="post">
+                    {% csrf_token %}
+                      <div class="form-group row">
+                          <label class="col-sm-3 form-control-label">Choose the number of days you want to trace back (default is 30 days)</label>
+                          <div class="col-sm-9">
+                            <select name="release_days" class="form-control mb-3">
+                            {% for day in release_days %}
+                                {% if day == cur_selected_days|last %}
+                                <option selected>{{ day }}</option>
+                                {% else %}
+                                <option>{{ day }}</option>
+                                {% endif %}
+                            {% endfor %}
+                            </select>
+                            <small class="help-block-none">Note: Depend on the number of days you've chosen, downloading those release files might take amount of time.</small>
+                            <input type="submit">
+                           </div>
+                      </div>
+                    <div class="line"></div>
+                </form>
+            </div>
             <div class="col-lg-6">
               <form class="form-horizontal" action="" method="post">
                     {% csrf_token %}
@@ -150,6 +172,8 @@
 
 {% block page_data %}
     <script>
+        release_days = {{ release_days|safe }}
+        cur_selected_days = {{ cur_selected_days|safe }}
         current_release = {{ current_release|safe }}
         cur_selected_release = {{ cur_selected_release|safe }}
         master_selected_release = {{  master_selected_release|safe }}

--- a/perf_dashboard/benchmarks/views.py
+++ b/perf_dashboard/benchmarks/views.py
@@ -151,7 +151,16 @@ def latency_vs_qps(request, uploaded_csv_url=None):
         os.remove(uploaded_csv_path)
         return context
     else:
-        cur_release_names, cur_release_dates, master_release_names, master_release_dates = download.download_benchmark_csv(60)
+        if request.method == "POST" and 'release_days' in request.POST:
+            cur_selected_days.append(request.POST['release_days'])
+
+        days = 30
+        if len(cur_selected_days) > 1:
+            cur_selected_days.pop(0)
+        if len(cur_selected_days) > 0:
+            days = int(cur_selected_days[0])
+
+        cur_release_names, cur_release_dates, master_release_names, master_release_dates = download.download_benchmark_csv(days)
 
         if request.method == "POST" and 'current_release_name' in request.POST:
             cur_selected_release.append(request.POST['current_release_name'])
@@ -206,7 +215,9 @@ def latency_vs_qps(request, uploaded_csv_url=None):
         latency_v2_sd_nologging_nullvm_both_p99_master = get_latency_vs_qps_y_series(df, '_v2-sd-nologging-nullvm_both', 'p99')
         latency_v2_sd_full_nullvm_both_p99_master = get_latency_vs_qps_y_series(df, '_v2-sd-full-nullvm_both', 'p99')
 
-        other_context = {'current_release': current_release,
+        other_context = {'release_days': release_days,
+                         'cur_selected_days': cur_selected_days,
+                         'current_release': current_release,
                          'cur_selected_release': cur_selected_release,
                          'master_selected_release':  master_selected_release,
                          'cur_release_names': cur_release_names,
@@ -248,7 +259,16 @@ def cpu_memory(request, uploaded_csv_url=None):
         os.remove(uploaded_csv_path)
         return context
     else:
-        cur_release_names, cur_release_dates, master_release_names, master_release_dates = download.download_benchmark_csv(60)
+        if request.method == "POST" and 'release_days' in request.POST:
+            cur_selected_days.append(request.POST['release_days'])
+
+        days = 30
+        if len(cur_selected_days) > 1:
+            cur_selected_days.pop(0)
+        if len(cur_selected_days) > 0:
+            days = int(cur_selected_days[0])
+
+        cur_release_names, cur_release_dates, master_release_names, master_release_dates = download.download_benchmark_csv(days)
 
         if request.method == "POST" and 'current_release_name' in request.POST:
             cpu_cur_selected_release.append(request.POST['current_release_name'])
@@ -295,7 +315,9 @@ def cpu_memory(request, uploaded_csv_url=None):
         mem_v2_sd_nologging_nullvm_both_master = get_mem_y_series(df, '_v2-sd-nologging-nullvm_both')
         mem_v2_sd_full_nullvm_both_master = get_mem_y_series(df, '_v2-sd-full-nullvm_both')
 
-        other_context = {'current_release': current_release,
+        other_context = {'release_days': release_days,
+                         'cur_selected_days': cur_selected_days,
+                         'current_release': current_release,
                          'cpu_cur_selected_release': cpu_cur_selected_release,
                          'cpu_master_selected_release': cpu_master_selected_release,
                          'cur_release_names': cur_release_names,

--- a/perf_dashboard/benchmarks/views.py
+++ b/perf_dashboard/benchmarks/views.py
@@ -29,6 +29,19 @@ release_days = ['30', '60', '90']
 cur_selected_days = []
 
 
+def get_traceback_days(request):
+    if request.method == "POST" and 'release_days' in request.POST:
+        cur_selected_days.append(request.POST['release_days'])
+
+    days = 30
+    if len(cur_selected_days) > 1:
+        cur_selected_days.pop(0)
+    if len(cur_selected_days) > 0:
+        days = int(cur_selected_days[0])
+
+    return days
+
+
 def benchmarks_overview(request):
     return render(request, "benchmarks_overview.html")
 
@@ -42,14 +55,7 @@ def latency_vs_conn(request, uploaded_csv_url=None):
         os.remove(uploaded_csv_path)
         return context
     else:
-        if request.method == "POST" and 'release_days' in request.POST:
-            cur_selected_days.append(request.POST['release_days'])
-
-        days = 30
-        if len(cur_selected_days) > 1:
-            cur_selected_days.pop(0)
-        if len(cur_selected_days) > 0:
-            days = int(cur_selected_days[0])
+        days = get_traceback_days(request)
 
         cur_release_names, cur_release_dates, master_release_names, master_release_dates = download.download_benchmark_csv(days)
 
@@ -151,14 +157,8 @@ def latency_vs_qps(request, uploaded_csv_url=None):
         os.remove(uploaded_csv_path)
         return context
     else:
-        if request.method == "POST" and 'release_days' in request.POST:
-            cur_selected_days.append(request.POST['release_days'])
 
-        days = 30
-        if len(cur_selected_days) > 1:
-            cur_selected_days.pop(0)
-        if len(cur_selected_days) > 0:
-            days = int(cur_selected_days[0])
+        days = get_traceback_days(request)
 
         cur_release_names, cur_release_dates, master_release_names, master_release_dates = download.download_benchmark_csv(days)
 
@@ -259,14 +259,7 @@ def cpu_memory(request, uploaded_csv_url=None):
         os.remove(uploaded_csv_path)
         return context
     else:
-        if request.method == "POST" and 'release_days' in request.POST:
-            cur_selected_days.append(request.POST['release_days'])
-
-        days = 30
-        if len(cur_selected_days) > 1:
-            cur_selected_days.pop(0)
-        if len(cur_selected_days) > 0:
-            days = int(cur_selected_days[0])
+        days = get_traceback_days(request)
 
         cur_release_names, cur_release_dates, master_release_names, master_release_dates = download.download_benchmark_csv(days)
 

--- a/perf_dashboard/benchmarks/views.py
+++ b/perf_dashboard/benchmarks/views.py
@@ -25,6 +25,8 @@ master_selected_release = []
 cpu_cur_selected_release = []
 cpu_master_selected_release = []
 current_release = [os.getenv('CUR_RELEASE')]
+release_days = ['30', '60', '90']
+cur_selected_days = []
 
 
 def benchmarks_overview(request):
@@ -40,7 +42,16 @@ def latency_vs_conn(request, uploaded_csv_url=None):
         os.remove(uploaded_csv_path)
         return context
     else:
-        cur_release_names, cur_release_dates, master_release_names, master_release_dates = download.download_benchmark_csv(60)
+        if request.method == "POST" and 'release_days' in request.POST:
+            cur_selected_days.append(request.POST['release_days'])
+
+        days = 30
+        if len(cur_selected_days) > 1:
+            cur_selected_days.pop(0)
+        if len(cur_selected_days) > 0:
+            days = int(cur_selected_days[0])
+
+        cur_release_names, cur_release_dates, master_release_names, master_release_dates = download.download_benchmark_csv(days)
 
         if request.method == "POST" and 'current_release_name' in request.POST:
             cur_selected_release.append(request.POST['current_release_name'])
@@ -95,7 +106,9 @@ def latency_vs_conn(request, uploaded_csv_url=None):
         latency_v2_sd_nologging_nullvm_both_p99_master = get_latency_vs_conn_y_series(df, '_v2-sd-nologging-nullvm_both', 'p99')
         latency_v2_sd_full_nullvm_both_p99_master = get_latency_vs_conn_y_series(df, '_v2-sd-full-nullvm_both', 'p99')
 
-        other_context = {'current_release': current_release,
+        other_context = {'release_days': release_days,
+                         'cur_selected_days': cur_selected_days,
+                         'current_release': current_release,
                          'cur_selected_release': cur_selected_release,
                          'master_selected_release':  master_selected_release,
                          'cur_release_names': cur_release_names,


### PR DESCRIPTION
Add the days selection section to make track back perf pipeline runs configurable. As shown here:

<img width="1102" alt="Screen Shot 2020-04-10 at 5 37 10 PM" src="https://user-images.githubusercontent.com/29208297/79031192-ef904b80-7b51-11ea-9b9c-b499c4e00609.png">

