### PR TITLE
Add modify check

### DIFF
--- a/cmd/gen-release-notes/main.go
+++ b/cmd/gen-release-notes/main.go
@@ -226,7 +226,7 @@ func populateTemplate(filepath string, filename string, releaseNotes []Note) (st
 }
 
 func getNewFilesInBranch(oldBranch string, newBranch string, path string, notesSubpath string) ([]string, error) {
-	cmd := fmt.Sprintf("cd %s; git diff-tree -r --diff-filter=AR --name-only --relative=%s '%s' '%s'", path, notesSubpath, oldBranch, newBranch)
+	cmd := fmt.Sprintf("cd %s; git diff-tree -r --diff-filter=AMR --name-only --relative=%s '%s' '%s'", path, notesSubpath, oldBranch, newBranch)
 	fmt.Printf("Executing: %s\n", cmd)
 
 	out, err := exec.Command("bash", "-c", cmd).CombinedOutput()


### PR DESCRIPTION
This PR changes the file search to look for modified files as well as added/renamed. This will: 

* Allow the release notes test to check for modified files when looking for release notes
* Mean that when generating release notes in between releases, modified files are treated as new release notes entries.