### PR TITLE
fix file not found issue

### DIFF
--- a/perf_dashboard/helpers/download.py
+++ b/perf_dashboard/helpers/download.py
@@ -76,7 +76,6 @@ def download_benchmark_csv(days):
                             master_release_names.pop(0)
                             print(e)
 
-    delete_outdated_files(cur_release_names + master_release_names)
     cur_release_dates = [[]] * len(cur_release_names)
     for i in range(len(cur_release_names)):
         cur_release = cur_release_names[i]


### PR DESCRIPTION
This should be a workaround to fix perf site file not found issue after the merging of trace back to days.

But later on we need to do lots of optimizations on this.

error message:
```
Request Method: | GET
-- | --
http://perf.dashboard.istio.io/benchmarks/latency_vs_qps/
2.2.10
FileNotFoundError
[Errno 2] File b'/perf_dashboard/perf_data/master.20200203-00.8d9c7c9.csv' does not exist: b'/perf_dashboard/perf_data/master.20200203-00.8d9c7c9.csv'
```

```
/perf_dashboard/benchmarks/views.py in latency_vs_qps
            df = pd.read_csv(perf_data_path + master_selected_release[0] + ".csv") 
```