### PR TITLE
Use full GIT_SHA to make it consumable by perf site

### DIFF
--- a/perf/benchmark/run_benchmark_job.sh
+++ b/perf/benchmark/run_benchmark_job.sh
@@ -190,7 +190,7 @@ export ISTIO_INJECT="true"
 ./setup_test.sh
 popd
 dt=$(date +'%Y%m%d')
-export OUTPUT_DIR="${GIT_BRANCH}.${dt}.${GIT_SHA}"
+export OUTPUT_DIR="benchmark_data-${GIT_BRANCH}.${dt}.${GIT_SHA}"
 LOCAL_OUTPUT_DIR="/tmp/${OUTPUT_DIR}"
 mkdir -p "${LOCAL_OUTPUT_DIR}"
 

--- a/perf/benchmark/run_benchmark_job.sh
+++ b/perf/benchmark/run_benchmark_job.sh
@@ -189,9 +189,8 @@ pushd "${WD}"
 export ISTIO_INJECT="true"
 ./setup_test.sh
 popd
-dt=$(date +'%Y%m%d-%H')
-SHA=$(git rev-parse --short "${GIT_SHA}")
-export OUTPUT_DIR="benchmark_data-${GIT_BRANCH}.${dt}.${SHA}"
+dt=$(date +'%Y%m%d')
+export OUTPUT_DIR="${GIT_BRANCH}.${dt}.${GIT_SHA}"
 LOCAL_OUTPUT_DIR="/tmp/${OUTPUT_DIR}"
 mkdir -p "${LOCAL_OUTPUT_DIR}"
 

--- a/perf/benchmark/runner/runner.py
+++ b/perf/benchmark/runner/runner.py
@@ -232,7 +232,7 @@ class Fortio:
         return fortio_cmd
 
     def run(self, headers, conn, qps, size, duration):
-        labels = self.generate_test_labels(conn, qps, size, duration)
+        labels = self.generate_test_labels(conn, qps, size)
 
         grpc = ""
         if self.mode == "grpc":


### PR DESCRIPTION
This PR is to resolve task 1 of https://github.com/istio/istio/issues/22895:

Since I want to link the corresponding release to perf site Artifact page, I need the full GIT_SHA, not short one. 

The full GIT_SHA should be represented as a part of benchmark data folder name so that the backend can parse it.