### PR TITLE
[release-1.6] disable plaintext run

### DIFF
--- a/perf/benchmark/configs/run_perf_test.conf
+++ b/perf/benchmark/configs/run_perf_test.conf
@@ -1,6 +1,6 @@
 mixer=false
 none=true
-plaintext=true
+plaintext=false
 telemetryv2_sd_full=true
 telemetryv2_sd_nologging=true
 telemetryv2_stats=true


### PR DESCRIPTION
Plaintext run currently blocked our perf pipeline for 1.6. I'm disabling it for 1.6 until we fixed the prerun script for it. 