### PR TITLE
Update README for istio building configuration and for Docker Building

### DIFF
--- a/docker/istio-dev/Dockerfile
+++ b/docker/istio-dev/Dockerfile
@@ -31,17 +31,17 @@ bash-completion=1:2.1-4.2ubuntu1.1 \
 build-essential=12.1ubuntu2 \
 ca-certificates=20170717~16.04.2 \
 curl=7.47.0-1ubuntu2.14 \
-git=1:2.7.4-0ubuntu1.7 \
+git=1:2.7.4-0ubuntu1.9 \
 iptables=1.6.0-2ubuntu3 \
 jq=1.5+dfsg-1ubuntu0.1 \
 libtool=2.4.6-0.1 \
 lsb-release=9.20160110ubuntu0.2 \
 make=4.1-6 \
 python3=3.5.1-3 \
-sudo=1.8.16-0ubuntu1.8 \
+sudo=1.8.16-0ubuntu1.9 \
 tmux=2.1-3build1 \
 unzip=6.0-20ubuntu1 \
-vim=2:7.4.1689-3ubuntu1.3 \
+vim=2:7.4.1689-3ubuntu1.4 \
 wget=1.17.1-1ubuntu1.5 \
 xz-utils=5.1.1alpha+20120614-2ubuntu2 \
 && rm -rf /var/lib/apt/lists/*
@@ -58,8 +58,8 @@ COPY --from=docker /usr/local/bin/docker /usr/local/bin/docker
 RUN echo "deb http://packages.cloud.google.com/apt cloud-sdk-$(lsb_release -c -s) main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
 && curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - \
 && apt-get update && apt-get -qqy install --no-install-recommends \
-google-cloud-sdk=272.0.0-0 \
-kubectl=1.17.0-00 \
+google-cloud-sdk=294.0.0-0 \
+kubectl=1.18.3-00 \
 && rm -rf /var/lib/apt/lists/*
 
 # Install bash completion files.

--- a/docker/istio-dev/README.md
+++ b/docker/istio-dev/README.md
@@ -73,6 +73,23 @@ Check that you can access the cluster:
 ```bash
 kubectl get nodes
 ```
+To build istio and unit tests in docker container
+```bash
+cd ~/go/src/istio.io/istio
+```
+For istio building
+```bash
+sudo path=$PATH make BUILD_WITH_CONTAINER=0  build
+```
+For istio unit tests
+```bash
+sudo path=$PATH make BUILD_WITH_CONTAINER=0 test
+```
+some times when we want to rebuild it, you may find that istio cannot find the go path,
+one simple approach to solve it is to add go binary file to system bin/
+```
+cp /usr/local/go/bin/go /bin
+```
 
 ## Removing The Container
 

--- a/docker/istio-dev/README.md
+++ b/docker/istio-dev/README.md
@@ -73,20 +73,31 @@ Check that you can access the cluster:
 ```bash
 kubectl get nodes
 ```
+
+
 To build istio and unit tests in docker container
+
+
 ```bash
 cd ~/go/src/istio.io/istio
 ```
+
 For istio building
+
 ```bash
 sudo path=$PATH make BUILD_WITH_CONTAINER=0  build
 ```
+
 For istio unit tests
+
 ```bash
 sudo path=$PATH make BUILD_WITH_CONTAINER=0 test
 ```
+
+
 some times when we want to rebuild it, you may find that istio cannot find the go path,
 one simple approach to solve it is to add go binary file to system bin/
+
 ```
 cp /usr/local/go/bin/go /bin
 ```

--- a/docker/istio-dev/README.md
+++ b/docker/istio-dev/README.md
@@ -104,5 +104,4 @@ cp /usr/local/go/bin/go /bin
 ```bash
 docker stop istio-dev
 docker rm istio-dev
-make clean-dev-shell BUILD_WITH_CONTAINER=0
 ```

--- a/docker/istio-dev/README.md
+++ b/docker/istio-dev/README.md
@@ -74,9 +74,7 @@ Check that you can access the cluster:
 kubectl get nodes
 ```
 
-
 To build istio and unit tests in docker container
-
 
 ```bash
 cd ~/go/src/istio.io/istio
@@ -94,11 +92,10 @@ For istio unit tests
 sudo path=$PATH make BUILD_WITH_CONTAINER=0 test
 ```
 
-
 some times when we want to rebuild it, you may find that istio cannot find the go path,
 one simple approach to solve it is to add go binary file to system bin/
 
-```
+```bash
 cp /usr/local/go/bin/go /bin
 ```
 

--- a/docker/istio-dev/README.md
+++ b/docker/istio-dev/README.md
@@ -96,4 +96,5 @@ cp /usr/local/go/bin/go /bin
 ```bash
 docker stop istio-dev
 docker rm istio-dev
+make clean-dev-shell BUILD_WITH_CONTAINER=0
 ```


### PR DESCRIPTION
During configuration, default make command introduce bugs, and here get off `BUILD_WITH_CONTAINER` option is a way to solve it.
Plus I also update the latest version of `kubectl, google-cloud-sdk, git, sudo, vim` which resolved the low level version incompatible problems happened in docker build process