### PR TITLE
Add more flexibility to generate_policies

### DIFF
--- a/perf/benchmark/security/generate_policies/README.md
+++ b/perf/benchmark/security/generate_policies/README.md
@@ -6,11 +6,10 @@ See the [Istio Security](https://istio.io/latest/docs/reference/config/security/
 
 ## Setup
 
-To build and run generate_policies, run the following command:
+To run generate_policies, run the following command:
 
 ```bash
-go build generate_policies.go generate.go
-./generate_polices
+go run generate_policies.go generate.go
 ```
 
 This will by default create an Authorization Policy as follows and print it out to the stdout. This AuthorizationPolicy is specifically made to work with the environment that is created in the setup of [Istio Performance Benchmarking](https://github.com/istio/tools/tree/master/perf/benchmark)
@@ -19,27 +18,15 @@ This will by default create an Authorization Policy as follows and print it out 
 apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
-  name: test_1
+  name: test-1
   namespace: twopods-istio
 spec:
  action: DENY
  rules:
- - when:
-   - key: request.headers[x-token]
-     notValues:
-     - admin
-     - guest
- - to:
-   - operation:
-       methods:
-       - GET
-       - HEAD
-       paths:
-       - /admin
  - from:
    - source:
-       namespaces:
-       - twopods-istio
+       ipBlocks:
+       - 0.0.0.0
 ```
 
 generate_polices allows to customize the generated policies with command line flags:
@@ -47,20 +34,14 @@ generate_polices allows to customize the generated policies with command line fl
 ```bash
 Optional arguments:
   -h, --help
-  -action string         Type of action (default "DENY")
-  -namespace string      Current namespace (default "twopods-istio")
-  -numPolicies int       Number of policies wanted (default 1)
-  -policyType string     The type of security policy (default "AuthorizationPolicy")
-  -to int                Number of To operations wanted (default 1)
-  -when int              Number of when condition wanted (default 1)
-  -from int              Number of From sources wanted (default 1)
-
+  -generate_policy string         List of key value pairs separated by commas.
+                                  Supported options: namespace:string, action:DENY/ALLOW, policyType:AuthorizationPolicy, numPolicies:int, numPaths:int, numValues:int, numSourceIP:int, numNamespaces:int (default "numPolicies:1")
 ```
 
 To create a large policy to an output .yaml file, run the following command:
 
 ```bash
-./generate_polices -to=1000 -when=1000 -from=1000 > largePolicy.yaml
+go run generate_policies.go generate.go -generate_policy="numSourceIP:1000,numPaths:1000,numNamespaces:1000" > largePolicy.yaml
 ```
 
 To apply largePolicy.yaml that was just created to istio use the following command.
@@ -72,15 +53,23 @@ kubectl apply -f largePolicy.yaml
 ## Example 1
 
 ```bash
- ./generate_polices -numPolicies=10 -to=10 -when=2
+go run generate_policies.go generate.go -generate_policy="numPolicies:10,numSourceIP:10,numPaths:2"
 ```
 
-- This creates 10 AuthorizationPolicies which each contains 10 "To" operations, 2 "When" conditions, and 1 "From" sources
+- This creates 10 AuthorizationPolicies which each contains 10 sourceIP's sources, and 2 paths operations
 
 ## Example 2
 
 ```bash
- ./generate_polices -to=100 -when=100 -from=100
+go run generate_policies.go generate.go -generate_policy="numSourceIP:100,numPaths:100,numNamespaces:100"
 ```
 
-- This creates 1 AuthorizationPolicy which each contains 100 "To" operations, 100 "When" conditions, and 100 "From" sources
+- This creates 1 AuthorizationPolicy which contains 100 sourceIP's sources, 100 paths operations, and 100 namespaces sources
+
+## Cleanup
+
+To remove the policies applied navigate to the generate_policies folder and run the following command (updating "largePolicy.yaml" if applied a different .yaml file): 
+
+```bash
+kubectl delete -f largePolicy.yaml
+```

--- a/perf/benchmark/security/generate_policies/README.md
+++ b/perf/benchmark/security/generate_policies/README.md
@@ -68,7 +68,7 @@ go run generate_policies.go generate.go -generate_policy="numSourceIP:100,numPat
 
 ## Cleanup
 
-To remove the policies applied navigate to the generate_policies folder and run the following command (updating "largePolicy.yaml" if applied a different .yaml file): 
+To remove the policies applied navigate to the generate_policies folder and run the following command (updating "largePolicy.yaml" if applied a different .yaml file):
 
 ```bash
 kubectl delete -f largePolicy.yaml

--- a/perf/benchmark/security/generate_policies/generate.go
+++ b/perf/benchmark/security/generate_policies/generate.go
@@ -31,7 +31,7 @@ func (operationGenerator) generate(_ string, ruleMap map[string]int) *authzpb.Ru
 	rule := &authzpb.Rule{}
 	var listOperation []*authzpb.Rule_To
 
-	if numPaths := ruleMap["numPaths"]; numPaths > 0  {
+	if numPaths := ruleMap["numPaths"]; numPaths > 0 {
 		paths := make([]string, numPaths)
 		for i := 0; i < numPaths; i++ {
 			paths[i] = fmt.Sprintf("/Invalid-path-%d", i)

--- a/perf/benchmark/security/generate_policies/generate.go
+++ b/perf/benchmark/security/generate_policies/generate.go
@@ -59,7 +59,7 @@ func (conditionGenerator) generate(action string, ruleMap map[string]int) *authz
 	if numValues > 0 {
 		values := make([]string, numValues)
 		for i := 0; i < numValues; i++ {
-			if i == numValues - 1 && action == "ALLOW" {
+			if i == numValues-1 && action == "ALLOW" {
 				values[i] = "admin"
 			} else {
 				values[i] = "guest"
@@ -86,7 +86,7 @@ func (sourceGenerator) generate(_ string, ruleMap map[string]int) *authzpb.Rule 
 	if numSourceIP > 0 {
 		sourceIPList := make([]string, numSourceIP)
 		for i := 0; i < numSourceIP; i++ {
-			sourceIPList[i] = fmt.Sprintf("0.0.%d.%d", i / 256, i % 256)
+			sourceIPList[i] = fmt.Sprintf("0.0.%d.%d", i/256, i%256)
 		}
 		source := &authzpb.Rule_From{
 			Source: &authzpb.Source{

--- a/perf/benchmark/security/generate_policies/generate.go
+++ b/perf/benchmark/security/generate_policies/generate.go
@@ -31,8 +31,7 @@ func (operationGenerator) generate(_ string, ruleMap map[string]int) *authzpb.Ru
 	rule := &authzpb.Rule{}
 	var listOperation []*authzpb.Rule_To
 
-	numPaths := ruleMap["numPaths"]
-	if numPaths > 0 {
+	if numPaths := ruleMap["numPaths"]; numPaths > 0  {
 		paths := make([]string, numPaths)
 		for i := 0; i < numPaths; i++ {
 			paths[i] = fmt.Sprintf("/Invalid-path-%d", i)
@@ -55,8 +54,7 @@ func (conditionGenerator) generate(action string, ruleMap map[string]int) *authz
 	rule := &authzpb.Rule{}
 	var listCondition []*authzpb.Condition
 
-	numValues := ruleMap["numValues"]
-	if numValues > 0 {
+	if numValues := ruleMap["numValues"]; numValues > 0 {
 		values := make([]string, numValues)
 		for i := 0; i < numValues; i++ {
 			if i == numValues-1 && action == "ALLOW" {
@@ -82,8 +80,7 @@ func (sourceGenerator) generate(_ string, ruleMap map[string]int) *authzpb.Rule 
 	rule := &authzpb.Rule{}
 	var listSource []*authzpb.Rule_From
 
-	numSourceIP := ruleMap["numSourceIP"]
-	if numSourceIP > 0 {
+	if numSourceIP := ruleMap["numSourceIP"]; numSourceIP > 0 {
 		sourceIPList := make([]string, numSourceIP)
 		for i := 0; i < numSourceIP; i++ {
 			sourceIPList[i] = fmt.Sprintf("0.0.%d.%d", i/256, i%256)
@@ -96,8 +93,7 @@ func (sourceGenerator) generate(_ string, ruleMap map[string]int) *authzpb.Rule 
 		listSource = append(listSource, source)
 	}
 
-	numNamepaces := ruleMap["numNamespaces"]
-	if numNamepaces > 0 {
+	if numNamepaces := ruleMap["numNamespaces"]; numNamepaces > 0 {
 		namespaces := make([]string, numNamepaces)
 		for i := 0; i < numNamepaces; i++ {
 			namespaces[i] = fmt.Sprintf("Invalid-namespace-%d", i)

--- a/perf/benchmark/security/generate_policies/generate_policies.go
+++ b/perf/benchmark/security/generate_policies/generate_policies.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/ghodss/yaml"
@@ -31,8 +32,7 @@ import (
 	authzpb "istio.io/api/security/v1beta1"
 )
 
-type ruleOption struct {
-	occurrence int
+type ruleGenerator struct {
 	gen        generator
 }
 
@@ -48,7 +48,7 @@ type MetadataStruct struct {
 }
 
 func ToJSON(msg proto.Message) (string, error) {
-	return ToJSONWithIndent(msg, " ")
+	return ToJSONWithIndent(msg, "")
 }
 
 func ToJSONWithIndent(msg proto.Message, indent string) (string, error) {
@@ -89,21 +89,22 @@ func PolicyToYAML(policy *MyPolicy, spec proto.Message) (string, error) {
 	rulesYaml.WriteString("spec:\n")
 	scanner := bufio.NewScanner(strings.NewReader(authorizationPolicy))
 	for scanner.Scan() {
-		rulesYaml.WriteString(scanner.Text() + "\n")
+		rulesYaml.WriteString(" " + scanner.Text() + "\n")
 	}
 	return string(headerYaml) + rulesYaml.String(), nil
 }
 
-func getOrderedKeySlice(ruleToOccurrences map[string]*ruleOption) *[]string {
+func getOrderedKeySlice(ruleToGenerator map[string]*ruleGenerator) *[]string {
 	var sortedKeys []string
-	for key := range ruleToOccurrences {
+	for key := range ruleToGenerator {
 		sortedKeys = append(sortedKeys, key)
 	}
 	sort.Strings(sortedKeys)
 	return &sortedKeys
 }
 
-func generateAuthorizationPolicy(action string, ruleToOccurrences map[string]*ruleOption, policy *MyPolicy) (string, error) {
+func generateAuthorizationPolicy(action string, ruleToGenerator map[string]*ruleGenerator, policy *MyPolicy,
+	ruleMap map[string]int) (string, error) {
 	spec := &authzpb.AuthorizationPolicy{}
 	switch action {
 	case "ALLOW":
@@ -113,10 +114,9 @@ func generateAuthorizationPolicy(action string, ruleToOccurrences map[string]*ru
 	}
 
 	var ruleList []*authzpb.Rule
-	sortedKeys := getOrderedKeySlice(ruleToOccurrences)
+	sortedKeys := getOrderedKeySlice(ruleToGenerator)
 	for _, name := range *sortedKeys {
-		ruleOp := ruleToOccurrences[name]
-		rule := ruleOp.gen.generate(name, ruleOp.occurrence, action)
+		rule := ruleToGenerator[name].gen.generate(action, ruleMap)
 		ruleList = append(ruleList, rule)
 	}
 	spec.Rules = ruleList
@@ -128,12 +128,12 @@ func generateAuthorizationPolicy(action string, ruleToOccurrences map[string]*ru
 	return yaml, nil
 }
 
-func generateRule(action string, ruleToOccurrences map[string]*ruleOption,
-	policy *MyPolicy) (string, error) {
+func generateRules(action string, ruleToGenerator map[string]*ruleGenerator,
+	policy *MyPolicy, ruleMap map[string]int) (string, error) {
 
 	switch policy.Kind {
 	case "AuthorizationPolicy":
-		return generateAuthorizationPolicy(action, ruleToOccurrences, policy)
+		return generateAuthorizationPolicy(action, ruleToGenerator, policy, ruleMap)
 	case "PeerAuthentication":
 		return "", fmt.Errorf("unimplemented")
 	case "RequestAuthentication":
@@ -141,14 +141,6 @@ func generateRule(action string, ruleToOccurrences map[string]*ruleOption,
 	default:
 		return "", fmt.Errorf("unknown policy kind: %s", policy.Kind)
 	}
-}
-
-func createRules(action string, ruleToOccurrences map[string]*ruleOption, policy *MyPolicy) (string, error) {
-	yaml, err := generateRule(action, ruleToOccurrences, policy)
-	if err != nil {
-		return "", err
-	}
-	return yaml, nil
 }
 
 func createPolicyHeader(namespace string, name string, kind string) *MyPolicy {
@@ -159,54 +151,111 @@ func createPolicyHeader(namespace string, name string, kind string) *MyPolicy {
 	}
 }
 
-func createRuleOptionMap(ruleToOccurancesPtr map[string]*int) (map[string]*ruleOption, error) {
-	ruleOptionMap := make(map[string]*ruleOption)
-	for rule, occurrence := range ruleToOccurancesPtr {
-		ruleOptionMap[rule] = &ruleOption{}
-		ruleOptionMap[rule].occurrence = *occurrence
-		switch rule {
-		case "when":
-			ruleOptionMap[rule].gen = conditionGenerator{}
-		case "to":
-			ruleOptionMap[rule].gen = operationGenerator{}
-		case "from":
-			ruleOptionMap[rule].gen = sourceGenerator{}
-		default:
-			return nil, fmt.Errorf("invalid rule: %s", rule)
+func createRuleGeneratorMap(ruleToOccurancesPtr map[string]int) (map[string]*ruleGenerator, error) {
+	ruleGeneratorMap := make(map[string]*ruleGenerator)
+
+	if ruleToOccurancesPtr["numSourceIP"] > 0 || ruleToOccurancesPtr["numNamespaces"] > 0 {
+		ruleGeneratorMap["from"] = &ruleGenerator{
+			gen: sourceGenerator{},
 		}
 	}
-	return ruleOptionMap, nil
+
+	if ruleToOccurancesPtr["numPaths"] > 0 {
+		ruleGeneratorMap["to"] = &ruleGenerator{
+			gen: operationGenerator{},
+		}
+	}
+
+	if ruleToOccurancesPtr["numValues"] > 0 {
+		ruleGeneratorMap["when"] = &ruleGenerator{
+			gen: conditionGenerator{},
+		}
+	}
+	return ruleGeneratorMap, nil
+}
+
+func parseArguments(arguments string) (map[string]string, error) {
+	argumentMap := make(map[string]string)
+	// These are the default values
+	argumentMap["namespace"] = "twopods-istio"
+	argumentMap["policyType"] = "AuthorizationPolicy"
+	argumentMap["action"] = "DENY"
+	argumentMap["numPolicies"] = "1"
+
+	if len(arguments) > 0 {
+		for _, arg := range strings.Split(arguments, ",") {
+			keyValue := strings.Split(arg, ":")
+			if len(keyValue) == 1 {
+				return nil, fmt.Errorf("invalid argument: %s", keyValue[0])
+			}
+			argumentMap[keyValue[0]] = keyValue[1]
+		}
+	}
+	return argumentMap, nil
+}
+
+func createRuleMap(arguments map[string]string) (map[string]int, error) {
+	ruleMap := make(map[string]int)
+	// These are the default values
+	ruleMap["numPaths"] = 0
+	ruleMap["numSourceIP"] = 1
+	ruleMap["numNamespaces"] = 0
+	ruleMap["numValues"] = 0
+
+	for key := range ruleMap {
+		if argVal, inMap := arguments[key]; inMap {
+			argVal, err := strconv.Atoi(argVal)
+			if err != nil {
+				return nil, fmt.Errorf("invalid value: %d", argVal)
+			}
+			ruleMap[key] = argVal
+		}
+	}
+	return ruleMap, nil
 }
 
 func main() {
-	namespacePtr := flag.String("namespace", "twopods-istio", "Namespace in which the rule shall be applied to.")
-	policyType := flag.String("policyType", "AuthorizationPolicy", "The type of security policy. Supported value: AuthorizationPolicy")
-	actionPtr := flag.String("action", "DENY", "Type of action. Supported values: DENY, ALLOW")
-	numPoliciesPtr := flag.Int("numPolicies", 1, "Number of policies wanted")
+	securityPtr := flag.String("generate_policy", "numPolicies:1", `List of key value pairs separated by commas.
+	Supported options: namespace:\"string\", action:DENY/ALLOW, policyType:AuthorizationPolicy, 
+	numPolicies:int, numPaths:int, numSourceIP:int. numNamespaces:int`)
 
-	ruleToOccurancesPtr := make(map[string]*int)
-	ruleToOccurancesPtr["when"] = flag.Int("when", 1, "Number of when condition wanted")
-	ruleToOccurancesPtr["to"] = flag.Int("to", 1, "Number of To operations wanted")
-	ruleToOccurancesPtr["from"] = flag.Int("from", 1, "Number of From sources wanted")
 	flag.Parse()
 
-	for i := 1; i <= *numPoliciesPtr; i++ {
-		yaml := bytes.Buffer{}
-		policy := createPolicyHeader(*namespacePtr, fmt.Sprintf("test-%d", i), *policyType)
+	argumentMap, err := parseArguments(*securityPtr)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
 
-		ruleOptionMap, err := createRuleOptionMap(ruleToOccurancesPtr)
+	ruleMap, err := createRuleMap(argumentMap)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	numPolices, err := strconv.Atoi(argumentMap["numPolicies"])
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	for i := 1; i <= numPolices; i++ {
+		policy := createPolicyHeader(argumentMap["namespace"], fmt.Sprintf("test-%d", i), argumentMap["policyType"])
+
+		ruleToGenerator, err := createRuleGeneratorMap(ruleMap)
 		if err != nil {
 			fmt.Println(err)
 			break
 		}
 
-		rules, err := createRules(*actionPtr, ruleOptionMap, policy)
+		rules, err := generateRules(argumentMap["action"], ruleToGenerator, policy, ruleMap)
 		if err != nil {
 			fmt.Println(err)
 			break
 		} else {
+			yaml := bytes.Buffer{}
 			yaml.WriteString(rules)
-			if i < *numPoliciesPtr {
+			if i < numPolices {
 				yaml.WriteString("---")
 			}
 			fmt.Println(yaml.String())

--- a/perf/benchmark/security/generate_policies/generate_policies.go
+++ b/perf/benchmark/security/generate_policies/generate_policies.go
@@ -33,7 +33,7 @@ import (
 )
 
 type ruleGenerator struct {
-	gen        generator
+	gen generator
 }
 
 type MyPolicy struct {
@@ -151,7 +151,7 @@ func createPolicyHeader(namespace string, name string, kind string) *MyPolicy {
 	}
 }
 
-func createRuleGeneratorMap(ruleToOccurancesPtr map[string]int) (map[string]*ruleGenerator, error) {
+func createRuleGeneratorMap(ruleToOccurancesPtr map[string]int) map[string]*ruleGenerator {
 	ruleGeneratorMap := make(map[string]*ruleGenerator)
 
 	if ruleToOccurancesPtr["numSourceIP"] > 0 || ruleToOccurancesPtr["numNamespaces"] > 0 {
@@ -171,7 +171,7 @@ func createRuleGeneratorMap(ruleToOccurancesPtr map[string]int) (map[string]*rul
 			gen: conditionGenerator{},
 		}
 	}
-	return ruleGeneratorMap, nil
+	return ruleGeneratorMap
 }
 
 func parseArguments(arguments string) (map[string]string, error) {
@@ -242,12 +242,7 @@ func main() {
 	for i := 1; i <= numPolices; i++ {
 		policy := createPolicyHeader(argumentMap["namespace"], fmt.Sprintf("test-%d", i), argumentMap["policyType"])
 
-		ruleToGenerator, err := createRuleGeneratorMap(ruleMap)
-		if err != nil {
-			fmt.Println(err)
-			break
-		}
-
+		ruleToGenerator := createRuleGeneratorMap(ruleMap)
 		rules, err := generateRules(argumentMap["action"], ruleToGenerator, policy, ruleMap)
 		if err != nil {
 			fmt.Println(err)

--- a/perf/benchmark/security/generate_policies/generate_policies.go
+++ b/perf/benchmark/security/generate_policies/generate_policies.go
@@ -216,7 +216,7 @@ func createRuleMap(arguments map[string]string) (map[string]int, error) {
 
 func main() {
 	securityPtr := flag.String("generate_policy", "numPolicies:1", `List of key value pairs separated by commas.
-	Supported options: namespace:\"string\", action:DENY/ALLOW, policyType:AuthorizationPolicy, 
+	Supported options: namespace:string, action:DENY/ALLOW, policyType:AuthorizationPolicy, 
 	numPolicies:int, numPaths:int, numSourceIP:int. numNamespaces:int`)
 
 	flag.Parse()


### PR DESCRIPTION
These changes allow for generate policies to have more customization, instead of passing in as a flag how many From, When, To rules you want to generate in a rule, these changes allow the user to choose between numPaths, numSourceIP, numNamespaces, and numValues to create those rules in a policy. These changes will also allow more flexibility when in the future we need to add more options for rules like requestPrinciple and so fourth