### PR TITLE
Use kube DNS pod/svc name via env variable

### DIFF
--- a/perf/benchmark/setup_test.sh
+++ b/perf/benchmark/setup_test.sh
@@ -26,6 +26,7 @@ cd "${WD}"
 NAMESPACE="${NAMESPACE:-twopods}"
 LOAD_GEN_TYPE="${LOAD_GEN_TYPE:-fortio}"
 DNS_DOMAIN=${DNS_DOMAIN:?"DNS_DOMAIN should be like v104.qualistio.org or local"}
+KUBE_DNS="${KUBE_DNS:-kube-dns}"
 TMPDIR=${TMPDIR:-${WD}/tmp}
 RBAC_ENABLED="false"
 SERVER_REPLICA="${SERVER_REPLICA:-1}"
@@ -39,11 +40,11 @@ mkdir -p "${TMPDIR}"
 
 # Get pod ip range, there must be a better way, but this works.
 function pod_ip_range() {
-    kubectl get pods --namespace kube-system -o wide | grep kube-dns | awk '{print $6}'|head -1 | awk -F '.' '{printf "%s.%s.0.0/16\n", $1, $2}'
+    kubectl get pods --namespace kube-system -o wide | grep "${KUBE_DNS}" | awk '{print $6}'|head -1 | awk -F '.' '{printf "%s.%s.0.0/16\n", $1, $2}'
 }
 
 function svc_ip_range() {
-    kubectl -n kube-system get svc kube-dns --no-headers | awk '{print $3}' | awk -F '.' '{printf "%s.%s.0.0/16\n", $1, $2}'
+    kubectl -n kube-system get svc "${KUBE_DNS}" --no-headers | awk '{print $3}' | awk -F '.' '{printf "%s.%s.0.0/16\n", $1, $2}'
 }
 
 function run_test() {


### PR DESCRIPTION
In `perf/bechmark/setup_test.sh`, the kube DNS name is hardcoded to kube-dns. Since k8s 1.13 uses coredns as a default and has different pod and service name so the script does not with with coredns based systems.

This patch makes possible to use both. The default stays with kube-dns but if you want to use coredns, use

`export KUBE_DNS=coredns` 