### PR TITLE
Bump golang to 1.15.0

### DIFF
--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -25,7 +25,7 @@
 # Binary tools
 ################
 
-ARG GOLANG_IMAGE=golang:1.14.7
+ARG GOLANG_IMAGE=golang:1.15.0
 # hadolint ignore=DL3006
 FROM ${GOLANG_IMAGE} as binary_tools_context
 


### PR DESCRIPTION
Part of https://github.com/istio/istio/issues/24637
Blocker is merged https://github.com/istio/istio/pull/26387

PR to update in main repo https://github.com/istio/istio/pull/26404

https://blog.golang.org/go1.15