### PR TITLE
Revert LLVM change

### DIFF
--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -500,7 +500,7 @@ ENV LLVM_ARCHIVE=clang+llvm-${LLVM_VERSION}-${LLVM_TARGET}
 ENV LLVM_URL=${LLVM_BASE_URL}/${LLVM_ARCHIVE}.tar.xz
 ENV LLVM_DIRECTORY=/usr/lib/llvm
 
-RUN wget --show-progress ${LLVM_URL}
+RUN wget ${LLVM_URL}
 RUN tar -xJf ${LLVM_ARCHIVE}.tar.xz -C /tmp
 RUN mkdir -p ${LLVM_DIRECTORY}
 RUN mv /tmp/${LLVM_ARCHIVE}/* ${LLVM_DIRECTORY}/

--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -500,7 +500,7 @@ ENV LLVM_ARCHIVE=clang+llvm-${LLVM_VERSION}-${LLVM_TARGET}
 ENV LLVM_URL=${LLVM_BASE_URL}/${LLVM_ARCHIVE}.tar.xz
 ENV LLVM_DIRECTORY=/usr/lib/llvm
 
-RUN wget ${LLVM_URL}
+RUN wget --show-progress ${LLVM_URL}
 RUN tar -xJf ${LLVM_ARCHIVE}.tar.xz -C /tmp
 RUN mkdir -p ${LLVM_DIRECTORY}
 RUN mv /tmp/${LLVM_ARCHIVE}/* ${LLVM_DIRECTORY}/

--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -482,20 +482,20 @@ ENTRYPOINT ["/usr/local/bin/docker-entrypoint"]
 # Clang+LLVM
 ##############
 
-FROM ubuntu:bionic as clang_context
+FROM ubuntu:xenial as clang_context
 
 # hadolint ignore=DL3008
 RUN apt-get update && apt-get install -y --no-install-recommends \
     xz-utils \
     wget \
     ca-certificates \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
 
-ENV LLVM_VERSION=10.0.0
-ENV LLVM_TARGET=x86_64-linux-gnu-ubuntu-18.04
+ENV LLVM_VERSION=9.0.0
+ENV LLVM_TARGET=x86_64-linux-gnu-ubuntu-16.04
 
-ENV LLVM_BASE_URL=https://github.com/llvm/llvm-project/releases/download/llvmorg-${LLVM_VERSION}
+ENV LLVM_BASE_URL=http://releases.llvm.org/${LLVM_VERSION}
 ENV LLVM_ARCHIVE=clang+llvm-${LLVM_VERSION}-${LLVM_TARGET}
 ENV LLVM_URL=${LLVM_BASE_URL}/${LLVM_ARCHIVE}.tar.xz
 ENV LLVM_DIRECTORY=/usr/lib/llvm
@@ -520,8 +520,8 @@ ENV BAZELISK_URL="${BAZELISK_BASE_URL}/${BAZELISK_VERSION}/${BAZELISK_BIN}"
 RUN apt-get update && apt-get install -y --no-install-recommends \
     wget \
     ca-certificates \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
 
 RUN wget ${BAZELISK_URL}
 RUN chmod +x ${BAZELISK_BIN}
@@ -584,8 +584,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3-setuptools \
     daemon \
     wget \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
 
 # Docker including docker-ce, docker-ce-cli, and containerd.io
 ADD https://download.docker.com/linux/ubuntu/gpg /tmp/docker-key
@@ -595,8 +595,8 @@ RUN apt-get update && apt-get -y install --no-install-recommends \
     docker-ce="${DOCKER_VERSION}" \
     docker-ce-cli="${DOCKER_VERSION}" \
     containerd.io="${CONTAINERD_VERSION}" \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
 
 # Run dockerd in CI
 COPY prow-entrypoint.sh /usr/local/bin/entrypoint
@@ -614,8 +614,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python \
     unzip \
     virtualenv \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
 
 COPY --from=binary_tools_context /out/ /
 COPY --from=binary_tools_context /usr/local/go /usr/local/go

--- a/docker/build-tools/Dockerfile.centos
+++ b/docker/build-tools/Dockerfile.centos
@@ -28,6 +28,7 @@ RUN echo "/opt/rh/httpd24/root/usr/lib64" > /etc/ld.so.conf.d/httpd24.conf && \
 ENV LLVM_VERSION=9.0.1
 ENV LLVM_DISTRO="x86_64-linux-sles11.3"
 ENV LLVM_RELEASE="clang+llvm-${LLVM_VERSION}-${LLVM_DISTRO}"
+# hadolint ignore=DL4001
 RUN wget --show-progress ${LLVM_RELEASE}.tar.xz https://releases.llvm.org/${LLVM_VERSION}/${LLVM_RELEASE}.tar.xz && \
     tar Jxf ${LLVM_RELEASE}.tar.xz && \
     mv ./${LLVM_RELEASE} /opt/llvm && \

--- a/docker/build-tools/Dockerfile.centos
+++ b/docker/build-tools/Dockerfile.centos
@@ -25,10 +25,10 @@ RUN ln -s /usr/bin/cmake3 /usr/bin/cmake && \
 RUN echo "/opt/rh/httpd24/root/usr/lib64" > /etc/ld.so.conf.d/httpd24.conf && \
     ldconfig
 
-ENV LLVM_VERSION=10.0.0
+ENV LLVM_VERSION=9.0.0
 ENV LLVM_DISTRO="x86_64-linux-sles11.3"
 ENV LLVM_RELEASE="clang+llvm-${LLVM_VERSION}-${LLVM_DISTRO}"
-RUN curl -fsSL --output ${LLVM_RELEASE}.tar.xz https://github.com/llvm/llvm-project/releases/download/llvmorg-${LLVM_VERSION}/${LLVM_RELEASE}.tar.xz && \
+RUN curl -fsSL --output ${LLVM_RELEASE}.tar.xz https://releases.llvm.org/${LLVM_VERSION}/${LLVM_RELEASE}.tar.xz && \
     tar Jxf ${LLVM_RELEASE}.tar.xz && \
     mv ./${LLVM_RELEASE} /opt/llvm && \
     chown -R root:root /opt/llvm && \

--- a/docker/build-tools/Dockerfile.centos
+++ b/docker/build-tools/Dockerfile.centos
@@ -25,7 +25,7 @@ RUN ln -s /usr/bin/cmake3 /usr/bin/cmake && \
 RUN echo "/opt/rh/httpd24/root/usr/lib64" > /etc/ld.so.conf.d/httpd24.conf && \
     ldconfig
 
-ENV LLVM_VERSION=9.0.1
+ENV LLVM_VERSION=9.0.0
 ENV LLVM_DISTRO="x86_64-linux-sles11.3"
 ENV LLVM_RELEASE="clang+llvm-${LLVM_VERSION}-${LLVM_DISTRO}"
 RUN curl -fsSL --output ${LLVM_RELEASE}.tar.xz https://releases.llvm.org/${LLVM_VERSION}/${LLVM_RELEASE}.tar.xz && \

--- a/docker/build-tools/Dockerfile.centos
+++ b/docker/build-tools/Dockerfile.centos
@@ -28,7 +28,6 @@ RUN echo "/opt/rh/httpd24/root/usr/lib64" > /etc/ld.so.conf.d/httpd24.conf && \
 ENV LLVM_VERSION=9.0.1
 ENV LLVM_DISTRO="x86_64-linux-sles11.3"
 ENV LLVM_RELEASE="clang+llvm-${LLVM_VERSION}-${LLVM_DISTRO}"
-# hadolint ignore=DL4001
 RUN wget --show-progress ${LLVM_RELEASE}.tar.xz https://releases.llvm.org/${LLVM_VERSION}/${LLVM_RELEASE}.tar.xz && \
     tar Jxf ${LLVM_RELEASE}.tar.xz && \
     mv ./${LLVM_RELEASE} /opt/llvm && \

--- a/docker/build-tools/Dockerfile.centos
+++ b/docker/build-tools/Dockerfile.centos
@@ -25,10 +25,10 @@ RUN ln -s /usr/bin/cmake3 /usr/bin/cmake && \
 RUN echo "/opt/rh/httpd24/root/usr/lib64" > /etc/ld.so.conf.d/httpd24.conf && \
     ldconfig
 
-ENV LLVM_VERSION=9.0.1
+ENV LLVM_VERSION=9.0.0
 ENV LLVM_DISTRO="x86_64-linux-sles11.3"
 ENV LLVM_RELEASE="clang+llvm-${LLVM_VERSION}-${LLVM_DISTRO}"
-RUN wget --show-progress ${LLVM_RELEASE}.tar.xz https://releases.llvm.org/${LLVM_VERSION}/${LLVM_RELEASE}.tar.xz && \
+RUN curl -fsSL --output ${LLVM_RELEASE}.tar.xz https://releases.llvm.org/${LLVM_VERSION}/${LLVM_RELEASE}.tar.xz && \
     tar Jxf ${LLVM_RELEASE}.tar.xz && \
     mv ./${LLVM_RELEASE} /opt/llvm && \
     chown -R root:root /opt/llvm && \

--- a/docker/build-tools/Dockerfile.centos
+++ b/docker/build-tools/Dockerfile.centos
@@ -25,7 +25,7 @@ RUN ln -s /usr/bin/cmake3 /usr/bin/cmake && \
 RUN echo "/opt/rh/httpd24/root/usr/lib64" > /etc/ld.so.conf.d/httpd24.conf && \
     ldconfig
 
-ENV LLVM_VERSION=9.0.0
+ENV LLVM_VERSION=9.0.1
 ENV LLVM_DISTRO="x86_64-linux-sles11.3"
 ENV LLVM_RELEASE="clang+llvm-${LLVM_VERSION}-${LLVM_DISTRO}"
 RUN curl -fsSL --output ${LLVM_RELEASE}.tar.xz https://releases.llvm.org/${LLVM_VERSION}/${LLVM_RELEASE}.tar.xz && \

--- a/docker/build-tools/Dockerfile.centos
+++ b/docker/build-tools/Dockerfile.centos
@@ -25,10 +25,10 @@ RUN ln -s /usr/bin/cmake3 /usr/bin/cmake && \
 RUN echo "/opt/rh/httpd24/root/usr/lib64" > /etc/ld.so.conf.d/httpd24.conf && \
     ldconfig
 
-ENV LLVM_VERSION=9.0.0
+ENV LLVM_VERSION=9.0.1
 ENV LLVM_DISTRO="x86_64-linux-sles11.3"
 ENV LLVM_RELEASE="clang+llvm-${LLVM_VERSION}-${LLVM_DISTRO}"
-RUN curl -fsSL --output ${LLVM_RELEASE}.tar.xz https://releases.llvm.org/${LLVM_VERSION}/${LLVM_RELEASE}.tar.xz && \
+RUN wget --show-progress ${LLVM_RELEASE}.tar.xz https://releases.llvm.org/${LLVM_VERSION}/${LLVM_RELEASE}.tar.xz && \
     tar Jxf ${LLVM_RELEASE}.tar.xz && \
     mv ./${LLVM_RELEASE} /opt/llvm && \
     chown -R root:root /opt/llvm && \

--- a/docker/build-tools/build-and-push.sh
+++ b/docker/build-tools/build-and-push.sh
@@ -41,7 +41,8 @@ ${CONTAINER_CLI} ${CONTAINER_BUILDER}  --target build_tools --build-arg "ISTIO_T
 # shellcheck disable=SC2086
 ${CONTAINER_CLI} ${CONTAINER_BUILDER}  --build-arg "ISTIO_TOOLS_SHA=${SHA}" --build-arg "VERSION=${VERSION}" -t "${HUB}/build-tools-proxy:${VERSION}" -t "${HUB}/build-tools-proxy:${BRANCH}-latest" .
 # shellcheck disable=SC2086
-${CONTAINER_CLI} ${CONTAINER_BUILDER}  --build-arg "ISTIO_TOOLS_SHA=${SHA}" --build-arg "VERSION=${VERSION}" -t "${HUB}/build-tools-centos:${VERSION}" -t "${HUB}/build-tools-centos:${BRANCH}-latest" -f Dockerfile.centos .
+# ${CONTAINER_CLI} ${CONTAINER_BUILDER}  --build-arg "ISTIO_TOOLS_SHA=${SHA}" --build-arg "VERSION=${VERSION}" -t "${HUB}/build-tools-centos:${VERSION}" -t "${HUB}/build-tools-centos:${BRANCH}-latest" -f Dockerfile.centos .
+# CentOS is temporarily disabled to workaround LLVM download issues
 
 if [[ -z "${DRY_RUN:-}" ]]; then
   ${CONTAINER_CLI} push "${HUB}/build-tools:${VERSION}"


### PR DESCRIPTION
This will break the proxy as it relies on the specific glibc version. The LLVM 404 issues seem transient