### PR TITLE
Add the user in docker-entrypoint.sh

### DIFF
--- a/docker/build-tools/docker-entrypoint.sh
+++ b/docker/build-tools/docker-entrypoint.sh
@@ -47,6 +47,10 @@ if [[ -f /config-copy/.docker/plaintext-passwords.json ]]; then
 	mv /config-copy/.docker/config-tmp.json /config-copy/.docker/config.json
 fi
 
+# Add user based upon passed UID. this means Istio need no longer host mount /etc/passwd
+# nor /etc/group
+su-exec 0:0 useradd --uid "${uid}" --system user
+
 # Set ownership of /home to UID:GID
 su-exec 0:0 chown "${uid}":"${gid}" /home
 


### PR DESCRIPTION
I may need to had the GID on linux, although on MacOS this is not
necessary.