### PR TITLE
cue-gen: update deprecated syntax

### DIFF
--- a/cmd/cue-gen/assets.gen.go
+++ b/cmd/cue-gen/assets.gen.go
@@ -101,7 +101,7 @@ all?: {
 
 // directories is a map of directories, relative to the root, for which to
 // process proto files.
-directories <Dir>: [...{
+directories: [string]: [...{
 	// mode indicates which proto files to include in generated output.
 	//   all      include all proto files
 	//   perFile  generate a separate OpenAPI file for each proto file

--- a/cmd/cue-gen/doc.cue
+++ b/cmd/cue-gen/doc.cue
@@ -53,7 +53,7 @@ all?: {
 
 // directories is a map of directories, relative to the root, for which to
 // process proto files.
-directories <Dir>: [...{
+directories: [string]: [...{
 	// mode indicates which proto files to include in generated output.
 	//   all      include all proto files
 	//   perFile  generate a separate OpenAPI file for each proto file


### PR DESCRIPTION
This syntax was deprecated for a while. Updating will
ensure compatility with latest versions.