### PR TITLE
[release-1.6] Update Golang to 1.14.9

### DIFF
--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -25,7 +25,7 @@
 # Binary tools
 ################
 
-FROM golang:1.14.7 as binary_tools_context
+FROM golang:1.14.9 as binary_tools_context
 
 # Istio tools SHA that we use for this image
 ARG ISTIO_TOOLS_SHA


### PR DESCRIPTION
Not sure if we want to move up, but 1.14.8 does have security fixes:
```
go1.14.8 (released 2020/09/01) includes security fixes to the net/http/cgi and net/http/fcgi packages. See the Go 1.14.8 milestone on our issue tracker for details.
```