### PR TITLE
Remove enable_perf record

### DIFF
--- a/perf/benchmark/configs/trialrun.yaml
+++ b/perf/benchmark/configs/trialrun.yaml
@@ -8,7 +8,7 @@ metrics:
   - p50
   - p90
   - p99
-perf_record: false
+perf_record: true
 run_bothsidecar: true
 run_serversidecar: false
 run_clientsidecar: false

--- a/perf/benchmark/run_benchmark_job.sh
+++ b/perf/benchmark/run_benchmark_job.sh
@@ -153,16 +153,6 @@ trap exit_handling EXIT
 
 # Step 8: run Istio performance test
 # Helper functions
-function enable_perf_record() {
-  nodes=$(kubectl get nodes -o=jsonpath='{.items[*].metadata.name}')
-
-  for node in $nodes
-  do
-    gcloud compute ssh --command "sudo sysctl kernel.perf_event_paranoid=-1;sudo sysctl kernel.kptr_restrict=0;exit" \
-    --zone us-central1-f bootstrap@"$node"
-  done
-}
-
 function collect_flame_graph() {
     FLAME_OUTPUT_DIR="${WD}/flame/flameoutput/"
     gsutil -q cp -r "${FLAME_OUTPUT_DIR}" "gs://${GCS_BUCKET}/${OUTPUT_DIR}/flamegraphs"
@@ -236,8 +226,6 @@ echo "Start to run perf benchmark test, all collected data will be dumped to GCS
 CONFIG_DIR="${WD}/configs/istio"
 # Read through perf test configuration file to determine which group of test configuration to run or not run
 read_perf_test_conf "${WD}/configs/run_perf_test.conf"
-
-#enable_perf_record
 
 for dir in "${CONFIG_DIR}"/*; do
     # Get the last directory name after splitting dir path by '/', which is the configuration dir name

--- a/perf/benchmark/run_benchmark_job.sh
+++ b/perf/benchmark/run_benchmark_job.sh
@@ -237,7 +237,7 @@ CONFIG_DIR="${WD}/configs/istio"
 # Read through perf test configuration file to determine which group of test configuration to run or not run
 read_perf_test_conf "${WD}/configs/run_perf_test.conf"
 
-enable_perf_record
+#enable_perf_record
 
 for dir in "${CONFIG_DIR}"/*; do
     # Get the last directory name after splitting dir path by '/', which is the configuration dir name

--- a/perf/benchmark/run_benchmark_job.sh
+++ b/perf/benchmark/run_benchmark_job.sh
@@ -266,6 +266,7 @@ for dir in "${CONFIG_DIR}"/*; do
     # TRIALRUN as a pre-submit check, only run agaist the first set of enabled perf run in the perf_conf file
     if [[ "${TRIALRUN}" == "True" ]]; then
        run_benchmark_test "${WD}/configs/trialrun.yaml"
+       collect_flame_graph
        break
     fi
 


### PR DESCRIPTION
As we got this error: https://storage.googleapis.com/istio-prow/logs/daily-fortio-performance-benchmark/37/build-log.txt

and I've tested on my local for my created GKE cluster, I do not need this step for generating flame graph. Let's remove it for now to see if things can go through, since I want to check another fix for nighthawk.