### PR TITLE
Remove telemetry field in v1alpha1.IstioComponentSetSpec

### DIFF
--- a/perf/benchmark/configs/istio/none/installation.yaml
+++ b/perf/benchmark/configs/istio/none/installation.yaml
@@ -1,9 +1,6 @@
 apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
 spec:
-  components:
-    telemetry:
-      enabled: false
   values:
     telemetry:
       enabled: false

--- a/perf/benchmark/configs/istio/plaintext/installation.yaml
+++ b/perf/benchmark/configs/istio/plaintext/installation.yaml
@@ -1,9 +1,6 @@
 apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
 spec:
-  components:
-    telemetry:
-      enabled: false
   values:
     telemetry:
       enabled: false


### PR DESCRIPTION
Fix errors:

```
/tools/perf/benchmark/configs/istio/none/installation.yaml'
Forwarding from 127.0.0.1:9076 -> 9076
Forwarding from [::1]:9076 -> 9076
Error: failed to install manifests: unknown field "telemetry" in v1alpha1.IstioComponentSetSpec:
```