### PR TITLE
Remove deprecated telemetry addon fields

### DIFF
--- a/perf/benchmark/runner/runner.py
+++ b/perf/benchmark/runner/runner.py
@@ -264,8 +264,9 @@ class Fortio:
 
         return fortio_cmd
 
-    def generate_nighthawk_cmd(self, cpus, conn, qps, jitter_uniform, duration, labels):
+    def generate_nighthawk_cmd(self, cpus, conn, qps, duration, labels):
         labels = "nighthawk_" + labels
+        jitter_uniform = float(0.1 * 1 / qps)
         nighthawk_args = [
             "nighthawk_client",
             "--concurrency {cpus}",
@@ -337,8 +338,7 @@ class Fortio:
             # See the comment above, we restrict execution to a single nighthawk worker for
             # now to avoid noise.
             workers = 1
-            jitter_uniform = float(0.1 * 1 / qps)
-            load_gen_cmd = self.generate_nighthawk_cmd(workers, conn, qps, jitter_uniform, duration, labels)
+            load_gen_cmd = self.generate_nighthawk_cmd(workers, conn, qps, duration, labels)
 
         if self.run_baseline:
             perf_label = "baseline_perf"

--- a/perf/istio-install/istioctl_profiles/default-overlay.yaml
+++ b/perf/istio-install/istioctl_profiles/default-overlay.yaml
@@ -95,20 +95,4 @@ spec:
       sds:
         token:
           aud: istio-ca
-    grafana:
-      datasources:
-        datasources.yaml:
-          apiVersion: 1
-          datasources:
-          - access: proxy
-            editable: true
-            isDefault: true
-            jsonData:
-              timeInterval: 5s
-            name: Prometheus
-            orgId: 1
-            type: prometheus
-            url: http://istio-prometheus.istio-prometheus:9090
-      enabled: true
-    tracing:
-      enabled: true
+

--- a/perf/istio-install/setup_istio.sh
+++ b/perf/istio-install/setup_istio.sh
@@ -77,7 +77,7 @@ function download_release() {
 }
 
 function install_istioctl() {
-  release=${1:?release folder}
+  release=${1:?missing release path}
   shift
   "${release}/bin/istioctl" install --skip-confirmation -d "${release}/manifests" "${@}"
 }
@@ -107,8 +107,6 @@ function install_extras() {
   done
   # Redeploy, this time with the Prometheus resource created
   helm template --set domain="${domain}" "${WD}/base" | kubectl apply -f -
-  # Also deploy relevant ServiceMonitors
-  "${release}/bin/istioctl" manifest generate --set profile=empty --set addonComponents.prometheusOperator.enabled=true -d "${release}/manifests" | kubectl apply -f -
   # deploy grafana
   kubectl apply -f "${release}/samples/addons/grafana.yaml" -n istio-system
 }


### PR DESCRIPTION
Fixed errors:
```
home/prow/go/src/istio.io/tools/perf/istio-install/tmp/istio-1.8-alpha.6fb5be6984e53eabcbff3e31af6df93dc902a271/manifests -f istioctl_profiles/default-overlay.yaml
! values.grafana.enabled is deprecated; use the samples/addons/ deployments instead
! values.tracing.enabled is deprecated; use the samples/addons/ deployments instead
```

```
+ kubectl apply -f -
Error: stat /home/prow/go/src/istio.io/tools/perf/istio-install/tmp/istio-1.8-alpha.6fb5be6984e53eabcbff3e31af6df93dc902a271/manifests/charts/addons/prometheusOperator: no such file or directory
error: no objects passed to apply
```