### PR TITLE
Fix dashboard static file serving issue

### DIFF
--- a/perf_dashboard/docker-entrypoint.sh
+++ b/perf_dashboard/docker-entrypoint.sh
@@ -15,4 +15,5 @@
 
 python manage.py makemigrations
 python manage.py migrate
+python manager.py collectstatic
 python manage.py runserver 0.0.0.0:8000

--- a/perf_dashboard/perf_dashboard/settings.py
+++ b/perf_dashboard/perf_dashboard/settings.py
@@ -56,6 +56,7 @@ INSTALLED_APPS = [
     'django.contrib.contenttypes',
     'django.contrib.sessions',
     'django.contrib.messages',
+    'whitenoise.runserver_nostatic',
     'django.contrib.staticfiles',
     'benchmarks',
     'analyze_perf_issues',
@@ -67,6 +68,7 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
+    'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
@@ -142,11 +144,11 @@ USE_TZ = True
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/3.0/howto/static-files/
+STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
+
 STATIC_URL = '/static/'
 
-STATICFILES_DIRS = [
-    os.path.join(BASE_DIR, 'static'),
-]
+STATICFILES_DIRS = (os.path.join(BASE_DIR, 'static'),)
 
 MEDIA_URL = '/media/'
 MEDIA_ROOT = os.path.join(BASE_DIR, 'media')

--- a/perf_dashboard/requirements.txt
+++ b/perf_dashboard/requirements.txt
@@ -2,3 +2,4 @@ Django==2.2.13
 beautifulsoup4==4.8.1
 pandas==0.25.3
 wget==3.2
+whitenoise==3.3.1


### PR DESCRIPTION
When Debug mode set to be False in production, the static file rendering get 404 error.