### PR TITLE
Remove helm dependency from dual control plane upgrade downgrade tests

### DIFF
--- a/upgrade_downgrade/test_dual_control_plane_upgrade_downgrade.sh
+++ b/upgrade_downgrade/test_dual_control_plane_upgrade_downgrade.sh
@@ -20,8 +20,6 @@ WD=$(dirname "$0")
 WD=$(cd "$WD" || exit; pwd)
 ROOT=$(dirname "$WD")
 
-command -v helm >/dev/null 2>&1 || { echo >&2 "helm must be installed, aborting."; exit 1; }
-
 ISTIO_NAMESPACE="istio-system"
 # Maximum % of 503 response that cannot exceed
 MAX_503_PCT_FOR_PASS="15"


### PR DESCRIPTION
Does not seem like helm is actually required to run this test.