### PR TITLE
Add debugging info for fortio json parsing issue

### DIFF
--- a/perf/benchmark/runner/fortio.py
+++ b/perf/benchmark/runner/fortio.py
@@ -139,8 +139,10 @@ def sync_fortio(url, table, selector=None, promUrl="", csv=None, csv_output="", 
 
     data = []
     for filename in os.listdir(temp_dir_path):
+        print(filename)
         with open(os.path.join(temp_dir_path, filename), 'r') as f:
-            data_dict = json.load(f)
+            print(f.read())
+            data_dict = json.load(f, strict=False)
             gd = convert_data(data_dict)
             if gd is None:
                 continue

--- a/perf/benchmark/runner/fortio.py
+++ b/perf/benchmark/runner/fortio.py
@@ -141,8 +141,21 @@ def sync_fortio(url, table, selector=None, promUrl="", csv=None, csv_output="", 
     for filename in os.listdir(temp_dir_path):
         print(filename)
         with open(os.path.join(temp_dir_path, filename), 'r') as f:
-            print(f.read())
-            data_dict = json.load(f, strict=False)
+            try:
+                data_dict = json.load(f, strict=False)
+                one_char = f.read(1)
+                if not one_char:
+                    print("json file is not empty")
+            except json.JSONDecodeError as e:
+                print(f.read())
+                while True:
+                    line = f.readline()
+                    print(line)
+                    if "" == line:
+                        print("file finished!")
+                        break
+                print(e)
+
             gd = convert_data(data_dict)
             if gd is None:
                 continue


### PR DESCRIPTION
Local run got no problems, but pipeline has constantly thrown json decoding error, adding this debugging info to get more insights of this issue.

If cannot reach to service, it will also throw exceptions, but I've verified both from local and the pipeline logs, it should not be that issue. Since the request response is 200.

Here is the full error log for master branch:
```
Traceback (most recent call last):
  File "fortio.py", line 270, in <module>
    sys.exit(main(sys.argv[1:]))
  File "fortio.py", line 236, in main
    args.csv_output)
  File "fortio.py", line 143, in sync_fortio
    data_dict = json.load(f)
  File "/usr/lib/python3.6/json/__init__.py", line 299, in load
    parse_constant=parse_constant, object_pairs_hook=object_pairs_hook, **kw)
  File "/usr/lib/python3.6/json/__init__.py", line 354, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python3.6/json/decoder.py", line 339, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python3.6/json/decoder.py", line 357, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```