### PR TITLE
Remove policy and telemetry fields in overlay

### DIFF
--- a/perf/istio-install/istioctl_profiles/default-overlay.yaml
+++ b/perf/istio-install/istioctl_profiles/default-overlay.yaml
@@ -27,30 +27,6 @@ spec:
         env:
         - name: ISTIO_META_REQUESTED_NETWORK_VIEW
           value: external
-    policy:
-      enabled: false
-    telemetry:
-      enabled: false
-      k8s:
-        hpaSpec:
-          maxReplicas: 15
-          minReplicas: 1
-          metrics:
-            - resource:
-                name: cpu
-                targetAverageUtilization: 80
-              type: Resource
-          scaleTargetRef:
-            apiVersion: apps/v1
-            kind: Deployment
-            name: istio-telemetry
-        resources:
-          limits:
-            cpu: 5800m
-            memory: 5G
-          requests:
-            cpu: 3800m
-            memory: 4G
     pilot:
       enabled: true
       k8s:


### PR DESCRIPTION
installation error for latest 1.8, remove deprecated fields.