### PR TITLE
Fixes typo in cue-gen all? version: v1alpha1 string default

### DIFF
--- a/cmd/cue-gen/doc.cue
+++ b/cmd/cue-gen/doc.cue
@@ -48,7 +48,7 @@ all?: {
 	// title overrides the $description associated with a directory.
 	title: string
 
-	version: =~#"^v\d."# | *"v1aplha1"
+	version: =~#"^v\d."# | *"v1alpha1"
 }
 
 // directories is a map of directories, relative to the root, for which to


### PR DESCRIPTION
Simple typo. s/aplha/alpha.