### PR TITLE
Custom profiling commands & flamegraphs

### DIFF
--- a/perf/benchmark/README.md
+++ b/perf/benchmark/README.md
@@ -141,12 +141,36 @@ optional arguments:
   --no_clientsidecar    do not run clientsidecar-only for all
   --bothsidecar         run both clientsidecar and serversidecar
   --no_sidecar          do not run clientsidecar and serversidecar
+  --custom_profiling_command
+                        runs a custom profiling commands on the nodes for the client and server,
+                        and produces a flamegraph based on that.
+                        Example on-cpu profile using bcc tools for the envoy sidecar proxy:
+                        --custom_profiling_command=\"profile-bpfcc -df {duration} -p {sidecar_pid}\"
+                        - runner.py will replace {duration} with whatever was specified for --duration.
+                        - runner.py will replace {sidecar_pid} with the actual process id of the envoy
+                          sidecar process.
+  --custom_profiling_name
+                        filename prefix for the result of any --custom_profiling_command
 ```
 
 Note:
 - `runner.py` will run all combinations of the parameters given. However, in order to reduce ambiguity when generating the graph, it would be
  better to change one parameter at a time and fix other parameters
 - if you want to run with `--perf` flag to generate a flame graph, please make sure you have the permission to gather perf data, please refer to step 2 of this [README](https://github.com/istio/tools/tree/master/perf/benchmark/flame#setup-perf-tool)
+- if you want to run with `--custom_profiling_command`, `profilingMode` must be set to `true` in `values.yaml`. Doing so will set up the client and server pods to run the perf/profiling container. It's worth noting that this container  runs `--priviledged`, and that `hostIPC` and `hostPID` will also be enabled,
+weakening security. Resulting flamegraphs will be written to `flame/flameoutput`.
+- sample sidecar profiling commands for `--custom_profiling_command`:
+  - "profile-bpfcc -df {duration} -p {sidecar_pid}" sidecar on-cpu profile
+  - "offcputime-bpfcc -df {duration} -p {sidecar_pid}" sidecar off-cpu profile
+  - "offwaketime-bpfcc -df {duration} -p {sidecar_pid}" sidecar offwaktime profile
+  - "wakeuptime-bpfcc -f -p {sidecar_pid} {duration}" sidecar wakeuptime profile
+  - "perf record -F 99 -a -g -p {sidecar_pid} -- sleep {duration} && perf script | ~/FlameGraph/stackcollapse-perf.pl | c++filt -n" on-cpu perf-generated profile
+  - "stackcount-bpfcc c:*alloc* -df -D {duration} -p {sidecar_pid}" profile calls to `*alloc*`
+- It's also possible to run machine-wide profiling, for example:
+  - "profile-bpfcc -df {duration}" for obtaining a machine-wide on-cpu flamegraph.
+  - See http://www.brendangregg.com/FlameGraphs/ for more examples and information.
+- Enabling `profilingMode` in `values.yaml` will also bring up and expose Prometheus's `node_exporter` at the configured port (default: 9100),
+  accessible over http via `/metrics.
 
 For example:
 

--- a/perf/benchmark/templates/fortio.yaml
+++ b/perf/benchmark/templates/fortio.yaml
@@ -40,7 +40,11 @@ spec:
     protocol: TCP
   - name: grpc-pinga
     port: 8076
+{{- if $.Values.profilingMode }}
+  - name: node-exporter
+    port: 9100
     protocol: TCP
+{{- end }}
   selector:
     app: {{ $.name }}
 {{- if $.V.expose }}
@@ -98,7 +102,7 @@ spec:
         config.linkerd.io/skip-inbound-ports: "8077"
 {{- end }}
         # exclude inbound ports of the uncaptured container
-        traffic.sidecar.istio.io/excludeInboundPorts: "8076,8077,8078"
+        traffic.sidecar.istio.io/excludeInboundPorts: "8076,8077,8078,{{ $.Values.nodeExporterPort }}"
         sidecar.istio.io/proxyCPU: {{ $.Values.proxy.cpu }}
         sidecar.istio.io/proxyMemory: {{ $.Values.proxy.memory }}
       labels:
@@ -118,9 +122,30 @@ spec:
                 - "fortioclient"
 {{- end }}
             topologyKey: "kubernetes.io/hostname"
+{{- if $.Values.profilingMode }}
+      hostIPC: true
+      hostPID: true   
+{{- end }}
       volumes:
       - name: shared-data
         emptyDir: {}
+{{- if $.Values.profilingMode }}
+      - name: sys
+        hostPath:
+          path: /sys
+      - name: lsb-release
+        hostPath:
+          path: /etc/lsb-release
+      - name: modules-generated
+        hostPath:
+          path: /var/cache/kernel/modules
+      - name: headers-generated
+        hostPath:
+          path: /var/cache/kernel/headers
+      - name: usr-host
+        hostPath:
+          path: /usr
+{{- end }}
       containers:
       - name: captured
         securityContext:
@@ -152,6 +177,33 @@ spec:
         args:
         - /bin/sleep
         - infinity
+{{- if $.Values.profilingMode }}
+      - name: perf
+        image: {{ $.Values.perfImage }}
+        imagePullPolicy: Always
+        securityContext:
+          privileged: true
+          capabilities:
+            add:
+              - SYS_ADMIN
+              - SYS_PTRACE
+        command: ["/bin/bash"]
+        args: ["-c", "./setup-node-for-profiling.sh :{{ $.Values.nodeExporterPort }}"]
+        ports:
+        - containerPort: {{ $.Values.nodeExporterPort }}
+          protocol: TCP
+        volumeMounts:
+          - mountPath: /sys
+            name: sys
+          - mountPath: /etc/lsb-release.host
+            name: lsb-release
+          - mountPath: /lib/modules
+            name: modules-generated
+          - mountPath: /usr/src
+            name: headers-generated
+          - mountPath: /usr-host
+            name: usr-host
+{{- end }}
       - name: uncaptured
         securityContext:
           runAsUser: 1

--- a/perf/benchmark/values.yaml
+++ b/perf/benchmark/values.yaml
@@ -43,5 +43,7 @@ client: # client overrides
 
 cert: false
 interceptionMode: REDIRECT
-
+profilingMode: true
+perfImage: oschaaf/istio-tools:profiling
+nodeExporterPort: 9100
 namespace: ""

--- a/perf/docker/Dockerfile.profiling
+++ b/perf/docker/Dockerfile.profiling
@@ -1,0 +1,21 @@
+FROM ubuntu:18.04
+
+WORKDIR /root
+
+COPY perf/setup-node-for-profiling.sh setup-node-for-profiling.sh
+
+RUN apt update && \
+  apt install -y git gcc make curl wget libelf-dev bc bpfcc-tools \
+    bison flex \
+    libdw-dev systemtap-sdt-dev libunwind-dev  libaudit-dev \
+    libssl-dev libslang2-dev libgtk2.0-dev libperl-dev python-dev && \
+  chmod +x setup-node-for-profiling.sh && \
+  wget -qO- https://github.com/prometheus/node_exporter/releases/download/v0.18.1/node_exporter-0.18.1.linux-amd64.tar.gz | tar -C . -xvzf - && \
+  cp node_exporter-*/node_exporter /usr/bin/ && \
+  rm -rf node_exporter-* && \
+  git clone --depth=1 https://github.com/BrendanGregg/FlameGraph && \
+  rm -rf /var/lib/apt/lists/* && \
+  rm -rf /tmp/*
+ 
+CMD ["setup-node-for-profiling.sh"]
+

--- a/perf/docker/perf/setup-node-for-profiling.sh
+++ b/perf/docker/perf/setup-node-for-profiling.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+set -ex
+
+USR_SRC="/usr/src"
+KERNEL_VERSION="$(uname -r)"
+CHROMEOS_RELEASE_VERSION="$(grep 'CHROMEOS_RELEASE_VERSION' /etc/lsb-release.host | cut -d '=' -f 2)"
+
+build_kernel()
+{
+  # Build the headers
+  cd "${WORKING_DIR}"
+  zcat /proc/config.gz > .config
+  make ARCH=x86 oldconfig > /dev/null
+  make ARCH=x86 prepare > /dev/null
+
+  # Build perf
+  cd tools/perf/
+  make ARCH=x86  > /dev/null
+  mv perf /usr/sbin/
+}
+
+prepare_node()
+{
+  WORKING_DIR="/linux-lakitu-${CHROMEOS_RELEASE_VERSION}"
+  SOURCES_DIR="${USR_SRC}/linux-lakitu-${CHROMEOS_RELEASE_VERSION}"
+  mkdir -p "${WORKING_DIR}"
+  curl -s "https://storage.googleapis.com/cos-tools/${CHROMEOS_RELEASE_VERSION}/kernel-src.tar.gz" \
+    | tar -xzf - -C "${WORKING_DIR}"
+  build_kernel
+  rm -rf "${USR_SRC}${WORKING_DIR}"
+  mv "${WORKING_DIR}" "${USR_SRC}"
+}
+
+prepare_node
+mkdir -p "/lib/modules/${KERNEL_VERSION}"
+ln -sf "${SOURCES_DIR}" "/lib/modules/${KERNEL_VERSION}/source"
+ln -sf "${SOURCES_DIR}" "/lib/modules/${KERNEL_VERSION}/build"
+
+# fire up the node exporter process, listening at the passed in address:port
+node_exporter --web.listen-address $1
+


### PR DESCRIPTION
Allows running custom profiling command on the nodes via bcc-tools
and perf, and obtains flamegraphs based on that.

See the updated README.md in perf/benchmark for examples and more
information.

Signed-off-by: Otto van der Schaaf <oschaaf@we-amp.com>