### PR TITLE
Fix nighthawk cmd and remove deprecated fields

### DIFF
--- a/perf/benchmark/runner/runner.py
+++ b/perf/benchmark/runner/runner.py
@@ -302,6 +302,7 @@ class Fortio:
             conn=round(conn / cpus),
             qps=round(qps / cpus),
             duration=duration,
+            jitter_uniform=jitter_uniform,
             labels=labels,
             size=self.size,
             cpus=cpus,

--- a/perf/istio-install/istioctl_profiles/default-overlay.yaml
+++ b/perf/istio-install/istioctl_profiles/default-overlay.yaml
@@ -77,9 +77,6 @@ spec:
           secretName: istio-ingressgateway-certs
         type: LoadBalancer
     global:
-      meshExpansion:
-        enabled: true
-        useILB: true
       multiCluster:
         enabled: true
       podDNSSearchNamespaces:


### PR DESCRIPTION
error log:

```
istioctl install --skip-confirmation -d /Users/carolynprh/tools/perf/istio-install/tmp/istio-1.8-alpha.a0ea40b37e1c81ad9ebdaca2c904a201a125ba59/manifests -f istioctl_profiles/default-overlay.yaml
! values.global.meshExpansion.enabled is deprecated; use Gateway and other Istio networking resources, such as in samples/istiod-gateway/ instead
```