### PR TITLE
Amend handling of modes in runner.py

### DIFF
--- a/perf/benchmark/runner/runner.py
+++ b/perf/benchmark/runner/runner.py
@@ -326,26 +326,28 @@ class Fortio:
         if self.run_baseline:
             sidecar_mode = "baseline"
             sidecar_mode_func = self.nosidecar
+            self.execute_sidecar_mode(sidecar_mode, self.load_gen_type, load_gen_cmd, sidecar_mode_func, labels, perf_label)
 
         if self.run_serversidecar:
             perf_label = "_srv_serveronly"
             sidecar_mode = "server sidecar"
             sidecar_mode_func = self.serversidecar
+            self.execute_sidecar_mode(sidecar_mode, self.load_gen_type, load_gen_cmd, sidecar_mode_func, labels, perf_label)
 
         if self.run_clientsidecar:
             perf_label = "_srv_clientonly"
             sidecar_mode = "client sidecar"
             sidecar_mode_func = self.clientsidecar
+            self.execute_sidecar_mode(sidecar_mode, self.load_gen_type, load_gen_cmd, sidecar_mode_func, labels, perf_label)
 
         if self.run_bothsidecar:
             perf_label = "_srv_bothsidecars"
             sidecar_mode = "both sidecar"
             sidecar_mode_func = self.bothsidecar
+            self.execute_sidecar_mode(sidecar_mode, self.load_gen_type, load_gen_cmd, sidecar_mode_func, labels, perf_label)
 
         if self.run_ingress:
             perf_label = "_srv_ingress"
-
-        if self.run_ingress:
             print('-------------- Running in ingress mode --------------')
             kubectl_exec(self.client.name, self.ingress(load_gen_cmd))
             if self.perf_record:
@@ -354,9 +356,6 @@ class Fortio:
                     self.server.name,
                     labels + "_srv_ingress",
                     duration=40)
-        else:
-            self.execute_sidecar_mode(sidecar_mode, self.load_gen_type, load_gen_cmd, sidecar_mode_func, labels, perf_label)
-
 
 PERFCMD = "/usr/lib/linux-tools/4.4.0-131-generic/perf"
 FLAMESH = "flame.sh"

--- a/perf/benchmark/runner/runner.py
+++ b/perf/benchmark/runner/runner.py
@@ -357,6 +357,7 @@ class Fortio:
                     labels + "_srv_ingress",
                     duration=40)
 
+
 PERFCMD = "/usr/lib/linux-tools/4.4.0-131-generic/perf"
 FLAMESH = "flame.sh"
 PERFSH = "get_perfdata.sh"


### PR DESCRIPTION
In 2db8284b54be946f42aceec670d74aa8b259612b a change was introduced
which broke handling of modes: only a single one would be executed.

This change amends that. Sorry!

Signed-off-by: Otto van der Schaaf <oschaaf@we-amp.com>