### PR TITLE
Release Notes Tooling

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,3 +2,4 @@
 perf/    @istio/wg-test-and-release-maintainers @istio/wg-perf-and-scalability-maintainers
 isotope/ @istio/wg-test-and-release-maintainers @istio/wg-perf-and-scalability-maintainers
 metrics/ @istio/wg-test-and-release-maintainers @istio/wg-perf-and-scalability-maintainers
+cmd/gen-release-notes/templates @istio/wg-test-and-release-maintainers @istio/wg-docs-maintainers @istio/release-managers

--- a/cmd/gen-release-notes/README.md
+++ b/cmd/gen-release-notes/README.md
@@ -1,0 +1,55 @@
+# Release notes generation
+
+The tooling in this directory is used to generate release notes based on the
+[release notes
+schema](https://github.com/istio/istio/tree/master/releasenotes). In this
+release notes system, a release notes file is created in each pull request which
+should have release notes. These notes are then collated in order to generate a
+single release notes file.
+
+## Generating Release Notes
+
+To generate release notes, run:
+
+```bash
+go run ./main.go --notes <notes-dir> --templates <templates-dir>
+```
+
+`--notes` and `--templates` are optional arguments indicating where release
+notes and templates should be found. By default, the generator looks for
+a `templates` and a `notes` directory in the current directory.
+
+## Templates
+
+Release notes templates are standard markdown files containing HTML comments
+indicating where content should be substituted. These are stored in the
+[templates](./templates) directory.
+
+* Release notes can be substituted using:
+
+```html
+<!-- releaseNotes -->
+```
+
+* Security notes can be substituted using:
+
+```html
+<!-- securityNotes -->
+```
+
+* Upgrade notes can be substituted using:
+
+```html
+<!-- upgradeNotes -->
+```
+
+### Filtering notes
+
+Notes can be substituted based on fields in the release notes files.
+
+To substitute for release notes matching the `traffic-management` area, use the
+following comment:
+
+```html
+<!-- releaseNotes area:traffic-management -->
+```

--- a/cmd/gen-release-notes/main.go
+++ b/cmd/gen-release-notes/main.go
@@ -1,0 +1,230 @@
+// Copyright 2020 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"regexp"
+	"strings"
+
+	"github.com/ghodss/yaml"
+	"github.com/russross/blackfriday/v2"
+)
+
+type ReleaseNote struct {
+	Kind          string      `json:"kind"`
+	Area          string      `json:"area"`
+	Issue         []string    `json:"issue,omitempty"`
+	ReleaseNotes  string      `json:"releaseNotes"`
+	UpgradeNotes  upgradeNote `json:"upgradeNotes"`
+	SecurityNotes string      `json:"securityNotes"`
+}
+
+type upgradeNote struct {
+	Title   string `json:"title"`
+	Content string `json:"content"`
+}
+
+func main() {
+	var notesDir string
+	var templatesDir string
+	flag.StringVar(&notesDir, "notes", "./notes", "the directory containing release notes")
+	flag.StringVar(&templatesDir, "templates", "./templates", "the directory containing release note templates")
+	flag.Parse()
+
+	fmt.Printf("Looking for release notes in %s.\n", notesDir)
+	releaseNoteFiles, err := getFilesWithExtension(notesDir, "yaml")
+	if err != nil {
+		fmt.Printf("failed to list files: %s", err.Error())
+		return
+	}
+	fmt.Printf("Found %d files.\n", len(releaseNoteFiles))
+
+	fmt.Printf("Looking for markdown templates in %s.\n", templatesDir)
+	templateFiles, err := getFilesWithExtension(templatesDir, "md")
+	if err != nil {
+		fmt.Printf("failed to list files: %s", err.Error())
+		return
+	}
+	fmt.Printf("Found %d files.\n\n", len(templateFiles))
+
+	fmt.Printf("Parsing release notes\n")
+	releaseNotes, err := parseReleaseNotesFiles(notesDir, releaseNoteFiles)
+	if err != nil {
+		fmt.Printf("Unable to read release notes: %s\n", err.Error())
+	}
+
+	processTemplates(templatesDir, templateFiles, releaseNotes)
+}
+
+//Bavery_todo: issue display formatting template
+//Bavery_TODO: find previous branch
+//Bavery_todo: diff previous branch
+
+func processTemplates(templatesDir string, templateFiles []string, releaseNotes []ReleaseNote) {
+
+	for _, file := range templateFiles {
+		output, err := parseTemplate(templatesDir, file, releaseNotes)
+		if err != nil {
+			fmt.Printf("Failed to parse markdown template: %s", err.Error())
+			return
+		}
+
+		if err := ioutil.WriteFile(file, []byte(output), 0644); err != nil {
+			fmt.Printf("Failed to write markdown: %s", err.Error())
+		} else {
+			fmt.Printf("Wrote markdown to %s\n", file)
+		}
+
+		if err := ioutil.WriteFile(file+".html", []byte(markdownToHTML(output)), 0644); err != nil {
+			fmt.Printf("Failed to write HTML: %s", err.Error())
+		} else {
+			fmt.Printf("Wrote markdown to %s.html\n", file)
+		}
+	}
+}
+
+func parseReleaseNote(releaseNotes []ReleaseNote, format string) []string {
+	parsedNotes := make([]string, 0)
+
+	noteType := "releaseNotes"
+	if strings.Contains(format, "upgradeNotes") {
+		noteType = "upgradeNotes"
+	} else if strings.Contains(format, "securityNotes") {
+		noteType = "securityNotes"
+	}
+
+	area := ""
+	areaRegexp := regexp.MustCompile("area:[a-zA-Z-]*")
+	if match := areaRegexp.FindString(format); match != "" {
+		sections := strings.Split(match, ":")
+		area = sections[1]
+	}
+	fmt.Printf("Notes format: %s type: %s area: %s\n", format, noteType, area)
+
+	for _, note := range releaseNotes {
+		formatted := ""
+		if noteType == "releaseNotes" && note.ReleaseNotes != "" && (note.Area == area || area == "") {
+			formatted = fmt.Sprintf("- %s %s", note.ReleaseNotes, issuesListToString(note.Issue))
+		} else if noteType == "upgradeNotes" && note.UpgradeNotes.Content != "" {
+			if note.UpgradeNotes.Title == "" {
+				fmt.Printf("Upgrade note is missing title. Skipping.")
+			} else {
+				formatted = fmt.Sprintf("## %s\n%s", note.UpgradeNotes.Title, note.UpgradeNotes.Content)
+			}
+		} else if noteType == "securityNotes" && note.SecurityNotes != "" {
+			formatted = fmt.Sprintf("- %s", note.SecurityNotes)
+		}
+
+		if formatted != "" {
+			parsedNotes = append(parsedNotes, formatted)
+		}
+	}
+
+	return parsedNotes
+}
+
+//Bavery_TODO: rewrite
+func issuesListToString(issues []string) string {
+	issueString := ""
+	for _, issue := range issues {
+		if issueString != "" {
+			issueString += ","
+		}
+		if strings.Contains(issue, "github.com") {
+			issueNumber := path.Base(issue)
+			issueString += fmt.Sprintf("([Issue #%s](%s))", issueNumber, issue)
+		} else {
+			issueString += fmt.Sprintf("([Issue #%s](https://github.com/istio/istio/issues/%s))", issue, issue)
+		}
+	}
+	return issueString
+}
+
+//getFilesWithExtension returns the files from filePath with extension extension
+func getFilesWithExtension(filePath string, extension string) ([]string, error) {
+	directory, err := os.Open(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open directory: %s", err.Error())
+	}
+	defer directory.Close()
+
+	var files []string
+	files, err = directory.Readdirnames(0)
+	if err != nil {
+		return nil, fmt.Errorf("unable to list files for directory %s: %s", filePath, err.Error())
+	}
+
+	filesWithExtension := make([]string, 0)
+	for _, fileName := range files {
+		if strings.HasSuffix(fileName, extension) {
+			filesWithExtension = append(filesWithExtension, fileName)
+		}
+	}
+
+	return filesWithExtension, nil
+
+}
+
+func parseReleaseNotesFiles(filePath string, files []string) ([]ReleaseNote, error) {
+	releaseNotes := make([]ReleaseNote, 0)
+	for _, file := range files {
+		file = path.Join(filePath, file)
+		contents, err := ioutil.ReadFile(file)
+		if err != nil {
+			return nil, fmt.Errorf("unable to open file %s: %s", file, err.Error())
+		}
+
+		var releaseNote ReleaseNote
+		if err = yaml.Unmarshal(contents, &releaseNote); err != nil {
+			return nil, fmt.Errorf("unable to parse release note %s:%s", file, err.Error())
+		}
+		releaseNotes = append(releaseNotes, releaseNote)
+
+	}
+	return releaseNotes, nil
+
+}
+
+//markdownToHTML is a wrapper around the blackfriday library to generate HTML previews from markdown
+func markdownToHTML(markdown string) string {
+	return string(blackfriday.Run([]byte(markdown)))
+}
+
+func parseTemplate(filepath string, filename string, releaseNotes []ReleaseNote) (string, error) {
+	filename = path.Join(filepath, filename)
+	fmt.Printf("Processing %s\n", filename)
+
+	contents, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return "", fmt.Errorf("unable to open file %s: %s", filename, err.Error())
+	}
+
+	comment := regexp.MustCompile("<!--(.*)-->")
+	output := string(contents)
+	results := comment.FindAllString(string(contents), -1)
+
+	for _, result := range results {
+		contents := parseReleaseNote(releaseNotes, result)
+		joinedContents := strings.Join(contents, "\n")
+		output = strings.Replace(output, result, joinedContents, -1)
+	}
+
+	return output, nil
+}

--- a/cmd/gen-release-notes/templates/minorReleaseNotes.md
+++ b/cmd/gen-release-notes/templates/minorReleaseNotes.md
@@ -1,0 +1,30 @@
+---
+title: Change Notes
+description: Istio 1.6 release notes.
+weight: 10
+---
+<!-- markdownlint-disable MD002 -->
+
+## Traffic Management
+
+<!-- releaseNotes area:traffic-management -->
+
+## Security
+
+<!-- releaseNotes area:security -->
+
+## Telemetry
+
+<!-- releaseNotes area:telemetry -->
+
+## Installation
+
+<!-- releaseNotes area:installation -->
+
+## istioctl
+
+<!-- releaseNotes area:istioctl -->
+
+## Documentation changes
+
+<!-- releaseNotes area:documentation -->

--- a/cmd/gen-release-notes/templates/minorReleaseNotes.md
+++ b/cmd/gen-release-notes/templates/minorReleaseNotes.md
@@ -3,7 +3,7 @@ title: Change Notes
 description: Istio 1.6 release notes.
 weight: 10
 ---
-<!-- markdownlint-disable MD002 -->
+# Release Notes
 
 ## Traffic Management
 

--- a/cmd/gen-release-notes/templates/releaseNotes.md
+++ b/cmd/gen-release-notes/templates/releaseNotes.md
@@ -1,0 +1,21 @@
+---
+title: Announcing Istio 1.6.6
+linktitle: 1.6.6
+subtitle: Patch Release
+description: Istio 1.6.6 patch release.
+publishdate: 2020-07-29
+release: 1.6.6
+aliases:
+    - /news/announcing-1.6.6
+---
+This release contains bug fixes to improve robustness. This release note describes what’s different between Istio 1.6.2 and Istio 1.6.3.
+
+{{< relnote >}}
+
+# Changes
+
+<!-- releaseNotes  -->
+
+# Security update
+
+<!-- securityNotes -->

--- a/cmd/gen-release-notes/templates/upgradeNotes.md
+++ b/cmd/gen-release-notes/templates/upgradeNotes.md
@@ -1,0 +1,12 @@
+---
+title: Upgrade Notes
+description: Important changes to consider when upgrading to Istio 1.6.
+weight: 20
+---
+
+When you upgrade from Istio 1.5.x to Istio 1.6.x, you need to consider the changes on this page.
+These notes detail the changes which purposefully break backwards compatibility with Istio 1.5.x.
+The notes also mention changes which preserve backwards compatibility while introducing new behavior.
+Changes are only included if the new behavior would be unexpected to a user of Istio 1.5.x.
+
+<!-- upgradeNotes -->


### PR DESCRIPTION
This tooling will be used to generate release notes for Istio. This PR is to get the conversation going on style. The code is messy and I am working on cleaning it up as well as implementing the list below. 

Missing: 
* Need to better formulate parsing of templates
* Templates should allow specifying the format that notes should be displayed in. 
* Templates need to be better filled out. 
* Can't currently diff across branches. This will be needed once we have more than one release we are comparing.