### PR TITLE
Allow cue-gen to generate field preserveUnknownFields in CRD

### DIFF
--- a/cmd/cue-gen/build.go
+++ b/cmd/cue-gen/build.go
@@ -447,6 +447,15 @@ func convertCrdConfig(c map[string]string, t string, cfg *CrdConfig) {
 			version.Name = v
 		case "schema":
 			sc = v
+		case "preserveUnknownFields":
+			var b bool
+			switch v {
+			case "true":
+				b = true
+			case "false":
+				b = false
+			}
+			src.Spec.PreserveUnknownFields = &b
 		}
 	}
 	if sc != "" {


### PR DESCRIPTION
As a result, CRD will have the field `preserveUnknownFields: false` if `+cue-gen:<CRD>:preserveUnknownFields:false` is specified in proto comments.

Helps with: https://github.com/istio/istio/issues/10872