### PR TITLE
Fix upgrade SOURCE_TAG issue

### DIFF
--- a/upgrade/run_upgrade_test.sh
+++ b/upgrade/run_upgrade_test.sh
@@ -49,9 +49,6 @@ export TARGET_LINUX_TAR_SUFFIX=${TARGET_LINUX_TAR_SUFFIX:-"linux-amd64.tar.gz"}
 # to downgrade to.
 export TEST_SCENARIO=${TEST_SCENARIO:-"upgrade-downgrade"}
 
-# obtain the actual source tag
-SOURCE_TAG=$(curl -s https://storage.googleapis.com/istio-build/dev/"$SOURCE_TAG")
-
 function get_git_sha() {
   local url_path=${1}
   local tag=${2}


### PR DESCRIPTION
Error log:

```
+ SOURCE_TAG='<?xml version='\''1.0'\'' encoding='\''UTF-8'\''?><Error><Code>NoSuchKey</Code><Message>The specified key does not exist.</Message><Details>No such object: istio-build/dev/1.6_latest</Details></Error>'
+ get_git_sha https://storage.googleapis.com/istio-build/dev '<?xml version='\''1.0'\'' encoding='\''UTF-8'\''?><Error><Code>NoSuchKey</Code><Message>The specified key does not exist.</Message><Details>No such object: istio-build/dev/1.6_latest</Details></Error>'
+ local url_path=https://storage.googleapis.com/istio-build/dev
+ local 'tag=<?xml version='\''1.0'\'' encoding='\''UTF-8'\''?><Error><Code>NoSuchKey</Code><Message>The specified key does not exist.</Message><Details>No such object: istio-build/dev/1.6_latest</Details></Error>'
+ GIT_SHA=
+ LINUX_TAR_SUFFIX=
+ [[ <?xml version='1.0' encoding='UTF-8'?><Error><Code>NoSuchKey</Code><Message>The specified key does not exist.</Message><Details>No such object: istio-build/dev/1.6_latest</Details></Error> =~ latest ]]
++ echo '<?xml version='\''1.0'\'' encoding='\''UTF-8'\''?><Error><Code>NoSuchKey</Code><Message>The specified key does not exist.</Message><Details>No such object: istio-build/dev/1.6_latest</Details></Error>'
++ cut -d_ -f1
+ release_version='<?xml version='\''1.0'\'' encoding='\''UTF-8'\''?><Error><Code>NoSuchKey</Code><Message>The specified key does not exist.</Message><Details>No such object: istio-build/dev/1.6'
+ [[ <?xml version='1.0' encoding='UTF-8'?><Error><Code>NoSuchKey</Code><Message>The specified key does not exist.</Message><Details>No such object: istio-build/dev/1.6 < 1.6 ]]
++ curl 'https://storage.googleapis.com/istio-build/dev/<?xml version='\''1.0'\'' encoding='\''UTF-8'\''?><Error><Code>NoSuchKey</Code><Message>The specified key does not exist.</Message><Details>No such object: istio-build/dev/1.6-dev'
```