### PR TITLE
[release-1.7] Update Golang to 1.14.9

### DIFF
--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -25,7 +25,7 @@
 # Binary tools
 ################
 
-ARG GOLANG_IMAGE=golang:1.14.7
+ARG GOLANG_IMAGE=golang:1.14.9
 # hadolint ignore=DL3006
 FROM ${GOLANG_IMAGE} as binary_tools_context
 


### PR DESCRIPTION
Not sure if we want to move up, but 1.14.8 does have security fixes:
```
go1.14.8 (released 2020/09/01) includes security fixes to the net/http/cgi and net/http/fcgi packages. See the Go 1.14.8 milestone on our issue tracker for details.
```