### PR TITLE
Reduce 503 error threshold on dual control plane upgrade downgrade tests

### DIFF
--- a/upgrade_downgrade/test_dual_control_plane_upgrade_downgrade.sh
+++ b/upgrade_downgrade/test_dual_control_plane_upgrade_downgrade.sh
@@ -22,7 +22,7 @@ ROOT=$(dirname "$WD")
 
 ISTIO_NAMESPACE="istio-system"
 # Maximum % of 503 response that cannot exceed
-MAX_503_PCT_FOR_PASS="15"
+MAX_503_PCT_FOR_PASS="5"
 # Maximum % of connection refused that cannot exceed
 # Set it to high value so it fails for explicit sidecar issues
 MAX_CONNECTION_ERR_FOR_PASS="30"


### PR DESCRIPTION
From local testing against a kind cluster and checking the prow logs for existing tests, on a successful run, the 503 rate hovers around <1%. Think these tests lose any signal if we allow for 15% of requests to fail during upgrade.

(side note: does anybody know why it was set that high to begin with?)