### PR TITLE
Disable plaintext, Add LOAD_GEN_TYPE in envoy dump, and Fix fortio.py data conversion issue

### DIFF
--- a/perf/benchmark/configs/run_perf_test.conf
+++ b/perf/benchmark/configs/run_perf_test.conf
@@ -1,6 +1,6 @@
 mixer=false
 none=true
-plaintext=true
+plaintext=false
 telemetryv2_sd_full=true
 telemetryv2_sd_nologging=true
 telemetryv2_stats=true

--- a/perf/benchmark/run_benchmark_job.sh
+++ b/perf/benchmark/run_benchmark_job.sh
@@ -192,7 +192,7 @@ function collect_envoy_info() {
   POD_NAME=${2}
   FILE_SUFFIX=${3}
 
-  ENVOY_DUMP_NAME="${POD_NAME}_${CONFIG_NAME}_${FILE_SUFFIX}.yaml"
+  ENVOY_DUMP_NAME="${LOAD_GEN_TYPE}_${POD_NAME}_${CONFIG_NAME}_${FILE_SUFFIX}.yaml"
   kubectl exec -n "${NAMESPACE}" "${POD_NAME}" -c istio-proxy -- curl http://localhost:15000/"${FILE_SUFFIX}" > "${ENVOY_DUMP_NAME}"
   gsutil -q cp -r "${ENVOY_DUMP_NAME}" "gs://${GCS_BUCKET}/${OUTPUT_DIR}/${FILE_SUFFIX}/${ENVOY_DUMP_NAME}"
 }

--- a/perf/benchmark/runner/fortio.py
+++ b/perf/benchmark/runner/fortio.py
@@ -61,10 +61,10 @@ def convert_data(data):
 
     success = 0
     if '200' in data["RetCodes"]:
-        success = data["RetCodes"]["200"]
+        success = int(data["RetCodes"]["200"])
 
     obj["errorPercent"] = 100 * \
-        (data["Sizes"]["Count"] - success) / data["Sizes"]["Count"]
+        (int(data["Sizes"]["Count"]) - success) / int(data["Sizes"]["Count"])
     obj["Payload"] = int(data['Sizes']['Avg'])
     return obj
 


### PR DESCRIPTION
This PR includes:

1. Disable plaintext run for now:
- Currently mtls line is overlapped with plaintext line, we need to figure out why and fix it.
- Also, plaintext run has the following error: https://storage.googleapis.com/istio-prow/logs/daily-fortio-performance-benchmark-release-1.6/8/build-log.txt

2. Add LOAD_GEN_TYPE in envoy dump
3. Fix fortio.py data conversion issue