### PR TITLE
Remove deprecated field certmanager

### DIFF
--- a/perf/istio-install/istioctl_profiles/default.yaml
+++ b/perf/istio-install/istioctl_profiles/default.yaml
@@ -75,8 +75,6 @@ spec:
             cpu: 4800m
             memory: 2G
   values:
-    certmanager:
-      email: mjog@google.com
     gateways:
       istio-ingressgateway:
         secretVolumes:


### PR DESCRIPTION
For fixing this error:
```
+ /home/prow/go/src/istio.io/tools/perf/istio-install/tmp/istio-1.6-alpha.eb9893cb31cef4974c0bf1d221e2b0a46c96dddd/bin/istioctl manifest apply --skip-confirmation --wait -d /home/prow/go/src/istio.io/tools/perf/istio-install/tmp/istio-1.6-alpha.eb9893cb31cef4974c0bf1d221e2b0a46c96dddd/manifests -f istioctl_profiles/default.yaml
Error: failed to apply manifests: validation errors (use --force to override): 
unknown field "certmanager" in v1alpha1.Values
```