### PR TITLE
Support https redirect in perf dashboard

### DIFF
--- a/perf_dashboard/deploy/perf-dashboard/templates/deployment.yaml
+++ b/perf_dashboard/deploy/perf-dashboard/templates/deployment.yaml
@@ -20,14 +20,13 @@ spec:
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         ports:
         - containerPort: {{ .Values.port }}
+        {{- with .Values.env }}
         env:
-        - name: NODE_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.hostIP
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
         readinessProbe:
           httpGet:
-            path: /
+            path: /healthz
             port: {{ .Values.port }}
             httpHeaders:
             - name: Host
@@ -38,7 +37,7 @@ spec:
           failureThreshold: 3
         livenessProbe:
           httpGet:
-            path: /
+            path: /healthz
             port: {{ .Values.port }}
             httpHeaders:
             - name: Host

--- a/perf_dashboard/deploy/perf-dashboard/values.yaml
+++ b/perf_dashboard/deploy/perf-dashboard/values.yaml
@@ -9,6 +9,14 @@ fullnameOverride: ""
 ipName: perf-dashboard
 domain: perf.dashboard.istio.io
 
+env:
+- name: SECURE_SSL_REDIRECT
+  value: "True"
+- name: NODE_IP
+  valueFrom:
+    fieldRef:
+      fieldPath: status.hostIP
+
 image: gcr.io/istio-testing/perf-dashboard
 version: latest
 imagePullPolicy: Always

--- a/perf_dashboard/perf_dashboard/settings.py
+++ b/perf_dashboard/perf_dashboard/settings.py
@@ -150,3 +150,9 @@ STATICFILES_DIRS = [
 
 MEDIA_URL = '/media/'
 MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
+
+# Enable SSL/HTTPS
+# https://docs.djangoproject.com/en/2.2/topics/security/#ssl-https
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+SECURE_SSL_REDIRECT = os.getenv('SECURE_SSL_REDIRECT', False)
+SECURE_REDIRECT_EXEMPT = [r"^healthz$"]

--- a/perf_dashboard/perf_dashboard/urls.py
+++ b/perf_dashboard/perf_dashboard/urls.py
@@ -37,6 +37,7 @@ from . import views
 
 urlpatterns = [
     url(r'^$', views.index, name="index_page"),
+    url(r'^healthz$', views.healthz, name="healthz"),
     url(r'^admin/', admin.site.urls),
     url(r'^artifacts/', include('artifacts.urls')),
     url(r'^analyze_perf_issues/', include('analyze_perf_issues.urls')),

--- a/perf_dashboard/perf_dashboard/views.py
+++ b/perf_dashboard/perf_dashboard/views.py
@@ -12,8 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from django.http import HttpResponse
 from django.shortcuts import render
 
 
 def index(request):
     return render(request, 'index.html')
+
+
+def healthz(request):
+    return HttpResponse("OK", status=200)


### PR DESCRIPTION
Second attempt at https://github.com/istio/tools/pull/903 which was reverted in https://github.com/istio/tools/pull/906 due to health check issues. 

In this iteration I am adding a dedicated endpoint for health check; one that is not redirected and thus always (when healthy) returns a 200 status code.

/hold 
As this requires health check modification, since this is not done automatically.