### PR TITLE
fix INSTALL_WITH_ISTIOCTL charts issue

### DIFF
--- a/perf/benchmark/run_benchmark_job.sh
+++ b/perf/benchmark/run_benchmark_job.sh
@@ -226,7 +226,7 @@ for dir in "${CONFIG_DIR}"/*; do
        extra_overlay="-f ${dir}/installation.yaml"
     fi
     pushd "${ROOT}/istio-install/tmp"
-      ./istioctl manifest apply -f "${DEFAULT_CR_PATH}" "${extra_overlay}" --force --wait
+      ./istioctl install --charts ./manifests -f "${DEFAULT_CR_PATH}" "${extra_overlay}" --force --wait
     popd
 
     # custom pre run

--- a/perf/istio-install/setup_istio.sh
+++ b/perf/istio-install/setup_istio.sh
@@ -142,7 +142,7 @@ function install_istio_with_helm() {
 function install_istio_with_istioctl() {
   local CR_PATH="${WD}/istioctl_profiles/${CR_FILENAME}"
   pushd "${ISTIOCTL_PATH}"
-  ./istioctl install --charts ../manifest apply -f "${CR_PATH}" --set "${SET_OVERLAY}" "${EXTRA_ARGS}"
+  ./istioctl install --charts ./manifests apply -f "${CR_PATH}" --set "${SET_OVERLAY}" "${EXTRA_ARGS}"
   popd
 }
 
@@ -170,9 +170,9 @@ function install_istio() {
       tar -xzf "${outfile}" -C "${DN}" --strip-components 1
       if [[ -z "${INSTALL_WITH_ISTIOCTL}" ]]; then
         mv "${DN}/install/kubernetes/helm" "${DIRNAME}/${release}"
-        mv "${DN}/bin/istioctl" "${DIRNAME}/${release}"
       fi
       cp "${DN}/bin/istioctl" "${DIRNAME}"
+      cp "${DN}/manifests" "${DIRNAME}"
       rm -rf "${DN}"
   fi
 

--- a/perf/istio-install/setup_istio.sh
+++ b/perf/istio-install/setup_istio.sh
@@ -172,7 +172,7 @@ function install_istio() {
         mv "${DN}/install/kubernetes/helm" "${DIRNAME}/${release}"
       fi
       cp "${DN}/bin/istioctl" "${DIRNAME}"
-      cp "${DN}/manifests" "${DIRNAME}"
+      cp -r "${DN}/manifests" "${DIRNAME}"
       rm -rf "${DN}"
   fi
 

--- a/perf/istio-install/setup_istio.sh
+++ b/perf/istio-install/setup_istio.sh
@@ -142,7 +142,7 @@ function install_istio_with_helm() {
 function install_istio_with_istioctl() {
   local CR_PATH="${WD}/istioctl_profiles/${CR_FILENAME}"
   pushd "${ISTIOCTL_PATH}"
-  ./istioctl install --charts ./manifests apply -f "${CR_PATH}" --set "${SET_OVERLAY}" "${EXTRA_ARGS}"
+  ./istioctl install --charts ./manifests -f "${CR_PATH}" --set "${SET_OVERLAY}" "${EXTRA_ARGS}"
   popd
 }
 


### PR DESCRIPTION
- The dir would look like `/tmp/istioctl` and `tmp/manifests/...` in the same tmp folder
- Also, INSTALL_WITH_ISTIOCTL is a bool, we should not mv /bin/istioctl when we do not use it, aka install with helm. 
