### PR TITLE
add burst-size flag for nighthawk

### DIFF
--- a/perf/benchmark/runner/runner.py
+++ b/perf/benchmark/runner/runner.py
@@ -257,6 +257,7 @@ class Fortio:
             "--experimental-h2-use-multiple-connections",
             "--label Nighthawk",
             "--connections {conn}",
+            "--burst-size {conn}",
             "--rps {qps}",
             "--duration {duration}",
             "--request-header \"x-nighthawk-test-server-config: {{response_body_size:{size}}}\""


### PR DESCRIPTION
By doing experiment, currently, with  --burst-size flag introduced, we can get perf number which is able to compare with fortio