### PR TITLE
Fix --perf flag for generating istio-proxy CPU flame graph

### DIFF
--- a/perf/benchmark/flame/README.md
+++ b/perf/benchmark/flame/README.md
@@ -1,4 +1,4 @@
-# Creating cpu flame graphs for Istio / Envoy
+# Creating CPU flame graphs for Istio / Envoy
 
 ![example](example_flame_graph/example_flagmegraph.svg)
 
@@ -56,7 +56,7 @@ Flame graphs are created from data collected using linux `perf_events` by the `p
 1. Run [`get_proxy_perf.sh`](get_proxy_perf.sh) to get the profiling svg. The following command collects samples at `177Hz` for `20s`. The svg file should be created under `flameoutput` dir
 
     ```plain
-    ./get_proxy_perf.sh -p svc05-0-7-564865d756-pvjhn -n service-graph05 -s 177 -t 20
+    ./get_proxy_perf.sh -p svc05-0-4-0-67bff5dbbf-grl94 -n service-graph05 -d 20 -f 99
     ...
     [ perf record: Woken up 1 times to write data ]
     [ perf record: Captured and wrote 0.061 MB /etc/istio/proxy/perf.data (74 samples) ]

--- a/perf/benchmark/flame/flame.sh
+++ b/perf/benchmark/flame/flame.sh
@@ -14,7 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Exit immediately for non zero status
 set -e
+# Check unset variables
+set -u
+# Print commands
+set -x
 
 WD=$(dirname "${0}")
 WD=$(cd "${WD}" && pwd)
@@ -34,7 +39,7 @@ if [[ ! -d ${FLAMEDIR} ]]; then
 fi
 
 # Given output of `perf script` produce a flamegraph
-FILE=${1:?"perf script output"}
+FILE=${1:?"get_perfdata script output"}
 FILENAME=$(basename "${FILE}")
 BASE=$(echo "${FILENAME}" | cut -d '.' -f 1)
 SVGNAME="${BASE}.svg"
@@ -42,7 +47,5 @@ SVGNAME="${BASE}.svg"
 mkdir -p "${WD}/flameoutput"
 "${FLAMEDIR}/stackcollapse-perf.pl" "${FILE}" | c++filt -n | "${FLAMEDIR}/flamegraph.pl" --cp > "./flameoutput/${SVGNAME}"
 
-echo "Wrote ${SVGNAME}"
-if [[ -n "${BUCKET}" ]];then
-    gsutil cp "${SVGNAME}" "${BUCKET}"
-fi
+echo "Wrote CPU flame graph for istio-proxy ${SVGNAME}"
+

--- a/perf/benchmark/runner/runner.py
+++ b/perf/benchmark/runner/runner.py
@@ -61,8 +61,6 @@ def run_command(command):
 
 def run_command_sync(command):
     op = getoutput(command)
-    print("==============")
-    print(command)
     return op.strip()
 
 
@@ -200,7 +198,6 @@ class Fortio:
 
         if self.perf_record and len(perf_label_suffix) > 0:
             run_perf(
-                self.mesh,
                 self.server.name,
                 labels + perf_label_suffix,
                 duration=40,
@@ -372,7 +369,11 @@ LOCAL_FLAME_PROXY_FILE_PATH = LOCAL_FLAMEDIR + PERF_PROXY_FILE
 LOCAL_FLAMEOUTPUT = LOCAL_FLAMEDIR + "flameoutput/"
 
 
-def run_perf(pod, labels, duration=40, frequency=99):
+def run_perf(pod, labels, duration, frequency):
+    if duration is None:
+        duration = 40
+    if frequency is None:
+        frequency = 99
     os.environ["PERF_DATA_FILENAME"] = labels + "_perf.data"
     print(os.environ["PERF_DATA_FILENAME"])
     run_command_sync(LOCAL_FLAME_PROXY_FILE_PATH + " -p {pod} -n {namespace} -d {duration} -f {frequency}".format(

--- a/perf/benchmark/runner/runner.py
+++ b/perf/benchmark/runner/runner.py
@@ -61,6 +61,8 @@ def run_command(command):
 
 def run_command_sync(command):
     op = getoutput(command)
+    print("==============")
+    print(command)
     return op.strip()
 
 
@@ -202,7 +204,7 @@ class Fortio:
                 self.server.name,
                 labels + perf_label_suffix,
                 duration=40,
-                frequncey=self.frequency)
+                frequency=self.frequency)
 
     def generate_test_labels(self, conn, qps, size):
         size = size or self.size
@@ -370,7 +372,7 @@ LOCAL_FLAME_PROXY_FILE_PATH = LOCAL_FLAMEDIR + PERF_PROXY_FILE
 LOCAL_FLAMEOUTPUT = LOCAL_FLAMEDIR + "flameoutput/"
 
 
-def run_perf(mesh, pod, labels, duration=20, frequency=99):
+def run_perf(pod, labels, duration=40, frequency=99):
     os.environ["PERF_DATA_FILENAME"] = labels + "_perf.data"
     print(os.environ["PERF_DATA_FILENAME"])
     run_command_sync(LOCAL_FLAME_PROXY_FILE_PATH + " -p {pod} -n {namespace} -d {duration} -f {frequency}".format(

--- a/perf/benchmark/values.yaml
+++ b/perf/benchmark/values.yaml
@@ -10,7 +10,7 @@ proxy:
 
 appresources1:
   requests:
-    cpu: "800m"
+    cpu: "1500m"
     memory: "1000Mi"
 
 fortioImage: fortio/fortio:latest

--- a/upgrade/run_upgrade_test.sh
+++ b/upgrade/run_upgrade_test.sh
@@ -63,7 +63,7 @@ function get_git_sha() {
        LINUX_TAR_SUFFIX="linux.tar.gz"
     fi
     GIT_SHA=$(curl "${url_path}/${release_version}-dev")
-  elif [ "${tag}" == "master" ];then
+  elif [[ "${tag}" == "master" ]];then
     GIT_SHA=$(curl "${url_path}/latest")
   fi
 }
@@ -110,7 +110,7 @@ download_untar_istio_release "${TARGET_RELEASE_PATH}" "${TARGET_TAG}" "${TARGET_
 
 # Check https://github.com/istio/test-infra/blob/master/boskos/resources.yaml
 # for existing resources types
-if [ "${UPGRADE_TEST_LOCAL}" = "" ]; then
+if [[ "${UPGRADE_TEST_LOCAL}" = "" ]]; then
     export RESOURCE_TYPE="${RESOURCE_TYPE:-gke-e2e-test}"
     export OWNER='upgrade-tests'
     export USE_MASON_RESOURCE="${USE_MASON_RESOURCE:-True}"

--- a/upgrade/test_crossgrade.sh
+++ b/upgrade/test_crossgrade.sh
@@ -198,7 +198,7 @@ withRetriesMaxTime() {
 #   OR checkIfDeleted namespace istio-system
 checkIfDeleted() {
     local resp
-    if [ -n "${3}" ]; then
+    if [[ -n "${3}" ]]; then
         resp=$( kubectl get "${1}" -n "${3}" "${2}" 2>&1 )
     else
         resp=$( kubectl get "${1}" "${2}" 2>&1 )
@@ -219,7 +219,7 @@ deleteWithWait() {
 
 installIstioAtVersionUsingHelm() {
     writeMsg "helm templating then applying new yaml using version ${2} from ${3}."
-    if [ -n "${AUTH_ENABLE}" ]; then
+    if [[ -n "${AUTH_ENABLE}" ]]; then
         echo "Auth is enabled, generating manifest with auth."
         auth_opts="--set global.mtls.enabled=true --set global.controlPlaneSecurityEnabled=true "
     fi
@@ -332,7 +332,7 @@ runFortioLoadCommand() {
 
 waitForExternalRequestTraffic() {
     echo "Waiting for external traffic to complete"
-    while [ ! -f "${EXTERNAL_FORTIO_DONE_FILE}" ]; do
+    while [[ ! -f "${EXTERNAL_FORTIO_DONE_FILE}" ]]; do
         sleep 10
     done
 }
@@ -363,7 +363,7 @@ _waitForIngress() {
     INGRESS_HOST=$(kubectl -n "${ISTIO_NAMESPACE}" get service istio-ingressgateway -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
     INGRESS_PORT=$(kubectl -n "${ISTIO_NAMESPACE}" get service istio-ingressgateway -o jsonpath='{.spec.ports[?(@.name=="http2")].port}')
     INGRESS_ADDR=${INGRESS_HOST}:${INGRESS_PORT}
-    if [ -z "${INGRESS_HOST}" ]; then return 1; fi
+    if [[ -z "${INGRESS_HOST}" ]]; then return 1; fi
 }
 
 waitForIngress() {
@@ -386,7 +386,7 @@ _waitForPodsReady() {
             ready="false"
         fi
     done
-    if [  "${ready}" = "true" ]; then
+    if [[  "${ready}" = "true" ]]; then
         return 0
     fi
 
@@ -570,7 +570,7 @@ else
     echo "=== Errors found in internal traffic is within threshold ==="
 fi
 
-if [ -n "${failed}" ]; then
+if [[ -n "${failed}" ]]; then
     exit 1
 fi
 


### PR DESCRIPTION
https://github.com/istio/istio/issues/24193

This PR includes:

- Fix `--perf` flag broken issue in runner.py file, simply the CPU flame graph profiling process by only directly calling `get_proxy_perf.sh`.
- Add PERF_DATA_FILENAME env var, when running runner.py file, the generated .svg file would be named to test_run_lables, e.g. `4637b0fd_qps_1000_c_4_1024_v2-nullvm_srv_bothsidecars_perf.svg` otherwise, it will be named to pod_name_timestamp.svg, like `fortioserver-6c8b98c89-nfddn_2020-05-31-16-45-41.svg`.
- Some cleanup in `flame.sh` script.
- Update Flame graph README.md.
- Increase requested CPU for perf deployment