### PR TITLE
disable jitter in nighthawk run

### DIFF
--- a/perf/benchmark/runner/runner.py
+++ b/perf/benchmark/runner/runner.py
@@ -252,7 +252,6 @@ class Fortio:
             "--output-format json",
             "--prefetch-connections",
             "--open-loop",
-            "--jitter-uniform 0.0001s",
             "--experimental-h1-connection-reuse-strategy lru",
             "--experimental-h2-use-multiple-connections",
             "--label Nighthawk",


### PR DESCRIPTION
Our published perf number for Fortio did not use --jitter. For better comparison, we should disable for nighthawk for now.