### PR TITLE
Fix GCS bucket copy path for flamegraphs

### DIFF
--- a/perf/benchmark/run_benchmark_job.sh
+++ b/perf/benchmark/run_benchmark_job.sh
@@ -154,8 +154,8 @@ trap exit_handling EXIT
 # Step 8: run Istio performance test
 # Helper functions
 function collect_flame_graph() {
-    FLAME_OUTPUT_DIR="${WD}/flame/flameoutput/"
-    gsutil -q cp -r "${FLAME_OUTPUT_DIR}" "gs://${GCS_BUCKET}/${OUTPUT_DIR}/flamegraphs"
+    FLAME_OUTPUT_DIR="${WD}/flame/flameoutput"
+    gsutil -q cp -r "${FLAME_OUTPUT_DIR}/*.svg" "gs://${GCS_BUCKET}/${OUTPUT_DIR}/flamegraphs"
 }
 
 function collect_metrics() {


### PR DESCRIPTION
Current path is:
gcs_bucket/flamegraphs/"some svg files"
and gcs_bucket/flamegraphs/flameoutput/"all of the svg files"
this is not as expected.

We should save all generated svg files under gcs_bucket/flamegraphs
