### PR TITLE
prometheus: add more customization to deployment

### DIFF
--- a/perf/istio-install/base/templates/prometheus-install.yaml
+++ b/perf/istio-install/base/templates/prometheus-install.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.prometheus.deploy }}
+{{- if .Values.storageclass.deploy }}
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
@@ -8,6 +9,7 @@ parameters:
 provisioner: kubernetes.io/gce-pd
 reclaimPolicy: Delete
 volumeBindingMode: Immediate
+{{- end}}
 ---
 # Source: prometheus-operator/templates/prometheus.yaml
 apiVersion: monitoring.coreos.com/v1
@@ -42,7 +44,7 @@ spec:
       sidecar.istio.io/inject: "false"
   resources:
     requests:
-      memory: 32Gi
+      memory: {{ $.Values.prometheus.memory }}
   securityContext:
     fsGroup: 2000
     runAsNonRoot: true
@@ -54,7 +56,7 @@ spec:
           - ReadWriteOnce
         resources:
           requests:
-            storage: 500Gi
+            storage: {{ $.Values.prometheus.storage }}
         storageClassName: ssd
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/perf/istio-install/base/values.yaml
+++ b/perf/istio-install/base/values.yaml
@@ -1,6 +1,11 @@
 prometheus:
   enabled: true
   deploy: true
+  memory: 32Gi
+  storage: 500Gi
+
+storageclass:
+  deploy: true
 
 domain: v103.qualistio.org
 


### PR DESCRIPTION
This patch helps to deploy Istio benchmarking tool (`perf/benchmark/setup_test.sh`) to other than GCP k8s cluster by making the Promethus more configurable via values.yaml. 

The new knobs are
- strorageclass:deploy - able to skip GCP specific storage classs
- prometheus:memory - able to tune promethus memory requirements
- prometheus:storage - able to tune promethus storage requirements

This batch won't change the default behavior.