### PR TITLE
Add PeerAuthN functionality to generate_policies

### DIFF
--- a/perf/benchmark/security/generate_policies/README.md
+++ b/perf/benchmark/security/generate_policies/README.md
@@ -4,21 +4,25 @@ This directory contains information needed to create large scale security polici
 
 See the [Istio Security](https://istio.io/latest/docs/reference/config/security/) for more information about policies.
 
-## Setup
+The default values of the policies are specifically made to work with the environment that is created in the setup of [Istio Performance Benchmarking](https://github.com/istio/tools/tree/master/perf/benchmark)
 
-To run generate_policies, run the following command:
+## AuthorizationPolicy
+
+To create an AuthorizationPolicy policy one must explicity pass in the following flag -generate_policy="AuthorizationPolicy:1".
+
+To create an AuthorizationPolicy, run the following command:
 
 ```bash
-go run generate_policies.go generate.go
+go run generate_policies.go generate.go -generate_policy="AuthorizationPolicy:1,numSourceIP:1"
 ```
 
-This will by default create an Authorization Policy as follows and print it out to the stdout. This AuthorizationPolicy is specifically made to work with the environment that is created in the setup of [Istio Performance Benchmarking](https://github.com/istio/tools/tree/master/perf/benchmark)
+This will create an Authorization Policy as follows and print it out to the stdout. The number after "AuthorizationPolicy" is used to determine how many AuthorizationPolicies will be produced to stdout.
 
 ```yaml
 apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
-  name: test-1
+  name: test-AuthorizationPolicy-1
   namespace: twopods-istio
 spec:
  action: DENY
@@ -29,20 +33,99 @@ spec:
        - 0.0.0.0
 ```
 
-generate_polices allows to customize the generated policies with command line flags:
+The flags which can be used to create custom AuthorizationPolicies are as follows:
 
 ```bash
-Optional arguments:
-  -h, --help
-  -generate_policy string         List of key value pairs separated by commas.
-                                  Supported options: namespace:string, action:DENY/ALLOW, policyType:AuthorizationPolicy, numPolicies:int, numPaths:int, numValues:int, numSourceIP:int, numNamespaces:int (default "numPolicies:1")
+  AuthorizationPolicies:int
+  namespace:string
+  action:DENY/ALLOW
+  numPolicies:int
+  numPaths:int
+  numValues:int
+  numSourceIP:int
+  numNamespaces:int
+  numPrincipals:int
 ```
 
-To create a large policy to an output .yaml file, run the following command:
+For more information see [AuthorizationPolicy Reference](https://istio.io/latest/docs/reference/config/security/authorization-policy/).
+
+## PeerAuthentication
+
+To create a PeerAuthentication policy one must explicity pass in the following flag -generate_policy="PeerAuthentication:1".
+
+To create a PeerAuthentication, run the following command:
 
 ```bash
-go run generate_policies.go generate.go -generate_policy="numSourceIP:1000,numPaths:1000,numNamespaces:1000" > largePolicy.yaml
+go run generate_policies.go generate.go -generate_policy="PeerAuthentication:1"
 ```
+
+This will create a PeerAuthentication policy as follows since mtlsMode has a default value of STRICT and print it out to the stdout. The number after "PeerAuthentication" is used to determine how many PeerAuthentication will be produced to stdout.
+
+```yaml
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
+metadata:
+  name: test-PeerAuthentication-1
+  namespace: twopods-istio
+spec:
+ mtls:
+   mode: STRICT
+```
+
+The flags which can be used to create custom PeerAuthentication are as follows:
+
+```bash
+  PeerAuthentication:int
+  namespace:string
+  mtlsMode:STRICT/DISABLE
+```
+
+For more information see [PeerAuthentication Reference](https://istio.io/latest/docs/reference/config/security/peer_authentication/).
+
+## Examples
+
+generate_policies.go also allows a user to create mutliple kinds of policies in one command.
+To generate 1 AuthorizationPolicy with a principals rule and 1 PeerAuthorization policy with STRICT mtlsMode, run the following command:
+
+```bash
+ go run generate_policies.go generate.go -generate_policy="AuthorizationPolicy:1,numPrincipals:1,PeerAuthentication:1"
+```
+
+Which outputs the following yaml:
+
+```yaml
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: test-AuthorizationPolicy-1
+  namespace: twopods-istio
+spec:
+ action: DENY
+ rules:
+ - from:
+   - source:
+       principals:
+       - cluster.local/ns/twopods-istio/sa/Invalid-0
+---
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
+metadata:
+  name: test-PeerAuthentication-1
+  namespace: twopods-istio
+spec:
+ mtls:
+   mode: STRICT
+```
+
+### Output to a yaml file
+
+To create a large AuthorizationPolicy to an output .yaml file, run the following command:
+
+```bash
+go run generate_policies.go generate.go -generate_policy="AuthorizationPolicy:1,numSourceIP:1000,numPaths:1000,numNamespaces:1000" > largePolicy.yaml
+```
+
+### Apply the yaml file
 
 To apply largePolicy.yaml that was just created to istio use the following command.
 
@@ -53,7 +136,7 @@ kubectl apply -f largePolicy.yaml
 ## Example 1
 
 ```bash
-go run generate_policies.go generate.go -generate_policy="numPolicies:10,numSourceIP:10,numPaths:2"
+go run generate_policies.go generate.go -generate_policy="AuthorizationPolicy:1,numPolicies:10,numSourceIP:10,numPaths:2"
 ```
 
 - This creates 10 AuthorizationPolicies which each contains 10 sourceIP's sources, and 2 paths operations
@@ -61,10 +144,18 @@ go run generate_policies.go generate.go -generate_policy="numPolicies:10,numSour
 ## Example 2
 
 ```bash
-go run generate_policies.go generate.go -generate_policy="numSourceIP:100,numPaths:100,numNamespaces:100"
+go run generate_policies.go generate.go -generate_policy="AuthorizationPolicy:1,numSourceIP:100,numPaths:100,numNamespaces:100"
 ```
 
 - This creates 1 AuthorizationPolicy which contains 100 sourceIP's sources, 100 paths operations, and 100 namespaces sources
+
+## Example 3
+
+```bash
+go run generate_policies.go generate.go -generate_policy="PeerAuthentication:1,mtlsMode:DISABLE"
+```
+
+- This creates 1 PeerAuthentication policy which has the mtls mode set to DISABLE
 
 ## Cleanup
 

--- a/perf/benchmark/security/generate_policies/README.md
+++ b/perf/benchmark/security/generate_policies/README.md
@@ -248,6 +248,7 @@ kubectl apply -f largePolicy.yaml
     "numPaths":2
   }
 }
+```
 
 ```bash
 go run generate_policies.go generate.go -configFile="config.json" > authZPolicy.yaml
@@ -269,6 +270,7 @@ go run generate_policies.go generate.go -configFile="config.json" > authZPolicy.
     "numNamespaces":100
   }
 }
+```
 
 ```bash
 go run generate_policies.go generate.go -configFile="config.json" > authZPolicy.yaml
@@ -288,6 +290,7 @@ go run generate_policies.go generate.go -configFile="config.json" > authZPolicy.
     "mtlsMode":"DISABLE"
   }
 }
+```
 
 ```bash
 go run generate_policies.go generate.go -generate_policy="PeerAuthentication:1,mtlsMode:DISABLE"

--- a/perf/benchmark/security/generate_policies/README.md
+++ b/perf/benchmark/security/generate_policies/README.md
@@ -6,17 +6,73 @@ See the [Istio Security](https://istio.io/latest/docs/reference/config/security/
 
 The default values of the policies are specifically made to work with the environment that is created in the setup of [Istio Performance Benchmarking](https://github.com/istio/tools/tree/master/perf/benchmark)
 
-## AuthorizationPolicy
+## Config file
 
-To create an AuthorizationPolicy policy one must explicity pass in the following flag -generate_policy="AuthorizationPolicy:1".
+To generate specific security policies begin by creating a json file that has the format of the struct below:
 
-To create an AuthorizationPolicy, run the following command:
-
-```bash
-go run generate_policies.go generate.go -generate_policy="AuthorizationPolicy:1,numSourceIP:1"
+```go
+"SecurityPolicy":
+{
+  "AuthZ":
+  {
+    "action":int,           // optional DENY/ALLOW. Default:DENY
+    "numNamespaces":int,    // optional. Default:0
+    "numPaths":int,         // optional. Default:0
+    "numPolicies":int,      // optional. Default:0
+    "numPrincipals":int,    // optional. Default:0
+    "numSourceIP":int,      // optional. Default:0
+    "numValues":int         // optional. Default:0
+  },
+  "namespace":string,       // optional, the namespace in which all the policies will be applied to. Default:twopods-istio
+  "peerAuthN":
+  {
+    "mtlsMode":string,      // optional STRICT/DISABLE. Default:STRICT
+    "numPolicies":int       // optional. Default:0
+  }
+}
 ```
 
-This will create an Authorization Policy as follows and print it out to the stdout. The number after "AuthorizationPolicy" is used to determine how many AuthorizationPolicies will be produced to stdout.
+An example config file that will create 2 AuthorizationPolicies that each contain 1 sourceIP rule and 3 paths rules is formed as follows in a file called config.json:
+
+```json
+{
+    "AuthZ":
+    {
+        "numPolicies": 2,
+        "numSourceIP":1,
+        "numPaths":3
+    }
+}
+```
+
+To generate the policies from the config file one must pass in the filename into the configFile flag. For example to generate the policy that is described in the above json run:
+
+```bash
+go run generate_policies.go generate.go -configFile="config.json"
+```
+
+## AuthorizationPolicy
+
+To create an AuthorizationPolicy policy one must create a json file with the AuthZ field as well as set the numPolicies >= 1.
+One should also include at least 1 rule. In this example numSourceIP is set to 1.
+
+```json
+{
+  "AuthZ":
+  {
+    "numPolicies":1,
+    "numSourceIP":1
+  }
+}
+```
+
+Once the wanted json file is created (called config.json) to generate the policies we just need pass in the config.json file to the configFile flag.
+
+```bash
+go run generate_policies.go generate.go -configFile="config.json"
+```
+
+This will create an Authorization Policy as follows and print it out to the stdout.
 
 ```yaml
 apiVersion: security.istio.io/v1beta1
@@ -33,33 +89,47 @@ spec:
        - 0.0.0.0
 ```
 
-The flags which can be used to create custom AuthorizationPolicies are as follows:
+##
 
-```bash
-  AuthorizationPolicies:int
-  namespace:string
-  action:DENY/ALLOW
-  numPolicies:int
-  numPaths:int
-  numValues:int
-  numSourceIP:int
-  numNamespaces:int
-  numPrincipals:int
+The values which can be used to create custom AuthorizationPolicies are as follows:
+
+```go
+  "AuthZ":
+  {
+    "action":int,           // optional DENY/ALLOW. Default:DENY
+    "numNamespaces":int,    // optional. Default:0
+    "numPaths":int,         // optional. Default:0
+    "numPolicies":int,      // optional. Default:0
+    "numPrincipals":int,    // optional. Default:0
+    "numSourceIP":int,      // optional. Default:0
+    "numValues":int         // optional. Default:0
+  }
 ```
 
 For more information see [AuthorizationPolicy Reference](https://istio.io/latest/docs/reference/config/security/authorization-policy/).
 
 ## PeerAuthentication
 
-To create a PeerAuthentication policy one must explicity pass in the following flag -generate_policy="PeerAuthentication:1".
+To create an PeerAuthentication policy one must create a json file with the PeerAuthN field as well as set the PeerAuthN.numPolicies >= 1.
+By default this generates a mtlsMode of "STRICT" but this can be overwritten as follows.
 
-To create a PeerAuthentication, run the following command:
-
-```bash
-go run generate_policies.go generate.go -generate_policy="PeerAuthentication:1"
+```json
+{
+  "PeerAuthN":
+  {
+    "numPolicies":1,
+    "mtlsMode":"DISABLE"
+  }
+}
 ```
 
-This will create a PeerAuthentication policy as follows since mtlsMode has a default value of STRICT and print it out to the stdout. The number after "PeerAuthentication" is used to determine how many PeerAuthentication will be produced to stdout.
+Once the wanted json file is created (called config.json) to generate the policies we just need pass in the config.json file to the configFile flag.
+
+```bash
+go run generate_policies.go generate.go -configFile="config.json"
+```
+
+This will create a PeerAuthentication policy as follows and print it out to the stdout.
 
 ```yaml
 apiVersion: security.istio.io/v1beta1
@@ -69,15 +139,19 @@ metadata:
   namespace: twopods-istio
 spec:
  mtls:
-   mode: STRICT
+   mode: DISABLE
 ```
 
-The flags which can be used to create custom PeerAuthentication are as follows:
+##
 
-```bash
-  PeerAuthentication:int
-  namespace:string
-  mtlsMode:STRICT/DISABLE
+The values which can be used to create custom AuthorizationPolicies are as follows:
+
+```go
+  "peerAuthN":
+  {
+    "mtlsMode":string,      // optional STRICT/DISABLE. Default:STRICT
+    "numPolicies":int       // optional. Default:0
+  }
 ```
 
 For more information see [PeerAuthentication Reference](https://istio.io/latest/docs/reference/config/security/peer_authentication/).
@@ -85,10 +159,24 @@ For more information see [PeerAuthentication Reference](https://istio.io/latest/
 ## Examples
 
 generate_policies.go also allows a user to create mutliple kinds of policies in one command.
-To generate 1 AuthorizationPolicy with a principals rule and 1 PeerAuthorization policy with STRICT mtlsMode, run the following command:
+To generate 1 AuthorizationPolicy with a principals rule and 1 PeerAuthorization policy with STRICT mtlsMode, create a json file called twoPolicies.json with the following data and then run the following command:
+
+```json
+{
+    "mtlsMode":
+    {
+      "numPolicies":1,
+      "numPrincipals":1
+    },
+    "peerAuthN":
+    {
+      "numPolicies":1
+    }
+}
+```
 
 ```bash
- go run generate_policies.go generate.go -generate_policy="AuthorizationPolicy:1,numPrincipals:1,PeerAuthentication:1"
+ go run generate_policies.go generate.go -configFile="twoPolicies.json"
 ```
 
 Which outputs the following yaml:
@@ -119,15 +207,29 @@ spec:
 
 ### Output to a yaml file
 
-To create a large AuthorizationPolicy to an output .yaml file, run the following command:
+To create a large AuthorizationPolicy to an output .yaml file, create a file called largeConfig.json which contains the following data:
+
+```json
+{
+  "AuthZ":
+  {
+    "numPolicies":1000,
+    "numSourceIP":100,
+    "numPaths":100,
+    "numValues":100
+  }
+}
+```
+
+run the following command:
 
 ```bash
-go run generate_policies.go generate.go -generate_policy="AuthorizationPolicy:1,numSourceIP:1000,numPaths:1000,numNamespaces:1000" > largePolicy.yaml
+go run generate_policies.go generate.go -configFile="largeConfig.json" > largePolicy.yaml
 ```
 
 ### Apply the yaml file
 
-To apply largePolicy.yaml that was just created to istio use the following command.
+To apply largePolicy.yaml that was just created to istio use the following command:
 
 ```bash
 kubectl apply -f largePolicy.yaml
@@ -135,21 +237,57 @@ kubectl apply -f largePolicy.yaml
 
 ## Example 1
 
+- By creating a config file called config.json with the following data, and then running the following command:
+
+```json
+{
+  "AuthZ":
+  {
+    "numPolicies":10,
+    "numSourceIP":10,
+    "numPaths":2
+  }
+}
+
 ```bash
-go run generate_policies.go generate.go -generate_policy="AuthorizationPolicy:1,numPolicies:10,numSourceIP:10,numPaths:2"
+go run generate_policies.go generate.go -configFile="config.json" > authZPolicy.yaml
 ```
 
-- This creates 10 AuthorizationPolicies which each contains 10 sourceIP's sources, and 2 paths operations
+- This creates 10 AuthorizationPolicies which each contains 10 sourceIP's sources, 2 paths operations, and places the policies in authZPolicy.yaml.
 
 ## Example 2
 
+- By creating a config file called config.json with the following data, and then running the following command:
+
+```json
+{
+  "AuthZ":
+  {
+    "numPolicies":1,
+    "numSourceIP":100,
+    "numPaths":100,
+    "numNamespaces":100
+  }
+}
+
 ```bash
-go run generate_policies.go generate.go -generate_policy="AuthorizationPolicy:1,numSourceIP:100,numPaths:100,numNamespaces:100"
+go run generate_policies.go generate.go -configFile="config.json" > authZPolicy.yaml
 ```
 
-- This creates 1 AuthorizationPolicy which contains 100 sourceIP's sources, 100 paths operations, and 100 namespaces sources
+- This creates 1 AuthorizationPolicy which contains 100 sourceIP's sources, 100 paths operations, 100 namespaces sources, and places the policy in authZPolicy.yaml.
 
 ## Example 3
+
+- By creating a config file called config.json with the following data, and then running the following command:
+
+```json
+{
+  "PeerAuthN":
+  {
+    "numPolicies":1,
+    "mtlsMode":"DISABLE"
+  }
+}
 
 ```bash
 go run generate_policies.go generate.go -generate_policy="PeerAuthentication:1,mtlsMode:DISABLE"
@@ -159,7 +297,7 @@ go run generate_policies.go generate.go -generate_policy="PeerAuthentication:1,m
 
 ## Cleanup
 
-To remove the policies applied navigate to the generate_policies folder and run the following command (updating "largePolicy.yaml" if applied a different .yaml file):
+To remove the policies applied navigate to the generate_policies folder and run the following command (update "largePolicy.yaml" if applied to a different .yaml file):
 
 ```bash
 kubectl delete -f largePolicy.yaml

--- a/perf/benchmark/security/generate_policies/generate.go
+++ b/perf/benchmark/security/generate_policies/generate.go
@@ -21,17 +21,17 @@ import (
 )
 
 type generator interface {
-	generate(action string, ruleMap map[string]int) *authzpb.Rule
+	generate(policyData SecurityPolicy) *authzpb.Rule
 }
 
 type operationGenerator struct {
 }
 
-func (operationGenerator) generate(_ string, ruleMap map[string]int) *authzpb.Rule {
+func (operationGenerator) generate(policyData SecurityPolicy) *authzpb.Rule {
 	rule := &authzpb.Rule{}
 	var listOperation []*authzpb.Rule_To
 
-	if numPaths := ruleMap["numPaths"]; numPaths > 0 {
+	if numPaths := policyData.AuthZ.NumPaths; numPaths > 0 {
 		paths := make([]string, numPaths)
 		for i := 0; i < numPaths; i++ {
 			paths[i] = fmt.Sprintf("/Invalid-path-%d", i)
@@ -50,14 +50,14 @@ func (operationGenerator) generate(_ string, ruleMap map[string]int) *authzpb.Ru
 type conditionGenerator struct {
 }
 
-func (conditionGenerator) generate(action string, ruleMap map[string]int) *authzpb.Rule {
+func (conditionGenerator) generate(policyData SecurityPolicy) *authzpb.Rule {
 	rule := &authzpb.Rule{}
 	var listCondition []*authzpb.Condition
 
-	if numValues := ruleMap["numValues"]; numValues > 0 {
+	if numValues := policyData.AuthZ.NumValues; numValues > 0 {
 		values := make([]string, numValues)
 		for i := 0; i < numValues; i++ {
-			if i == numValues-1 && action == "ALLOW" {
+			if i == numValues-1 && policyData.AuthZ.Action == "ALLOW" {
 				values[i] = "admin"
 			} else {
 				values[i] = "guest"
@@ -76,11 +76,11 @@ func (conditionGenerator) generate(action string, ruleMap map[string]int) *authz
 type sourceGenerator struct {
 }
 
-func (sourceGenerator) generate(_ string, ruleMap map[string]int) *authzpb.Rule {
+func (sourceGenerator) generate(policyData SecurityPolicy) *authzpb.Rule {
 	rule := &authzpb.Rule{}
 	var listSource []*authzpb.Rule_From
 
-	if numSourceIP := ruleMap["numSourceIP"]; numSourceIP > 0 {
+	if numSourceIP := policyData.AuthZ.NumSourceIP; numSourceIP > 0 {
 		sourceIPList := make([]string, numSourceIP)
 		for i := 0; i < numSourceIP; i++ {
 			sourceIPList[i] = fmt.Sprintf("0.0.%d.%d", i/256, i%256)
@@ -93,7 +93,7 @@ func (sourceGenerator) generate(_ string, ruleMap map[string]int) *authzpb.Rule 
 		listSource = append(listSource, source)
 	}
 
-	if numNamepaces := ruleMap["numNamespaces"]; numNamepaces > 0 {
+	if numNamepaces := policyData.AuthZ.NumNamespaces; numNamepaces > 0 {
 		namespaces := make([]string, numNamepaces)
 		for i := 0; i < numNamepaces; i++ {
 			namespaces[i] = fmt.Sprintf("Invalid-namespace-%d", i)
@@ -106,7 +106,7 @@ func (sourceGenerator) generate(_ string, ruleMap map[string]int) *authzpb.Rule 
 		listSource = append(listSource, source)
 	}
 
-	if numPrincipals := ruleMap["numPrincipals"]; numPrincipals > 0 {
+	if numPrincipals := policyData.AuthZ.NumPrincipals; numPrincipals > 0 {
 		principals := make([]string, numPrincipals)
 		for i := 0; i < numPrincipals; i++ {
 			principals[i] = fmt.Sprintf("cluster.local/ns/twopods-istio/sa/Invalid-%d", i)

--- a/perf/benchmark/security/generate_policies/generate.go
+++ b/perf/benchmark/security/generate_policies/generate.go
@@ -105,6 +105,19 @@ func (sourceGenerator) generate(_ string, ruleMap map[string]int) *authzpb.Rule 
 		}
 		listSource = append(listSource, source)
 	}
+
+	if numPrincipals := ruleMap["numPrincipals"]; numPrincipals > 0 {
+		principals := make([]string, numPrincipals)
+		for i := 0; i < numPrincipals; i++ {
+			principals[i] = fmt.Sprintf("cluster.local/ns/twopods-istio/sa/Invalid-%d", i)
+		}
+		source := &authzpb.Rule_From{
+			Source: &authzpb.Source{
+				Principals: principals,
+			},
+		}
+		listSource = append(listSource, source)
+	}
 	rule.From = listSource
 	return rule
 }

--- a/perf/benchmark/security/generate_policies/generate_policies.go
+++ b/perf/benchmark/security/generate_policies/generate_policies.go
@@ -128,7 +128,7 @@ func generateAuthorizationPolicy(action string, ruleToGenerator map[string]*rule
 	return yaml, nil
 }
 
-func generatePeerAuthentication(mtlsMode string, ruleToGenerator map[string]*ruleGenerator, policy *MyPolicy) (string, error) {
+func generatePeerAuthentication(mtlsMode string, policy *MyPolicy) (string, error) {
 	spec := &authzpb.PeerAuthentication{
 		Mtls: &authzpb.PeerAuthentication_MutualTLS{},
 	}
@@ -138,7 +138,7 @@ func generatePeerAuthentication(mtlsMode string, ruleToGenerator map[string]*rul
 	case "DISABLE":
 		spec.Mtls.Mode = authzpb.PeerAuthentication_MutualTLS_DISABLE
 	default:
-		return "", fmt.Errorf("Invalid mtlsMode: %s", mtlsMode)
+		return "", fmt.Errorf("invalid mtlsMode: %s", mtlsMode)
 	}
 
 	yaml, err := PolicyToYAML(policy, spec)
@@ -155,7 +155,7 @@ func generateRules(argumentMap map[string]string, ruleToGenerator map[string]*ru
 	case "AuthorizationPolicy":
 		return generateAuthorizationPolicy(argumentMap["action"], ruleToGenerator, policy, ruleMap)
 	case "PeerAuthentication":
-		return generatePeerAuthentication(argumentMap["mtlsMode"], ruleToGenerator, policy)
+		return generatePeerAuthentication(argumentMap["mtlsMode"], policy)
 	case "RequestAuthentication":
 		return "", fmt.Errorf("unimplemented")
 	default:
@@ -279,12 +279,12 @@ func main() {
 		return
 	}
 
-	policiesLeft := 0;
+	policiesLeft := 0
 	for _, numPolicy := range policyMap {
 		policiesLeft += numPolicy
 	}
 	if policiesLeft <= 0 {
-		fmt.Errorf("Invalid number of policies: %d", policiesLeft)
+		fmt.Errorf("invalid number of policies: %d", policiesLeft)
 	}
 
 	for policyType, numPolicy := range policyMap {

--- a/perf/benchmark/security/generate_policies/generate_policies.go
+++ b/perf/benchmark/security/generate_policies/generate_policies.go
@@ -284,7 +284,7 @@ func main() {
 		policiesLeft += numPolicy
 	}
 	if policiesLeft <= 0 {
-		fmt.Errorf("invalid number of policies: %d", policiesLeft)
+		fmt.Println(fmt.Errorf("invalid number of policies: %d", policiesLeft))
 	}
 
 	for policyType, numPolicy := range policyMap {

--- a/perf/benchmark/security/generate_policies/generate_policies.go
+++ b/perf/benchmark/security/generate_policies/generate_policies.go
@@ -47,7 +47,7 @@ type AuthorizationPolicy struct {
 	NumNamespaces int    `json:"numNamespaces"`
 	NumPaths      int    `json:"numPaths"`
 	NumPolicies   int    `json:"numPolicies"`
-	NumPrincipals int    `json:"numPrincipals`
+	NumPrincipals int    `json:"numPrincipals"`
 	NumSourceIP   int    `json:"numSourceIP"`
 	NumValues     int    `json:"numValues"`
 }
@@ -216,7 +216,7 @@ func generatePolicy(policyData SecurityPolicy, kind string, numPolicy int, total
 		testName := fmt.Sprintf("test-%s-%d", kind, i)
 		policyHeader := createPolicyHeader(policyData.Namespace, testName, kind)
 
-		rules, err := generateRules(policyData, policyHeader);
+		rules, err := generateRules(policyData, policyHeader)
 		if err != nil {
 			return 0, err
 		}
@@ -250,7 +250,10 @@ func main() {
 	}
 
 	policyData := SecurityPolicy{}
-	json.Unmarshal([]byte(jsonString), &policyData)
+	err := json.Unmarshal([]byte(jsonString), &policyData)
+	if err != nil {
+		fmt.Println(err)
+	}
 
 	policiesLeft := policyData.AuthZ.NumPolicies + policyData.PeerAuthN.NumPolicies
 	if policiesLeft <= 0 {


### PR DESCRIPTION
These code changes allow for generate_policies.go to generate PeerAuthN policies. This includes changes to the README.md which now explains how to generate AuthZ and peerAuthN policies.