### PR TITLE
Update bucket resolution to make it suitable for the actual perf number

### DIFF
--- a/perf/benchmark/runner/runner.py
+++ b/perf/benchmark/runner/runner.py
@@ -132,7 +132,7 @@ class Fortio:
         self.protocol_mode = protocol_mode
         self.ns = NAMESPACE
         # bucket resolution in seconds
-        self.r = "0.00005"
+        self.r = "0.1"
         self.telemetry_mode = telemetry_mode
         self.perf_record = perf_record
         self.server = pod_info("-lapp=" + server, namespace=self.ns)

--- a/perf/benchmark/runner/runner.py
+++ b/perf/benchmark/runner/runner.py
@@ -132,7 +132,7 @@ class Fortio:
         self.protocol_mode = protocol_mode
         self.ns = NAMESPACE
         # bucket resolution in seconds
-        self.r = "0.1"
+        self.r = "0.001"
         self.telemetry_mode = telemetry_mode
         self.perf_record = perf_record
         self.server = pod_info("-lapp=" + server, namespace=self.ns)


### PR DESCRIPTION
perf number is around 10ms +- (x)ms , so the appropriate resolution should be set to 1ms

Other concerns:
(1) whether should I set offset here: no, since we have min number which is approaching to 0.