### PR TITLE
fix upgrade test charts not found issue

### DIFF
--- a/upgrade/test_crossgrade.sh
+++ b/upgrade/test_crossgrade.sh
@@ -257,6 +257,7 @@ upgradeIstioAtVersionUsingIstioctl(){
   istioctl_path="${3}"/bin
   # shellcheck disable=SC2072
   if [[ "${TO_TAG}" > "1.5" ]]; then
+    make gen-charts
     "${istioctl_path}"/istioctl upgrade --skip-confirmation
   elif [[ "${TO_TAG}" > "1.4" ]]; then
     "${istioctl_path}"/istioctl x upgrade --skip-confirmation


### PR DESCRIPTION
Error log:

```
istioctl upgrade istio using version 1.6-alpha.9550ee4a1084ded0df27e516930acf91a3bb8096 from to_dir.OQQZXU/istio-1.6-alpha.9550ee4a1084ded0df27e516930acf91a3bb8096.

****************

Error: failed to generate Istio configs from file [], error: compiled in charts not found in this development build, use --charts with local charts instead or run make gen-charts
Waiting for pods to be ready in istio-system...
RUNNING _waitForPodsReady istio-system
Succeeded.
All pods ready.
```