### PR TITLE
Collect istio-proxy CPU and memory usage for perf test

### DIFF
--- a/perf/benchmark/README.md
+++ b/perf/benchmark/README.md
@@ -270,8 +270,7 @@ Once `runner.py` has completed, extract the results from Fortio and Prometheus.
 1. Run `fortio.py`:
 
     ```bash
-    python ./runner/fortio.py $FORTIO_CLIENT_URL --prometheus=$PROMETHEUS_URL --csv StartTime,ActualDuration,Labels,NumThreads,ActualQPS,p50,p90,p99,cpu_mili_avg_telemetry_mixer,cpu_mili_max_telemetry_mixer,mem_MB_max_telemetry_mixer,cpu_mili_avg_fortioserver_deployment_proxy,cpu_mili_max_fortioserver_deployment_proxy,mem_MB_max_fortioserver_deployment_proxy,cpu_mili_avg_ingressgateway_proxy,cpu_mili_max_ingressgateway_proxy,mem_MB_max_ingressgateway_proxy
-    ```
+    python ./runner/fortio.py $FORTIO_CLIENT_URL --prometheus=$PROMETHEUS_URL --csv StartTime,ActualDuration,Labels,NumThreads,ActualQPS,p50,p90,p99,cpu_mili_avg_istio_proxy,mem_MB_avg_istio_proxy
 
     This script will generate two output files (one JSON, one CSV), both containing the same result metrics: Queries Per Second (QPS) attained, latency, and CPU/Memory usage.
 

--- a/perf/benchmark/README.md
+++ b/perf/benchmark/README.md
@@ -270,7 +270,7 @@ Once `runner.py` has completed, extract the results from Fortio and Prometheus.
 1. Run `fortio.py`:
 
     ```bash
-    python ./runner/fortio.py $FORTIO_CLIENT_URL --prometheus=$PROMETHEUS_URL --csv StartTime,ActualDuration,Labels,NumThreads,ActualQPS,p50,p90,p99,cpu_mili_avg_istio_proxy,mem_MB_avg_istio_proxy
+    python ./runner/fortio.py $FORTIO_CLIENT_URL --prometheus=$PROMETHEUS_URL --csv StartTime,ActualDuration,Labels,NumThreads,ActualQPS,p50,p90,p99,cpu_mili_avg_istio_proxy,mem_Mi_avg_istio_proxy
 
     This script will generate two output files (one JSON, one CSV), both containing the same result metrics: Queries Per Second (QPS) attained, latency, and CPU/Memory usage.
 

--- a/perf/benchmark/run_benchmark_job.sh
+++ b/perf/benchmark/run_benchmark_job.sh
@@ -157,9 +157,7 @@ function collect_metrics() {
   # shellcheck disable=SC2155
   export CSV_OUTPUT="$(mktemp /tmp/benchmark_XXXX.csv)"
   pipenv run python3 fortio.py ${FORTIO_CLIENT_URL} --csv_output="$CSV_OUTPUT" --prometheus=${PROMETHEUS_URL} \
-   --csv StartTime,ActualDuration,Labels,NumThreads,ActualQPS,p50,p90,p99,cpu_mili_avg_telemetry_mixer,cpu_mili_max_telemetry_mixer,\
-mem_MB_max_telemetry_mixer,cpu_mili_avg_fortioserver_deployment_proxy,cpu_mili_max_fortioserver_deployment_proxy,\
-mem_MB_max_fortioserver_deployment_proxy,cpu_mili_avg_ingressgateway_proxy,cpu_mili_max_ingressgateway_proxy,mem_MB_max_ingressgateway_proxy
+   --csv StartTime,ActualDuration,Labels,NumThreads,ActualQPS,p50,p90,p99,cpu_mili_avg_istio_proxy,mem_MB_avg_istio_proxy
 
   gsutil -q cp "${CSV_OUTPUT}" "gs://${GCS_BUCKET}/${OUTPUT_DIR}/benchmark.csv"
 }

--- a/perf/benchmark/runner/fortio.py
+++ b/perf/benchmark/runner/fortio.py
@@ -112,7 +112,7 @@ METRICS_END_SKIP_DURATION = 30
 METRICS_SUMMARY_DURATION = 180
 
 
-def sync_fortio(url, table, selector=None, promUrl="http://localhost:9090", csv=None, csv_output=""):
+def sync_fortio(url, table, selector=None, promUrl="", csv=None, csv_output=""):
     listurl = url + "/fortio/data/"
     listdata = requests.Response()
     try:
@@ -129,7 +129,6 @@ def sync_fortio(url, table, selector=None, promUrl="http://localhost:9090", csv=
     dataurl = url + "/data/"
     data = []
     for fl in convert_data_to_list(listdata.text):
-        print("+++++++++++")
         gd = fetch(dataurl + fl)
         if gd is None:
             continue
@@ -142,7 +141,6 @@ def sync_fortio(url, table, selector=None, promUrl="http://localhost:9090", csv=
                 continue
 
         if promUrl:
-            print("=================")
             sd = datetime.strptime(st[:19], "%Y-%m-%dT%H:%M:%S")
             print("Fetching prometheus metrics for", sd, gd["Labels"])
             if gd['errorPercent'] > 10:
@@ -239,7 +237,7 @@ def get_parser():
         "--csv",
         help="columns in the csv file",
         default="StartTime,ActualDuration,Labels,NumThreads,ActualQPS,p50,p90,p99,"
-                "cpu_mili_avg_istio_proxy,mem_MB_avg_istio_proxy")
+                "cpu_mili_avg_istio_proxy,mem_Mi_avg_istio_proxy")
     parser.add_argument(
         "--csv_output",
         help="output path of csv file")

--- a/perf/benchmark/runner/fortio.py
+++ b/perf/benchmark/runner/fortio.py
@@ -112,7 +112,7 @@ METRICS_END_SKIP_DURATION = 30
 METRICS_SUMMARY_DURATION = 180
 
 
-def sync_fortio(url, table, selector=None, promUrl="", csv=None, csv_output=""):
+def sync_fortio(url, table, selector=None, promUrl="http://localhost:9090", csv=None, csv_output=""):
     listurl = url + "/fortio/data/"
     listdata = requests.Response()
     try:
@@ -129,6 +129,7 @@ def sync_fortio(url, table, selector=None, promUrl="", csv=None, csv_output=""):
     dataurl = url + "/data/"
     data = []
     for fl in convert_data_to_list(listdata.text):
+        print("+++++++++++")
         gd = fetch(dataurl + fl)
         if gd is None:
             continue
@@ -141,6 +142,7 @@ def sync_fortio(url, table, selector=None, promUrl="", csv=None, csv_output=""):
                 continue
 
         if promUrl:
+            print("=================")
             sd = datetime.strptime(st[:19], "%Y-%m-%dT%H:%M:%S")
             print("Fetching prometheus metrics for", sd, gd["Labels"])
             if gd['errorPercent'] > 10:
@@ -236,10 +238,8 @@ def get_parser():
     parser.add_argument(
         "--csv",
         help="columns in the csv file",
-        default="StartTime,ActualDuration,Labels,NumThreads,ActualQPS,p50,p90,p99,cpu_mili_avg_telemetry_mixer,"
-                "cpu_mili_max_telemetry_mixer,mem_MB_max_telemetry_mixer,cpu_mili_avg_fortioserver_deployment_proxy,"
-                "cpu_mili_max_fortioserver_deployment_proxy,mem_MB_max_fortioserver_deployment_proxy,cpu_mili_avg_"
-                "ingressgateway_proxy,cpu_mili_max_ingressgateway_proxy,mem_MB_max_ingressgateway_proxy")
+        default="StartTime,ActualDuration,Labels,NumThreads,ActualQPS,p50,p90,p99,"
+                "cpu_mili_avg_istio_proxy,mem_MB_avg_istio_proxy")
     parser.add_argument(
         "--csv_output",
         help="output path of csv file")

--- a/perf/benchmark/runner/fortio.py
+++ b/perf/benchmark/runner/fortio.py
@@ -156,7 +156,7 @@ def sync_fortio(url, table, selector=None, promUrl="", csv=None, csv_output=""):
             duration = min(gd['ActualDuration'] - min_duration,
                            METRICS_SUMMARY_DURATION)
             p = prom.Prom(promUrl, duration, start=prom_start)
-            prom_metrics = p.fetch_cpu_and_mem()
+            prom_metrics = p.fetch_istio_proxy_cpu_and_mem()
             if not prom_metrics:
                 print("... Not found")
                 continue

--- a/perf/benchmark/runner/prom.py
+++ b/perf/benchmark/runner/prom.py
@@ -96,6 +96,13 @@ class Prom:
             metric_by_deployment_by_container,
             to_mega_bytes)
 
+    def fetch_istio_proxy_cpu_and_mem(self):
+        out = flatten(self.fetch_istio_proxy_cpu_usage(),
+                      "cpu_mili", aggregate=self.aggregate)
+        out.update(flatten(self.fetch_istio_proxy_memory_usage(),
+                           "mem_MB", aggregate=self.aggregate))
+        return out
+
     def fetch_cpu_by_container(self):
         return self.fetch(
             'irate(container_cpu_usage_seconds_total{job="kubernetes-cadvisor",container_name=~"mixer|policy|discovery|istio-proxy|captured|uncaptured"}[1m])',

--- a/perf/benchmark/runner/prom.py
+++ b/perf/benchmark/runner/prom.py
@@ -64,7 +64,7 @@ class Prom:
             self.headers["Host"] = host
         self.aggregate = aggregate
 
-    def fetch(self, query, groupby=None, xform=None):
+    def query_prom(self, query):
         resp = requests.get(self.url + "/api/v1/query_range", {
             "query": query,
             "start": self.start,
@@ -76,6 +76,12 @@ class Prom:
             raise Exception(str(resp.text))
 
         data = resp.json()
+        print("=============")
+        print(data)
+        return data
+
+    def fetch(self, query, groupby=None, xform=None):
+        data = self.query_prom(query)
         return compute_min_max_avg(
             data,
             groupby=groupby,
@@ -83,6 +89,7 @@ class Prom:
             aggregate=self.aggregate)
 
     def fetch_istio_proxy_cpu_usage(self):
+        print("cpu==============")
         return self.fetch(
             'sum(rate(container_cpu_usage_seconds_total{job="kubernetes-cadvisor",container_name="istio-proxy"}[1m])) '
             'by (container_name)',
@@ -90,6 +97,7 @@ class Prom:
             to_mili_cpus)
 
     def fetch_istio_proxy_memory_usage(self):
+        print("mem===============")
         return self.fetch(
             'sum(rate(container_memory_usage_bytes{job = "kubernetes-cadvisor", container_name = "istio-proxy"}[1m])) '
             'by(container_name)',

--- a/perf/benchmark/runner/prom.py
+++ b/perf/benchmark/runner/prom.py
@@ -39,7 +39,6 @@ if os.environ.get("DEBUG", "0") != "0":
 
 class Prom:
     # url: base url for prometheus
-    #
     def __init__(
             self,
             url,
@@ -64,24 +63,37 @@ class Prom:
             self.headers["Host"] = host
         self.aggregate = aggregate
 
-    def query_prom(self, query):
+    def fetch_by_query(self, query):
         resp = requests.get(self.url + "/api/v1/query_range", {
             "query": query,
             "start": self.start,
             "end": self.end,
-            "step": "15"
+            "step": 15
         }, headers=self.headers)
 
         if not resp.ok:
-            raise Exception(str(resp.text))
+            raise Exception(str(resp))
 
-        data = resp.json()
-        print("=============")
-        print(data)
-        return data
+        return resp.json()
+
+    # We query from start_time to end_time and make 15s as the time interval to note down a data point
+    # The function is to calculate the average of all the data points we get
+    def get_average_within_query_time_range(self, data, resource_type):
+        if data["data"]["result"]:
+            data_points_list = data["data"]["result"][0]["values"]
+            data_sum = 0
+            for data_point in data_points_list:
+                data_sum += float(data_point[1])
+            data_avg = float(data_sum / len(data_points_list))
+            print(data_avg)
+            if resource_type == "cpu":
+                return to_mili_cpus(data_avg)
+            else:
+                return to_mega_bytes(data_avg)
+        return -1
 
     def fetch(self, query, groupby=None, xform=None):
-        data = self.query_prom(query)
+        data = self.fetch_by_query(query)
         return compute_min_max_avg(
             data,
             groupby=groupby,
@@ -89,26 +101,27 @@ class Prom:
             aggregate=self.aggregate)
 
     def fetch_istio_proxy_cpu_usage(self):
-        print("cpu==============")
-        return self.fetch(
-            'sum(rate(container_cpu_usage_seconds_total{job="kubernetes-cadvisor",container_name="istio-proxy"}[1m])) '
-            'by (container_name)',
-            metric_by_deployment_by_container,
-            to_mili_cpus)
+        cpu_query = 'sum(rate(container_cpu_usage_seconds_total{job="kubernetes-cadvisor",container_name="istio-proxy"}[1m])) by (container_name)'
+        data = self.fetch_by_query(cpu_query)
+        avg_cpu = self.get_average_within_query_time_range(data, "cpu")
+        if avg_cpu == -1:
+            return []
+        return avg_cpu
 
     def fetch_istio_proxy_memory_usage(self):
-        print("mem===============")
-        return self.fetch(
-            'sum(rate(container_memory_usage_bytes{job = "kubernetes-cadvisor", container_name = "istio-proxy"}[1m])) '
-            'by(container_name)',
-            metric_by_deployment_by_container,
-            to_mega_bytes)
+        mem_query = 'container_memory_usage_bytes{job = "kubernetes-cadvisor", container_name="istio-proxy"}'
+        data = self.fetch_by_query(mem_query)
+        print(data)
+        avg_mem = self.get_average_within_query_time_range(data, "mem")
+        print(avg_mem)
+        if avg_mem == -1:
+            return []
+        return avg_mem
 
     def fetch_istio_proxy_cpu_and_mem(self):
-        out = flatten(self.fetch_istio_proxy_cpu_usage(),
-                      "cpu_mili", aggregate=self.aggregate)
-        out.update(flatten(self.fetch_istio_proxy_memory_usage(),
-                           "mem_MB", aggregate=self.aggregate))
+        out = {}
+        out["cpu_mili_avg_istio_proxy"] = self.fetch_istio_proxy_cpu_usage()
+        out["mem_Mi_avg_istio_proxy"] = self.fetch_istio_proxy_memory_usage()
         return out
 
     def fetch_cpu_by_container(self):
@@ -127,21 +140,8 @@ class Prom:
         out = flatten(self.fetch_cpu_by_container(),
                       "cpu_mili", aggregate=self.aggregate)
         out.update(flatten(self.fetch_memory_by_container(),
-                           "mem_MB", aggregate=self.aggregate))
+                           "mem_Mi", aggregate=self.aggregate))
         return out
-
-    def fetch_by_query(self, query):
-        resp = requests.get(self.url + "/api/v1/query_range", {
-            "query": query,
-            "start": self.start,
-            "end": self.end,
-            "step": str(self.nseconds)
-        }, headers=self.headers)
-
-        if not resp.ok:
-            raise Exception(str(resp))
-
-        return resp.json()
 
     def fetch_num_requests_by_response_code(self, code):
         data = self.fetch_by_query(
@@ -349,18 +349,17 @@ def flatten(data, metric, aggregate):
             res[metric + "_max_" + grp] = summary[2]
         else:
             res[metric + '_' + grp] = summary
-
     return res
 
 
 # convert float bytes to in megabytes
-def to_mega_bytes(m):
-    return int(m / (1024 * 1024))
+def to_mega_bytes(mem):
+    return float(mem / (1024 * 1024))
 
 
 # convert float cpus to int mili cpus
-def to_mili_cpus(c):
-    return int(c * 1000.0)
+def to_mili_cpus(cpu):
+    return float(cpu * 1000.0)
 
 
 DEPL_MAP = {

--- a/perf/benchmark/runner/prom.py
+++ b/perf/benchmark/runner/prom.py
@@ -82,6 +82,20 @@ class Prom:
             xform=xform,
             aggregate=self.aggregate)
 
+    def fetch_istio_proxy_cpu_usage(self):
+        return self.fetch(
+            'sum(rate(container_cpu_usage_seconds_total{job="kubernetes-cadvisor",container_name="istio-proxy"}[1m])) '
+            'by (container_name)',
+            metric_by_deployment_by_container,
+            to_mili_cpus)
+
+    def fetch_istio_proxy_memory_usage(self):
+        return self.fetch(
+            'sum(rate(container_memory_usage_bytes{job = "kubernetes-cadvisor", container_name = "istio-proxy"}[1m])) '
+            'by(container_name)',
+            metric_by_deployment_by_container,
+            to_mega_bytes)
+
     def fetch_cpu_by_container(self):
         return self.fetch(
             'irate(container_cpu_usage_seconds_total{job="kubernetes-cadvisor",container_name=~"mixer|policy|discovery|istio-proxy|captured|uncaptured"}[1m])',
@@ -323,15 +337,13 @@ def flatten(data, metric, aggregate):
 
     return res
 
+
 # convert float bytes to in megabytes
-
-
 def to_mega_bytes(m):
     return int(m / (1024 * 1024))
 
+
 # convert float cpus to int mili cpus
-
-
 def to_mili_cpus(c):
     return int(c * 1000.0)
 
@@ -341,9 +353,8 @@ DEPL_MAP = {
     "fortioclient": "fortio_deployment"
 }
 
+
 # returns deployment_name/container_name
-
-
 def metric_by_deployment_by_container(metric):
     depl = metric_by_deployment(metric)
     if depl is None:
@@ -363,14 +374,12 @@ Watched_Deployments = set(["istio-pilot",
                            "fortioclient",
                            "istio-ingressgateway"])
 
+
 # returns deployment_name
-
-
 def metric_by_deployment(metric):
     depl = metric['pod_name'].rsplit('-', 2)[0]
     if depl not in Watched_Deployments:
         return None
-
     return depl
 
 


### PR DESCRIPTION
https://github.com/istio/istio/issues/20227

Prometheus scraping time for perf test: 
Each test duration is 240s, and min_duration=92s (METRICS_START_SKIP_DURATION + METRICS_END_SKIP_DURATION). The start and end prometheus query time is among (240-92)s

Here, I'm querying for:
Say for CPU: 
'sum(rate(container_cpu_usage_seconds_total{job="kubernetes-cadvisor",container_name="istio-proxy"}[1m])) by (container_name)'

get the average CPU usage of istio-proxy within 1 min, and accumulate by container_name.

Similar for memory.