### PR TITLE
Remove python version hard requirement, depend on what build-tools provide

### DIFF
--- a/perf/benchmark/Pipfile
+++ b/perf/benchmark/Pipfile
@@ -11,5 +11,3 @@ matplotlib = "*"
 PyYAML = "*"
 requests = "*"
 
-[requires]
-python_version = "3.8"


### PR DESCRIPTION
Fix: 
```
Warning: Python 3.8 was not found on your system…
Neither 'pyenv' nor 'asdf' could be found to install Python.
You can specify specific versions of Python with:```
