### PR TITLE
fix(annotations_prep): correct resources list in template

### DIFF
--- a/cmd/annotations_prep/main.go
+++ b/cmd/annotations_prep/main.go
@@ -78,15 +78,19 @@ type Instance struct {
 }
 
 var (
-	{{ range .Annotations }}
-		{{ .VariableName }} = Instance {
-          Name: "{{ .Name }}",
-          Description: {{ wordWrap .Description 24 }},
-          Hidden: {{ .Hidden }},
-          Deprecated: {{ .Deprecated }},
-		  Resources: []ResourceTypes{ {{ range .Resources }}{{ . }}{{ end }}, },
-        }
-	{{ end }}
+{{ range .Annotations }}
+	{{ .VariableName }} = Instance {
+		Name: "{{ .Name }}",
+		Description: {{ wordWrap .Description 24 }},
+		Hidden: {{ .Hidden }},
+		Deprecated: {{ .Deprecated }},
+		Resources: []ResourceTypes{
+			{{- range .Resources }}
+			{{ . }},
+			{{- end }}
+		},
+	}
+{{ end }}
 )
 
 func AllResourceAnnotations() []*Instance {


### PR DESCRIPTION
Signed-off-by: knight42 <anonymousknight96@gmail.com>

Part of https://github.com/istio/api/issues/1360

The root cause of this problem is that we forgot to append a trailing comma after the resource in template.