### PR TITLE
Allow unknown fields in unmarshaler generation

### DIFF
--- a/cmd/protoc-gen-jsonshim/jsonshim/plugin.go
+++ b/cmd/protoc-gen-jsonshim/jsonshim/plugin.go
@@ -106,7 +106,7 @@ func (p *Plugin) Generate(file *generator.FileDescriptor) {
 	p.P(`var (`)
 	p.In()
 	p.P(marshalerName, ` = &`, jsonpbPkg.Use(), `.Marshaler{}`)
-	p.P(unmarshalerName, ` = &`, jsonpbPkg.Use(), `.Unmarshaler{}`)
+	p.P(unmarshalerName, ` = &`, jsonpbPkg.Use(), `.Unmarshaler{AllowUnknownFields: true}`)
 	p.Out()
 	p.P(`)`)
 

--- a/cmd/protoc-gen-jsonshim/test/generated/external_json.gen.go
+++ b/cmd/protoc-gen-jsonshim/test/generated/external_json.gen.go
@@ -27,7 +27,18 @@ func (this *ExternalSimple) UnmarshalJSON(b []byte) error {
 	return ExternalUnmarshaler.Unmarshal(bytes.NewReader(b), this)
 }
 
+// MarshalJSON is a custom marshaler for ExternalSimple_ExternalNested
+func (this *ExternalSimple_ExternalNested) MarshalJSON() ([]byte, error) {
+	str, err := ExternalMarshaler.MarshalToString(this)
+	return []byte(str), err
+}
+
+// UnmarshalJSON is a custom unmarshaler for ExternalSimple_ExternalNested
+func (this *ExternalSimple_ExternalNested) UnmarshalJSON(b []byte) error {
+	return ExternalUnmarshaler.Unmarshal(bytes.NewReader(b), this)
+}
+
 var (
 	ExternalMarshaler   = &github_com_gogo_protobuf_jsonpb.Marshaler{}
-	ExternalUnmarshaler = &github_com_gogo_protobuf_jsonpb.Unmarshaler{}
+	ExternalUnmarshaler = &github_com_gogo_protobuf_jsonpb.Unmarshaler{AllowUnknownFields: true}
 )

--- a/cmd/protoc-gen-jsonshim/test/generated/types_json.gen.go
+++ b/cmd/protoc-gen-jsonshim/test/generated/types_json.gen.go
@@ -38,6 +38,17 @@ func (this *SimpleWithMap) UnmarshalJSON(b []byte) error {
 	return TypesUnmarshaler.Unmarshal(bytes.NewReader(b), this)
 }
 
+// MarshalJSON is a custom marshaler for SimpleWithMap_Nested
+func (this *SimpleWithMap_Nested) MarshalJSON() ([]byte, error) {
+	str, err := TypesMarshaler.MarshalToString(this)
+	return []byte(str), err
+}
+
+// UnmarshalJSON is a custom unmarshaler for SimpleWithMap_Nested
+func (this *SimpleWithMap_Nested) UnmarshalJSON(b []byte) error {
+	return TypesUnmarshaler.Unmarshal(bytes.NewReader(b), this)
+}
+
 // MarshalJSON is a custom marshaler for ReferencedMap
 func (this *ReferencedMap) MarshalJSON() ([]byte, error) {
 	str, err := TypesMarshaler.MarshalToString(this)
@@ -62,5 +73,5 @@ func (this *ImportedReference) UnmarshalJSON(b []byte) error {
 
 var (
 	TypesMarshaler   = &github_com_gogo_protobuf_jsonpb.Marshaler{}
-	TypesUnmarshaler = &github_com_gogo_protobuf_jsonpb.Unmarshaler{}
+	TypesUnmarshaler = &github_com_gogo_protobuf_jsonpb.Unmarshaler{AllowUnknownFields: true}
 )


### PR DESCRIPTION
This allows our unmarshaler for go client in 1.5 to allow unknown fields.