### PR TITLE
Fix perf pipeline issues

### DIFF
--- a/perf/benchmark/run_benchmark_job.sh
+++ b/perf/benchmark/run_benchmark_job.sh
@@ -95,7 +95,7 @@ pipenv install
 
 # Step 5: setup perf data local output directory
 dt=$(date +'%Y%m%d')
-# Current output dir should be like: 20191025_1.5-alpha.f19fb40b777e357b605e85c04fb871578592ad1e
+# Current output dir should be like: 20200523_nighthawk_master_1.7-alpha.f19fb40b777e357b605e85c04fb871578592ad1e
 export OUTPUT_DIR="${dt}_${LOAD_GEN_TYPE}_${GIT_BRANCH}_${INSTALL_VERSION}"
 LOCAL_OUTPUT_DIR="/tmp/${OUTPUT_DIR}"
 mkdir -p "${LOCAL_OUTPUT_DIR}"

--- a/perf/benchmark/run_benchmark_job.sh
+++ b/perf/benchmark/run_benchmark_job.sh
@@ -207,6 +207,13 @@ function collect_clusters_info() {
   collect_envoy_info "${1}" "${FORTIO_SERVER_POD}" "clusters"
 }
 
+function collect_pod_spec() {
+  POD_NAME=${1}
+  POD_SPEC_NAME="${LOAD_GEN_TYPE}_${POD_NAME}.yaml"
+  kubectl get pods "${POD_NAME}" -n "${NAMESPACE}" -o yaml > "${POD_SPEC_NAME}"
+  gsutil -q cp -r "${POD_SPEC_NAME}" "gs://${GCS_BUCKET}/${OUTPUT_DIR}/pod_spec/${POD_SPEC_NAME}"
+}
+
 # Start run perf test
 echo "Start to run perf benchmark test, all collected data will be dumped to GCS bucket: ${GCS_BUCKET}/${OUTPUT_DIR}"
 
@@ -247,6 +254,10 @@ for dir in "${CONFIG_DIR}"/*; do
 
     # Collect config_dump after prerun.sh and before test run, in order to verify test setup is correct
     collect_config_dump "${config_name}"
+
+    # Collect pod spec
+    collect_pod_spec "${FORTIO_CLIENT_POD}"
+    collect_pod_spec "${FORTIO_SERVER_POD}"
 
     # Run test and collect data
     if [[ -e "./cpu_mem.yaml" ]]; then

--- a/perf/benchmark/run_benchmark_job.sh
+++ b/perf/benchmark/run_benchmark_job.sh
@@ -96,7 +96,7 @@ pipenv install
 # Step 5: setup perf data local output directory
 dt=$(date +'%Y%m%d')
 # Current output dir should be like: 20191025_1.5-alpha.f19fb40b777e357b605e85c04fb871578592ad1e
-export OUTPUT_DIR="${dt}_${INSTALL_VERSION}"
+export OUTPUT_DIR="${dt}_${LOAD_GEN_TYPE}_${GIT_BRANCH}_${INSTALL_VERSION}"
 LOCAL_OUTPUT_DIR="/tmp/${OUTPUT_DIR}"
 mkdir -p "${LOCAL_OUTPUT_DIR}"
 

--- a/perf/benchmark/runner/runner.py
+++ b/perf/benchmark/runner/runner.py
@@ -247,6 +247,7 @@ class Fortio:
         return fortio_cmd
 
     def generate_nighthawk_cmd(self, cpus, conn, qps, duration, labels):
+        labels = "nighthawk_" + labels
         nighthawk_args = [
             "nighthawk_client",
             "--concurrency {cpus}",
@@ -255,7 +256,6 @@ class Fortio:
             "--open-loop",
             "--experimental-h1-connection-reuse-strategy lru",
             "--experimental-h2-use-multiple-connections",
-            "--label Nighthawk",
             "--connections {conn}",
             "--burst-size {conn}",
             "--rps {qps}",


### PR DESCRIPTION
This PR fixes 3 issues:

- Make perf folder name distinguishable by add LOAD_GEN_TYPE and GIT_BRANCH in the name. 
  Without this change, different perf job running against same release-sha would be overwritten by the later job, which is not the correct behavoir.
- Fix nighthawk Labels name
  Current generated label is like: `Nighthawk 3d9b5daa_qps_1000_c_64_1024_v2-stats-nullvm_both` which should be `nighthawk_3d9b5daa_qps_1000_c_64_1024_v2-stats-nullvm_both`
- Collect pod spec info for providing more debugging info

