### PR TITLE
Dockerfile: Add PyYAML to build container.

### DIFF
--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -313,6 +313,7 @@ ENV YAMLLINT_VERSION=1.17.0
 ENV REQUESTS_VERSION=2.22.0
 ENV RUAMELYAML_VERSION=0.16.5
 ENV PYTHON_PROTOBUF_VERSION=3.11.2
+ENV PYYAML_VERSION=5.3.1
 
 # hadolint ignore=DL3008
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -334,6 +335,7 @@ RUN pip3 install yamllint==${YAMLLINT_VERSION}
 RUN pip3 install requests==${REQUESTS_VERSION}
 RUN pip3 install ruamel.yaml==${RUAMELYAML_VERSION}
 RUN pip3 install protobuf==${PYTHON_PROTOBUF_VERSION}
+RUN pip3 install PyYAML==${PYYAML_VERSION}
 # hadolint ignore=DL3013
 RUN pip3 install /tmp/mako-0.1-cp37-cp37m-linux_x86_64.whl
 


### PR DESCRIPTION
The script that generates user doc tests needs to parse a YAML file, so
include a Python YAML parser.