### PR TITLE
Remove deprecated controlPlaneSecurityEnabled field in GlobalConfig

### DIFF
--- a/isotope/helm-values.yaml
+++ b/isotope/helm-values.yaml
@@ -1,10 +1,6 @@
 # This is used to generate istio-auth.yaml for automated CI/CD test, using v1/alpha1
 # or v2/alpha3 with 'gradual migration' (using env variable at inject time).
 global:
-  # controlPlaneMtls enabled. Will result in delays starting the pods while secrets are
-  # propagated, not recommended for tests.
-  controlPlaneSecurityEnabled: true
-
   mtls:
     # Default setting for service-to-service mtls. Can be set explicitly using
     # destination rules or service annotations.

--- a/perf/benchmark/values-istio-auth.yaml
+++ b/perf/benchmark/values-istio-auth.yaml
@@ -1,7 +1,7 @@
 # This is used to generate istio-auth.yaml for automated CI/CD test, using v1/alpha1
 # or v2/alpha3 with 'gradual migration' (using env variable at inject time).
 global:
- mtls:
+  mtls:
     # Default setting for service-to-service mtls. Can be set explicitly using
     # destination rules or service annotations.
     enabled: true

--- a/perf/benchmark/values-istio-auth.yaml
+++ b/perf/benchmark/values-istio-auth.yaml
@@ -1,11 +1,7 @@
 # This is used to generate istio-auth.yaml for automated CI/CD test, using v1/alpha1
 # or v2/alpha3 with 'gradual migration' (using env variable at inject time).
 global:
-  # controlPlaneMtls enabled. Will result in delays starting the pods while secrets are
-  # propagated, not recommended for tests.
-  controlPlaneSecurityEnabled: true
-
-  mtls:
+ mtls:
     # Default setting for service-to-service mtls. Can be set explicitly using
     # destination rules or service annotations.
     enabled: true

--- a/perf/istio-install/istioctl_profiles/default-overlay.yaml
+++ b/perf/istio-install/istioctl_profiles/default-overlay.yaml
@@ -77,7 +77,6 @@ spec:
           secretName: istio-ingressgateway-certs
         type: LoadBalancer
     global:
-      controlPlaneSecurityEnabled: false
       meshExpansion:
         enabled: true
         useILB: true

--- a/perf/istio-install/istioctl_profiles/istio-non-sds.yaml
+++ b/perf/istio-install/istioctl_profiles/istio-non-sds.yaml
@@ -7,7 +7,6 @@ spec:
 
   values:
     global:
-      controlPlaneSecurityEnabled: false
       mtls:
         enabled: true
       sds:

--- a/perf/istio-install/istioctl_profiles/multi-citadel-non-sds.yaml
+++ b/perf/istio-install/istioctl_profiles/multi-citadel-non-sds.yaml
@@ -10,7 +10,6 @@ spec:
 
   values:
     global:
-      controlPlaneSecurityEnabled: false
       mtls:
         enabled: true
       sds:

--- a/perf/istio-install/istioctl_profiles/sds-auth.yaml
+++ b/perf/istio-install/istioctl_profiles/sds-auth.yaml
@@ -7,7 +7,6 @@ spec:
 
   values:
     global:
-      controlPlaneSecurityEnabled: false
       # Default is 10s second
       refreshInterval: 1s
       mtls:

--- a/perf/load/values-istio-auth.yaml
+++ b/perf/load/values-istio-auth.yaml
@@ -1,10 +1,6 @@
 # This is used to generate istio-auth.yaml for automated CI/CD test, using v1/alpha1
 # or v2/alpha3 with 'gradual migration' (using env variable at inject time).
 global:
-  # controlPlaneMtls enabled. Will result in delays starting the pods while secrets are
-  # propagated, not recommended for tests.
-  controlPlaneSecurityEnabled: true
-
   mtls:
     # Default setting for service-to-service mtls. Can be set explicitly using
     # destination rules or service annotations.

--- a/upgrade/test_crossgrade.sh
+++ b/upgrade/test_crossgrade.sh
@@ -221,7 +221,7 @@ installIstioAtVersionUsingHelm() {
     writeMsg "helm templating then applying new yaml using version ${2} from ${3}."
     if [[ -n "${AUTH_ENABLE}" ]]; then
         echo "Auth is enabled, generating manifest with auth."
-        auth_opts="--set global.mtls.enabled=true --set global.controlPlaneSecurityEnabled=true "
+        auth_opts="--set global.mtls.enabled=true"
     fi
     release_path="${3}"/install/kubernetes/helm/istio
 


### PR DESCRIPTION
error log:

```
+ /home/prow/go/src/istio.io/tools/perf/istio-install/tmp/istio-1.8-alpha.78fa9a988acdda70785b0dd5b1ea1b30cb89e1bc/bin/istioctl manifest apply --skip-confirmation -d /home/prow/go/src/istio.io/tools/perf/istio-install/tmp/istio-1.8-alpha.78fa9a988acdda70785b0dd5b1ea1b30cb89e1bc/manifests -f istioctl_profiles/default-overlay.yaml
Error: failed to apply manifests: validation errors (use --force to override): 
unknown field "controlPlaneSecurityEnabled" in v1alpha1.GlobalConfig
```