### PR TITLE
add release flags

### DIFF
--- a/cmd/gen-release-notes/README.md
+++ b/cmd/gen-release-notes/README.md
@@ -28,7 +28,7 @@ go build
 * `--oldBranch` -- indicates the branch (or tag) to compare against
 * `--newBranch` -- indicates the branch (or tag) containing new release notes
 * `--oldRelease` -- indicates the name of the release being upgrade from
-* `--newRelease` -- indicates the name of the new release. 
+* `--newRelease` -- indicates the name of the new release.
 
 ## Templates
 

--- a/cmd/gen-release-notes/README.md
+++ b/cmd/gen-release-notes/README.md
@@ -27,6 +27,8 @@ go build
 * (optional) `--validateOnly` -- indicates to perform validation but not release notes generation.
 * `--oldBranch` -- indicates the branch (or tag) to compare against
 * `--newBranch` -- indicates the branch (or tag) containing new release notes
+* `--oldRelease` -- indicates the name of the release being upgrade from
+* `--newRelease` -- indicates the name of the new release. 
 
 ## Templates
 

--- a/cmd/gen-release-notes/templates/minorReleaseNotes.md
+++ b/cmd/gen-release-notes/templates/minorReleaseNotes.md
@@ -1,6 +1,6 @@
 ---
 title: Change Notes
-description: Istio x.y release notes.
+description: Istio <!--newRelease--> release notes.
 weight: 10
 ---
 

--- a/cmd/gen-release-notes/templates/releaseNotes.md
+++ b/cmd/gen-release-notes/templates/releaseNotes.md
@@ -1,19 +1,19 @@
 ---
-title: Announcing Istio x.y.z
-linktitle: x.y.z
+title: Announcing Istio <!--newRelease-->
+linktitle: <!--newRelease-->
 subtitle: Patch Release
-description: Istio x.y.z patch release.
+description: Istio <!--newRelease--> patch release.
 publishdate: 2020-07-29
-release: x.y.z
+release: <!--newRelease-->
 aliases:
-    - /news/announcing-x.y.z
+    - /news/announcing-<!--newRelease-->
 ---
 
 {{< warning >}}
 This is an automatically generated rough draft of the release notes and has not yet been reviewed.
 {{< /warning >}}
 
-This release contains bug fixes to improve robustness. This release note describes what’s different between Istio x.y.(z-1) and Istio x.y.z
+This release contains bug fixes to improve robustness. This release note describes what’s different between Istio <!--oldRelease--> and Istio <!--newRelease-->
 
 {{< relnote >}}
 

--- a/cmd/gen-release-notes/templates/upgradeNotes.md
+++ b/cmd/gen-release-notes/templates/upgradeNotes.md
@@ -1,6 +1,6 @@
 ---
 title: Upgrade Notes
-description: Important changes to consider when upgrading to Istio x.y.
+description: Important changes to consider when upgrading to Istio <!--newRelease-->.
 weight: 20
 ---
 
@@ -8,9 +8,9 @@ weight: 20
 This is an automatically generated rough draft of the release notes and has not yet been reviewed.
 {{< /warning >}}
 
-When you upgrade from Istio x.(y-1).z to Istio x.y.z, you need to consider the changes on this page.
-These notes detail the changes which purposefully break backwards compatibility with Istio x.(y-1).z.
+When you upgrade from Istio <!--oldRelease--> to Istio <!--newRelease-->, you need to consider the changes on this page.
+These notes detail the changes which purposefully break backwards compatibility with Istio <!--oldRelease-->.
 The notes also mention changes which preserve backwards compatibility while introducing new behavior.
-Changes are only included if the new behavior would be unexpected to a user of Istio x.(y-z).z.
+Changes are only included if the new behavior would be unexpected to a user of Istio <!--oldRelease-->.
 
 <!-- upgradeNotes -->


### PR DESCRIPTION
This adds two flags to the release notes tooling, oldRelease and newRelease and updates the templates to match. Without these flags, the output stays the same as it was previously. With these flags, the templates get updated with the actual release names. If this flag is omitted, the output is the same as it was previously. 

This can be used like: 

```
./gen-release-notes --notes ../../../istio/releasenotes/notes/ --newBranch release-1.8 --oldBranch master --oldRelease "1.7" --newRelease "1.8.alpha.0" --outDir out
```