### PR TITLE
Collect istio-proxy CPU and memory usage by pod name

### DIFF
--- a/perf/benchmark/README.md
+++ b/perf/benchmark/README.md
@@ -261,7 +261,7 @@ Once `runner.py` has completed, extract the results from Fortio and Prometheus.
 1. Run `fortio.py`:
 
     ```bash
-    python ./runner/fortio.py $FORTIO_CLIENT_URL --prometheus=$PROMETHEUS_URL --csv StartTime,ActualDuration,Labels,NumThreads,ActualQPS,p50,p90,p99,cpu_mili_avg_istio_proxy,mem_Mi_avg_istio_proxy
+    python ./runner/fortio.py $FORTIO_CLIENT_URL --prometheus=$PROMETHEUS_URL --csv StartTime,ActualDuration,Labels,NumThreads,ActualQPS,p50,p90,p99,cpu_mili_avg_istio_proxy_fortioclient,cpu_mili_avg_istio_proxy_fortioserver,cpu_mili_avg_istio_proxy_istio-ingressgateway,mem_Mi_avg_istio_proxy_fortioclient,mem_Mi_avg_istio_proxy_fortioserver,mem_Mi_avg_istio_proxy_istio-ingressgateway
     ```
 
     This script will generate two output files (one JSON, one CSV), both containing the same result metrics: Queries Per Second (QPS) attained, latency, and CPU/Memory usage.

--- a/perf/benchmark/run_benchmark_job.sh
+++ b/perf/benchmark/run_benchmark_job.sh
@@ -162,7 +162,9 @@ function collect_metrics() {
   # shellcheck disable=SC2155
   export CSV_OUTPUT="$(mktemp /tmp/benchmark_XXXX.csv)"
   pipenv run python3 fortio.py ${FORTIO_CLIENT_URL} --csv_output="$CSV_OUTPUT" --prometheus=${PROMETHEUS_URL} \
-   --csv StartTime,ActualDuration,Labels,NumThreads,ActualQPS,p50,p90,p99,cpu_mili_avg_istio_proxy,mem_Mi_avg_istio_proxy
+   --csv StartTime,ActualDuration,Labels,NumThreads,ActualQPS,p50,p90,p99,cpu_mili_avg_istio_proxy_fortioclient, \
+   cpu_mili_avg_istio_proxy_fortioserver,cpu_mili_avg_istio_proxy_istio-ingressgateway,\
+   mem_Mi_avg_istio_proxy_fortioclient,mem_Mi_avg_istio_proxy_fortioserver,mem_Mi_avg_istio_proxy_istio-ingressgateway
 
   gsutil -q cp "${CSV_OUTPUT}" "gs://${GCS_BUCKET}/${OUTPUT_DIR}/benchmark.csv"
 }

--- a/perf/benchmark/runner/fortio.py
+++ b/perf/benchmark/runner/fortio.py
@@ -240,7 +240,9 @@ def get_parser():
         "--csv",
         help="columns in the csv file",
         default="StartTime,ActualDuration,Labels,NumThreads,ActualQPS,p50,p90,p99,"
-                "cpu_mili_avg_istio_proxy,mem_Mi_avg_istio_proxy")
+                "cpu_mili_avg_istio_proxy_fortioclient,cpu_mili_avg_istio_proxy_fortioserver,"
+                "cpu_mili_avg_istio_proxy_istio-ingressgateway,mem_Mi_avg_istio_proxy_fortioclient,"
+                "mem_Mi_avg_istio_proxy_fortioserver,mem_Mi_avg_istio_proxy_istio-ingressgateway")
     parser.add_argument(
         "--csv_output",
         help="output path of csv file")

--- a/perf/benchmark/runner/prom.py
+++ b/perf/benchmark/runner/prom.py
@@ -37,6 +37,32 @@ if os.environ.get("DEBUG", "0") != "0":
     req_log.propagate = True
 
 
+def calculate_average(item, resource_type):
+    data_points_list = item["values"]
+    data_sum = 0
+    for data_point in data_points_list:
+        data_sum += float(data_point[1])
+    data_avg = float(data_sum / len(data_points_list))
+    if resource_type == "cpu":
+        return to_mili_cpus(data_avg)
+    else:
+        return to_mega_bytes(data_avg)
+
+
+def get_average_within_query_time_range(data, resource_type):
+    val_by_pod_name = {"fortioclient": 0, "fortioserver": 0, "istio-ingressgateway": 0}
+    if data["data"]["result"]:
+        for item in data["data"]["result"]:
+            pod_name = item["metric"]["pod_name"]
+            if "fortioclient" in pod_name:
+                val_by_pod_name["fortioclient"] = calculate_average(item, resource_type)
+            if "fortioserver" in pod_name:
+                val_by_pod_name["fortioserver"] = calculate_average(item, resource_type)
+            if "istio-ingressgateway" in pod_name:
+                val_by_pod_name["istio-ingressgateway"] = calculate_average(item, resource_type)
+    return val_by_pod_name
+
+
 class Prom:
     # url: base url for prometheus
     def __init__(
@@ -78,30 +104,6 @@ class Prom:
 
     # We query from start_time to end_time and make 15s as the time interval to note down a data point
     # The function is to calculate the average of all the data points we get
-    def get_average_within_query_time_range(self, data, resource_type):
-        val_by_pod_name = {"fortioclient": 0, "fortioserver": 0, "istio-ingressgateway": 0}
-        if data["data"]["result"]:
-            for item in data["data"]["result"]:
-                pod_name = item["metric"]["pod_name"]
-                if "fortioclient" in pod_name:
-                    val_by_pod_name["fortioclient"] = self.calculate_average(item, resource_type)
-                if "fortioserver" in pod_name:
-                    val_by_pod_name["fortioserver"] = self.calculate_average(item, resource_type)
-                if "istio-ingressgateway" in pod_name:
-                    val_by_pod_name["istio-ingressgateway"] = self.calculate_average(item, resource_type)
-        return val_by_pod_name
-
-
-    def calculate_average(self, item, resource_type):
-        data_points_list = item["values"]
-        data_sum = 0
-        for data_point in data_points_list:
-            data_sum += float(data_point[1])
-        data_avg = float(data_sum / len(data_points_list))
-        if resource_type == "cpu":
-            return to_mili_cpus(data_avg)
-        else:
-            return to_mega_bytes(data_avg)
 
     def fetch(self, query, groupby=None, xform=None):
         data = self.fetch_by_query(query)
@@ -114,13 +116,13 @@ class Prom:
     def fetch_istio_proxy_cpu_usage_by_pod_name(self):
         cpu_query = 'sum(rate(container_cpu_usage_seconds_total{job="kubernetes-cadvisor",container_name="istio-proxy"}[1m])) by (pod_name)'
         data = self.fetch_by_query(cpu_query)
-        avg_cpu_dict = self.get_average_within_query_time_range(data, "cpu")
+        avg_cpu_dict = get_average_within_query_time_range(data, "cpu")
         return avg_cpu_dict
 
     def fetch_istio_proxy_memory_usage_by_pod_name(self):
         mem_query = 'container_memory_usage_bytes{job = "kubernetes-cadvisor", container_name="istio-proxy"}'
         data = self.fetch_by_query(mem_query)
-        avg_mem_dict = self.get_average_within_query_time_range(data, "mem")
+        avg_mem_dict = get_average_within_query_time_range(data, "mem")
         return avg_mem_dict
 
     def fetch_istio_proxy_cpu_and_mem(self):


### PR DESCRIPTION
https://github.com/istio/istio/issues/20227

Collect proxy cpu and mem usage by pod name: fortioclient, fortioserver and ingressgateway. Here is a sample data:
<img width="1560" alt="Screen Shot 2020-07-01 at 3 00 03 AM" src="https://user-images.githubusercontent.com/29208297/86278238-e8933b00-bb8c-11ea-8e6b-0b4abea8362e.png">
and I've verified this number with prometheus, which is correct.