### PR TITLE
[release-1.6] Update 1.6 istio install default profile + Fix fortio.py data conversion issue + Update configdump name

### DIFF
--- a/perf/benchmark/run_benchmark_job.sh
+++ b/perf/benchmark/run_benchmark_job.sh
@@ -192,7 +192,7 @@ function collect_envoy_info() {
   POD_NAME=${2}
   FILE_SUFFIX=${3}
 
-  ENVOY_DUMP_NAME="${POD_NAME}_${CONFIG_NAME}_${FILE_SUFFIX}.yaml"
+  ENVOY_DUMP_NAME="${LOAD_GEN_TYPE}_${POD_NAME}_${CONFIG_NAME}_${FILE_SUFFIX}.yaml"
   kubectl exec -n "${NAMESPACE}" "${POD_NAME}" -c istio-proxy -- curl http://localhost:15000/"${FILE_SUFFIX}" > "${ENVOY_DUMP_NAME}"
   gsutil -q cp -r "${ENVOY_DUMP_NAME}" "gs://${GCS_BUCKET}/${OUTPUT_DIR}/${FILE_SUFFIX}/${ENVOY_DUMP_NAME}"
 }

--- a/perf/benchmark/runner/fortio.py
+++ b/perf/benchmark/runner/fortio.py
@@ -61,10 +61,10 @@ def convert_data(data):
 
     success = 0
     if '200' in data["RetCodes"]:
-        success = data["RetCodes"]["200"]
+        success = int(data["RetCodes"]["200"])
 
     obj["errorPercent"] = 100 * \
-        (data["Sizes"]["Count"] - success) / data["Sizes"]["Count"]
+        (int(data["Sizes"]["Count"]) - success) / int(data["Sizes"]["Count"])
     obj["Payload"] = int(data['Sizes']['Avg'])
     return obj
 

--- a/perf/istio-install/istioctl_profiles/default.yaml
+++ b/perf/istio-install/istioctl_profiles/default.yaml
@@ -1,125 +1,611 @@
-apiVersion: operator.istio.io/v1alpha1
+apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
+metadata:
+  namespace: istio-system
 spec:
+  hub: gcr.io/istio-testing
+  tag: latest
+
+  # You may override parts of meshconfig by uncommenting the following lines.
+  meshConfig:
+    enablePrometheusMerge: false
+    # Opt-out of global http2 upgrades.
+    # Destination rule is used to opt-in.
+    # h2_upgrade_policy: DO_NOT_UPGRADE
+
+  # Traffic management feature
   components:
-    galley:
-      enabled: false
-    ingressGateways:
-    - name: istio-ingressgateway
+    base:
       enabled: true
-      k8s:
-        hpaSpec:
-          maxReplicas: 5
-          minReplicas: 3
-          scaleTargetRef:
-            apiVersion: apps/v1
-            kind: Deployment
-            name: istio-ingressgateway
-        resources:
-          limits:
-            cpu: 6000m
-            memory: 512Mi
-          requests:
-            cpu: 4000m
-            memory: 512Mi
-    egressGateways:
-    - name: istio-egressgateway
+    pilot:
       enabled: true
       k8s:
         env:
-        - name: ISTIO_META_REQUESTED_NETWORK_VIEW
-          value: external
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.name
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.namespace
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 1
+          periodSeconds: 3
+          timeoutSeconds: 5
+        strategy:
+          rollingUpdate:
+            maxSurge: "100%"
+            maxUnavailable: "25%"
+
+    # Policy feature
     policy:
-      enabled: false
-    citadel:
-      enabled: true
-    nodeAgent:
-      enabled: false
-    telemetry:
       enabled: false
       k8s:
         hpaSpec:
-          maxReplicas: 15
+          maxReplicas: 5
+          minReplicas: 1
+          scaleTargetRef:
+            apiVersion: apps/v1
+            kind: Deployment
+            name: istio-policy
           metrics:
-            - resource:
+            - type: Resource
+              resource:
                 name: cpu
                 targetAverageUtilization: 80
-              type: Resource
+        env:
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.namespace
+        strategy:
+          rollingUpdate:
+            maxSurge: "100%"
+            maxUnavailable: "25%"
+
+    # Telemetry feature
+    telemetry:
+      enabled: false
+      k8s:
+        env:
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.namespace
+          - name: GOMAXPROCS
+            value: "6"
+        hpaSpec:
+          maxReplicas: 5
           minReplicas: 1
           scaleTargetRef:
             apiVersion: apps/v1
             kind: Deployment
             name: istio-telemetry
+          metrics:
+            - type: Resource
+              resource:
+                name: cpu
+                targetAverageUtilization: 80
+        replicaCount: 1
         resources:
-          limits:
-            cpu: 5800m
-            memory: 5G
           requests:
-            cpu: 3800m
+            cpu: 1000m
+            memory: 1G
+          limits:
+            cpu: 4800m
             memory: 4G
-    pilot:
+        strategy:
+          rollingUpdate:
+            maxSurge: "100%"
+            maxUnavailable: "25%"
+
+    # Security feature
+    citadel:
+      enabled: false
+      k8s:
+        strategy:
+          rollingUpdate:
+            maxSurge: "100%"
+            maxUnavailable: "25%"
+
+    # Istio Gateway feature
+    ingressGateways:
+    - name: istio-ingressgateway
       enabled: true
       k8s:
+        env:
+          - name: ISTIO_META_ROUTER_MODE
+            value: "sni-dnat"
+        service:
+          ports:
+            - port: 15021
+              targetPort: 15021
+              name: status-port
+            - port: 80
+              targetPort: 8080
+              name: http2
+            - port: 443
+              targetPort: 8443
+              name: https
+            - port: 15443
+              targetPort: 15443
+              name: tls
         hpaSpec:
-          maxReplicas: 10
-          minReplicas: 2
+          maxReplicas: 5
+          minReplicas: 1
           scaleTargetRef:
             apiVersion: apps/v1
             kind: Deployment
-            name: istio-pilot
+            name: istio-ingressgateway
+          metrics:
+            - type: Resource
+              resource:
+                name: cpu
+                targetAverageUtilization: 80
         resources:
-          limits:
-            cpu: 5800m
-            memory: 12G
           requests:
-            cpu: 4800m
-            memory: 2G
+            cpu: 100m
+            memory: 128Mi
+          limits:
+            cpu: 2000m
+            memory: 1024Mi
+        strategy:
+          rollingUpdate:
+            maxSurge: "100%"
+            maxUnavailable: "25%"
+
+    egressGateways:
+    - name: istio-egressgateway
+      enabled: false
+      k8s:
+        env:
+          - name: ISTIO_META_ROUTER_MODE
+            value: "sni-dnat"
+        service:
+          ports:
+            - port: 80
+              name: http2
+            - port: 443
+              name: https
+            - port: 15443
+              targetPort: 15443
+              name: tls
+        hpaSpec:
+          maxReplicas: 5
+          minReplicas: 1
+          scaleTargetRef:
+            apiVersion: apps/v1
+            kind: Deployment
+            name: istio-egressgateway
+          metrics:
+            - type: Resource
+              resource:
+                name: cpu
+                targetAverageUtilization: 80
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+          limits:
+            cpu: 2000m
+            memory: 1024Mi
+        strategy:
+          rollingUpdate:
+            maxSurge: "100%"
+            maxUnavailable: "25%"
+    # Istio CNI feature
+    cni:
+      enabled: false
+
+    # istiod remote configuration wwhen istiod isn't installed on the cluster
+    istiodRemote:
+      enabled: false
+
+  addonComponents:
+    prometheus:
+      enabled: true
+      k8s:
+        replicaCount: 1
+    kiali:
+      enabled: false
+      k8s:
+        replicaCount: 1
+    grafana:
+      enabled: false
+      k8s:
+        replicaCount: 1
+    tracing:
+      enabled: false
+    istiocoredns:
+      enabled: false
+
+  # Global values passed through to helm global.yaml.
+  # Please keep this in sync with manifests/charts/global.yaml
   values:
-    gateways:
-      istio-ingressgateway:
-        secretVolumes:
-        - mountPath: /etc/istio/ingressgateway-certs
-          name: istio-ingressgateway-certs
-          secretName: istio-ingressgateway-certs
-        type: LoadBalancer
     global:
-      controlPlaneSecurityEnabled: false
-      meshExpansion:
+      istioNamespace: istio-system
+      istiod:
         enabled: true
-        useILB: true
-      mtls:
-        enabled: true
-      multiCluster:
-        enabled: true
-      podDNSSearchNamespaces:
-        - global
+        enableAnalysis: false
+      logging:
+        level: "default:info"
+      logAsJson: false
+      pilotCertProvider: istiod
+      jwtPolicy: third-party-jwt
       proxy:
-        enableCoreDump: true
+        image: proxyv2
+        clusterDomain: "cluster.local"
         resources:
           requests:
-            cpu: 250m
-            memory: 256Mi
+            cpu: 100m
+            memory: 128Mi
           limits:
-            memory: 256Mi
-      sds:
+            cpu: 2000m
+            memory: 1024Mi
+        logLevel: warning
+        componentLogLevel: "misc:error"
+        privileged: false
+        enableCoreDump: false
+        statusPort: 15020
+        readinessInitialDelaySeconds: 1
+        readinessPeriodSeconds: 2
+        readinessFailureThreshold: 30
+        includeIPRanges: "*"
+        excludeIPRanges: ""
+        excludeOutboundPorts: ""
+        excludeInboundPorts: ""
+        autoInject: enabled
+        envoyStatsd:
+          enabled: false
+          host: # example: statsd-svc.istio-system
+          port: # example: 9125
+        tracer: "zipkin"
+      proxy_init:
+        image: proxyv2
+        resources:
+          limits:
+            cpu: 100m
+            memory: 50Mi
+          requests:
+            cpu: 10m
+            memory: 10Mi
+      # Specify image pull policy if default behavior isn't desired.
+      # Default behavior: latest images will be Always else IfNotPresent.
+      imagePullPolicy: ""
+      operatorManageWebhooks: false
+      controlPlaneSecurityEnabled: true
+      tracer:
+        lightstep:
+          address: ""                # example: lightstep-satellite:443
+          accessToken: ""            # example: abcdefg1234567
+        zipkin:
+          address: ""
+        datadog:
+          address: "$(HOST_IP):8126"
+        stackdriver:
+          debug: false
+          maxNumberOfAttributes: 200
+          maxNumberOfAnnotations: 200
+          maxNumberOfMessageEvents: 200
+      imagePullSecrets: []
+      arch:
+        amd64: 2
+        s390x: 2
+        ppc64le: 2
+      oneNamespace: false
+      defaultNodeSelector: {}
+      configValidation: true
+      meshExpansion:
         enabled: false
-        udsPath: ""
+        useILB: false
+      multiCluster:
+        enabled: false
+        clusterName: ""
+      omitSidecarInjectorConfigMap: false
+      network: ""
+      defaultResources:
+        requests:
+          cpu: 10m
+      defaultPodDisruptionBudget:
+        enabled: true
+      priorityClassName: ""
+      useMCP: false
+      trustDomain: "cluster.local"
+      sds:
         token:
           aud: istio-ca
+      sts:
+        servicePort: 0
+      meshNetworks: {}
+      enableHelmTest: false
+      mountMtlsCerts: false
+    base:
+      validationURL: ""
+    pilot:
+      autoscaleEnabled: true
+      autoscaleMin: 1
+      autoscaleMax: 5
+      replicaCount: 1
+      image: pilot
+      traceSampling: 1.0
+      configNamespace: istio-config
+      appNamespaces: []
+      env: {}
+      cpu:
+        targetAverageUtilization: 80
+      nodeSelector: {}
+      tolerations: []
+      podAntiAffinityLabelSelector: []
+      podAntiAffinityTermLabelSelector: []
+      keepaliveMaxServerConnectionAge: 30m
+      enableProtocolSniffingForOutbound: true
+      enableProtocolSniffingForInbound: true
+      deploymentLabels:
+      configMap: true
+      policy:
+        enabled: false
+
+    telemetry:
+      enabled: true
+      v1:
+        enabled: false
+      v2:
+        enabled: true
+        metadataExchange: {}
+        prometheus:
+          enabled: true
+        stackdriver:
+          enabled: false
+          logging: false
+          monitoring: false
+          topology: false
+          configOverride: {}
+    mixer:
+      adapters:
+        stdio:
+          enabled: false
+          outputAsJson: false
+        prometheus:
+          enabled: true
+          metricsExpiryDuration: 10m
+        kubernetesenv:
+          enabled: true
+        stackdriver:
+          enabled: false
+          auth:
+            appCredentials: false
+            apiKey: ""
+            serviceAccountPath: ""
+          tracer:
+            enabled: false
+            sampleProbability: 1
+        useAdapterCRDs: false
+
+      telemetry:
+        image: mixer
+        replicaCount: 1
+        autoscaleEnabled: true
+        sessionAffinityEnabled: false
+        loadshedding:
+          mode: enforce
+          latencyThreshold: 100ms
+        env:
+          GOMAXPROCS: "6"
+        nodeSelector: {}
+        tolerations: []
+        podAntiAffinityLabelSelector: []
+        podAntiAffinityTermLabelSelector: []
+
+      policy:
+        autoscaleEnabled: true
+        image: mixer
+        sessionAffinityEnabled: false
+        adapters:
+          kubernetesenv:
+            enabled: true
+          useAdapterCRDs: false
+
+    istiodRemote:
+      injectionURL: ""
+
+    gateways:
+      istio-egressgateway:
+        zvpn: {}
+        env: {}
+        autoscaleEnabled: true
+        type: ClusterIP
+        name: istio-egressgateway
+        secretVolumes:
+          - name: egressgateway-certs
+            secretName: istio-egressgateway-certs
+            mountPath: /etc/istio/egressgateway-certs
+          - name: egressgateway-ca-certs
+            secretName: istio-egressgateway-ca-certs
+            mountPath: /etc/istio/egressgateway-ca-certs
+
+      istio-ingressgateway:
+        autoscaleEnabled: true
+        applicationPorts: ""
+        debug: info
+        domain: ""
+        type: LoadBalancer
+        name: istio-ingressgateway
+        zvpn: {}
+        env: {}
+        meshExpansionPorts:
+          - port: 15011
+            targetPort: 15011
+            name: tcp-pilot-grpc-tls
+          - port: 15012
+            targetPort: 15012
+            name: tcp-istiod
+          - port: 8060
+            targetPort: 8060
+            name: tcp-citadel-grpc-tls
+          - port: 853
+            targetPort: 8853
+            name: tcp-dns-tls
+        secretVolumes:
+          - name: ingressgateway-certs
+            secretName: istio-ingressgateway-certs
+            mountPath: /etc/istio/ingressgateway-certs
+          - name: ingressgateway-ca-certs
+            secretName: istio-ingressgateway-ca-certs
+            mountPath: /etc/istio/ingressgateway-ca-certs
+
+    sidecarInjectorWebhook:
+      enableNamespacesByDefault: false
+      rewriteAppHTTPProbe: true
+      injectLabel: istio-injection
+      objectSelector:
+        enabled: false
+        autoInject: true
+
+    prometheus:
+      hub: docker.io/prom
+      tag: v2.15.1
+      retention: 6h
+      scrapeInterval: 15s
+      contextPath: /prometheus
+
+      security:
+        enabled: true
+      nodeSelector: {}
+      tolerations: []
+      podAntiAffinityLabelSelector: []
+      podAntiAffinityTermLabelSelector: []
+      provisionPrometheusCert: true
+
     grafana:
+      image:
+        repository: grafana/grafana
+        tag: 6.5.2
+      persist: false
+      storageClassName: ""
+      accessMode: ReadWriteMany
+      security:
+        enabled: false
+        secretName: grafana
+        usernameKey: username
+        passphraseKey: passphrase
+      contextPath: /grafana
+      service:
+        annotations: {}
+        name: http
+        type: ClusterIP
+        externalPort: 3000
+        loadBalancerIP:
+        loadBalancerSourceRanges:
       datasources:
         datasources.yaml:
           apiVersion: 1
           datasources:
-          - access: proxy
-            editable: true
-            isDefault: true
-            jsonData:
-              timeInterval: 5s
-            name: Prometheus
-            orgId: 1
-            type: prometheus
-            url: http://istio-prometheus.istio-prometheus:9090
-      enabled: true
+      dashboardProviders:
+        dashboardproviders.yaml:
+          apiVersion: 1
+          providers:
+            - name: 'istio'
+              orgId: 1
+              folder: 'istio'
+              type: file
+              disableDeletion: false
+              options:
+                path: /var/lib/grafana/dashboards/istio
+      nodeSelector: {}
+      tolerations: []
+      podAntiAffinityLabelSelector: []
+      podAntiAffinityTermLabelSelector: []
+      env: {}
+      envSecrets: {}
+
     tracing:
-      enabled: true
+      provider: jaeger
+      nodeSelector: {}
+      podAntiAffinityLabelSelector: []
+      podAntiAffinityTermLabelSelector: []
+      jaeger:
+        hub: docker.io/jaegertracing
+        tag: "1.16"
+        memory:
+          max_traces: 50000
+        spanStorageType: badger
+        persist: false
+        storageClassName: ""
+        accessMode: ReadWriteMany
+      zipkin:
+        hub: docker.io/openzipkin
+        tag: 2.20.0
+        probeStartupDelay: 10
+        queryPort: 9411
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 2048Mi
+          requests:
+            cpu: 150m
+            memory: 900Mi
+        javaOptsHeap: 700
+        maxSpans: 500000
+        node:
+          cpus: 2
+      opencensus:
+        hub: docker.io/omnition
+        tag: 0.1.9
+        resources:
+          limits:
+            cpu: "1"
+            memory: 2Gi
+          requests:
+            cpu: 200m
+            memory: 400Mi
+        exporters:
+          stackdriver:
+            enable_tracing: true
+      service:
+        annotations: {}
+        name: http-query
+        type: ClusterIP
+        externalPort: 9411
+    istiocoredns:
+      coreDNSImage: coredns/coredns
+      coreDNSTag: 1.6.2
+      coreDNSPluginImage: istio/coredns-plugin:0.2-istio-1.1
+
+    kiali:
+      hub: quay.io/kiali
+      tag: v1.18
+      contextPath: /kiali
+      nodeSelector: {}
+      podAntiAffinityLabelSelector: []
+      podAntiAffinityTermLabelSelector: []
+      dashboard:
+        secretName: kiali
+        usernameKey: username
+        passphraseKey: passphrase
+        viewOnlyMode: false
+        grafanaURL:
+        grafanaInClusterURL: http://grafana:3000
+        jaegerURL:
+        jaegerInClusterURL: http://tracing/jaeger
+        auth:
+          strategy: login
+      prometheusNamespace:
+      createDemoSecret: false
+      security:
+        enabled: false
+        cert_file: /kiali-cert/cert-chain.pem
+        private_key_file: /kiali-cert/key.pem
+      service:
+        annotations: {}
+
+    # TODO: derive from operator API
+    version: ""
+    clusterResources: true


### PR DESCRIPTION
- Apply the latest default.yaml istio install profile, ref: https://github.com/istio/istio/blob/release-1.6/manifests/profiles/default.yaml
- Fix data conversion issue:

```
File "fortio.py", line 86, in fetch
    return convert_data(data)
  File "fortio.py", line 67, in convert_data
    (data["Sizes"]["Count"] - success) / data["Sizes"]["Count"]
TypeError: unsupported operand type(s) for -: 'str' and 'str'
```

- Update configdump name to have LOAD_GEN_TYPE