### PR TITLE
fix Asset charts not found when installing istio

### DIFF
--- a/perf/istio-install/setup_istio.sh
+++ b/perf/istio-install/setup_istio.sh
@@ -142,7 +142,7 @@ function install_istio_with_helm() {
 function install_istio_with_istioctl() {
   local CR_PATH="${WD}/istioctl_profiles/${CR_FILENAME}"
   pushd "${ISTIOCTL_PATH}"
-  ./istioctl manifest apply -f "${CR_PATH}" --set "${SET_OVERLAY}" "${EXTRA_ARGS}"
+  ./istioctl --charts manifest apply -f "${CR_PATH}" --set "${SET_OVERLAY}" "${EXTRA_ARGS}"
   popd
 }
 

--- a/perf/istio-install/setup_istio.sh
+++ b/perf/istio-install/setup_istio.sh
@@ -142,7 +142,7 @@ function install_istio_with_helm() {
 function install_istio_with_istioctl() {
   local CR_PATH="${WD}/istioctl_profiles/${CR_FILENAME}"
   pushd "${ISTIOCTL_PATH}"
-  ./istioctl --charts manifest apply -f "${CR_PATH}" --set "${SET_OVERLAY}" "${EXTRA_ARGS}"
+  ./istioctl install --charts ../manifest apply -f "${CR_PATH}" --set "${SET_OVERLAY}" "${EXTRA_ARGS}"
   popd
 }
 


### PR DESCRIPTION
This PR is to fix:

```
+ install_istio_with_istioctl
+ local CR_PATH=/home/prow/go/src/istio.io/tools/perf/istio-install/istioctl_profiles/default.yaml
+ pushd /home/prow/go/src/istio.io/tools/perf/istio-install/tmp
~/prow/go/src/istio.io/tools/perf/istio-install/tmp ~/prow/go/src/istio.io/tools/perf/istio-install
+ ./istioctl manifest apply -f /home/prow/go/src/istio.io/tools/perf/istio-install/istioctl_profiles/default.yaml --set meshConfig.rootNamespace=istio-system --force=true
Error: failed to apply manifests: failed to generate manifest: failed to scan bundled addon components: Asset charts not found
+ cleanup
```
