### PR TITLE
Support https redirect in perf dashboard

### DIFF
--- a/perf_dashboard/deploy/perf-dashboard/templates/deployment.yaml
+++ b/perf_dashboard/deploy/perf-dashboard/templates/deployment.yaml
@@ -20,11 +20,10 @@ spec:
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         ports:
         - containerPort: {{ .Values.port }}
+        {{- with .Values.env }}
         env:
-        - name: NODE_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.hostIP
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
         readinessProbe:
           httpGet:
             path: /

--- a/perf_dashboard/deploy/perf-dashboard/values.yaml
+++ b/perf_dashboard/deploy/perf-dashboard/values.yaml
@@ -9,6 +9,14 @@ fullnameOverride: ""
 ipName: perf-dashboard
 domain: perf.dashboard.istio.io
 
+env:
+- name: SECURE_SSL_REDIRECT
+  value: "True"
+- name: NODE_IP
+  valueFrom:
+    fieldRef:
+      fieldPath: status.hostIP
+
 image: gcr.io/istio-testing/perf-dashboard
 version: latest
 imagePullPolicy: Always

--- a/perf_dashboard/perf_dashboard/settings.py
+++ b/perf_dashboard/perf_dashboard/settings.py
@@ -25,6 +25,7 @@ https://docs.djangoproject.com/en/3.0/ref/settings/
 """
 
 import os
+
 from socket import gethostname, gethostbyname
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
@@ -149,3 +150,8 @@ STATICFILES_DIRS = [
 
 MEDIA_URL = '/media/'
 MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
+
+# Enable SSL/HTTPS
+# https://docs.djangoproject.com/en/2.2/topics/security/#ssl-https
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+SECURE_SSL_REDIRECT = os.getenv('SECURE_SSL_REDIRECT', False)


### PR DESCRIPTION
Enable SSL redirection for http://perf.dashboard.istio.io/ in production.

fix https://github.com/istio/istio/issues/22406