### PR TITLE
Add /home/.cache as a volume mount in the image

### DIFF
--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -467,6 +467,7 @@ RUN mkdir -p /go && \
     mkdir -p /config/.config/gcloud && \
     mkdir -p /config/.kube && \
     mkdir -p /config-copy && \
+    mkdir -p /home/.cache && \
     mkdir -p /home/.helm && \
     mkdir -p /home/.gsutil
 
@@ -481,6 +482,7 @@ RUN chmod 777 /go && \
     chmod 777 /config/.docker && \
     chmod 777 /config/.config/gcloud && \
     chmod 777 /config/.kube && \
+    chmod 777 /home/.cache && \
     chmod 777 /home/.helm && \
     chmod 777 /home/.gsutil
 
@@ -652,6 +654,7 @@ RUN mkdir -p /go && \
     mkdir -p /config/.config/gcloud && \
     mkdir -p /config/.kube && \
     mkdir -p /config-copy && \
+    mkdir -p /home/.cache && \
     mkdir -p /home/.helm && \
     mkdir -p /home/.gsutil
 
@@ -666,6 +669,7 @@ RUN chmod 777 /go && \
     chmod 777 /config/.docker && \
     chmod 777 /config/.config/gcloud && \
     chmod 777 /config/.kube && \
+    chmod 777 /home/.cache && \
     chmod 777 /home/.helm && \
     chmod 777 /home/.gsutil
 


### PR DESCRIPTION
This doesn't do much for the istio/istio build, although for istio/docker
after an initial build, building from a cached build shows these results:

INFO: Analyzed 175 targets (831 packages loaded, 51099 targets configured).
INFO: Found 175 targets...
INFO: Deleting stale sandbox base /home/.cache/bazel/_bazel_sdake/1e0bb3bee2d09d2e4ad3523530d3b40c/sandbox
INFO: Elapsed time: 19.151s, Critical Path: 5.32s
INFO: Build completed successfully, 4 total actions

Instead of taking 20 minutes.

The build did and does not work properly yet (no files are output) -
however, caching the build is an important step.