### PR TITLE
Add option to run upgrade_downgrade tests in kind

### DIFF
--- a/upgrade_downgrade/kind.sh
+++ b/upgrade_downgrade/kind.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+# Copyright Istio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+function cleanup_kind_cluster() {
+  NAME=istio-upgrade-testing
+  kind delete cluster --name "${NAME}" -v9 || true
+}
+
+function setup_kind_cluster() {
+  NAME=istio-upgrade-testing
+
+  echo "Deleting previous KinD cluster with name=${NAME}"
+  if ! (kind delete cluster --name="${NAME}" -v9) > /dev/null; then
+    echo "No existing kind cluster with name ${NAME}. Continue..."
+  fi
+
+  # note: don't need private registry for upgrade tests, just
+  # create kind cluster with default config
+  kind create cluster --name ${NAME}
+}
+
+# metallb installation so we can access cluster through ingress service
+# taken from istio/istio/prow scripts
+cidr_to_ips() {
+    CIDR="$1"
+    python3 - <<EOF
+from ipaddress import IPv4Network; [print(str(ip)) for ip in IPv4Network('$CIDR').hosts()]
+EOF
+}
+
+metallb() {
+  kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.9.3/manifests/namespace.yaml
+  kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.9.3/manifests/metallb.yaml
+  kubectl create secret generic -n metallb-system memberlist --from-literal=secretkey="$(openssl rand -base64 128)" || true
+
+  if [ -z "${METALLB_IPS[*]}" ]; then
+    # Take IPs from the end of the docker kind network subnet to use for MetalLB IPs
+    DOCKER_KIND_SUBNET="$(docker inspect kind | jq '.[0].IPAM.Config[0].Subnet' -r)"
+    METALLB_IPS=()
+    while read -r ip; do
+      METALLB_IPS+=("$ip")
+    done < <(cidr_to_ips "$DOCKER_KIND_SUBNET" | tail -n 100)
+  fi
+
+  # Give this cluster of those IPs
+  RANGE="${METALLB_IPS[1]}-${METALLB_IPS[9]}"
+  METALLB_IPS=("${METALLB_IPS[@]:10}")
+
+  echo 'apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: metallb-system
+  name: config
+data:
+  config: |
+    address-pools:
+    - name: default
+      protocol: layer2
+      addresses:
+      - '"$RANGE" | kubectl apply -f -
+}

--- a/upgrade_downgrade/run_upgrade_downgrade_test.sh
+++ b/upgrade_downgrade/run_upgrade_downgrade_test.sh
@@ -100,6 +100,10 @@ function download_untar_istio_release() {
 
 # shellcheck disable=SC1090
 source "${ROOT}/bin/setup_cluster.sh"
+
+# shellcheck disable=SC1090
+source "${ROOT}/upgrade_downgrade/kind.sh"
+
 # Set to any non-empty value to use kubectl configured cluster instead of mason provisioned cluster.
 UPGRADE_DOWNGRADE_TEST_LOCAL="${UPGRADE_DOWNGRADE_TEST_LOCAL:-""}"
 
@@ -111,13 +115,17 @@ download_untar_istio_release "${TARGET_RELEASE_PATH}" "${TARGET_TAG}" "${TARGET_
 
 # Check https://github.com/istio/test-infra/blob/master/boskos/resources.yaml
 # for existing resources types
-if [[ "${UPGRADE_DOWNGRADE_TEST_LOCAL}" = "" ]]; then
+if [ "${UPGRADE_DOWNGRADE_TEST_LOCAL}" = "boskos" ] || [ "${UPGRADE_DOWNGRADE_TEST_LOCAL}" = "" ]; then
     export RESOURCE_TYPE="${RESOURCE_TYPE:-gke-e2e-test}"
     export OWNER='upgrade-downgrade-tests'
     export USE_MASON_RESOURCE="${USE_MASON_RESOURCE:-True}"
     export CLEAN_CLUSTERS="${CLEAN_CLUSTERS:-True}"
 
     setup_e2e_cluster
+elif [[ "${UPGRADE_DOWNGRADE_TEST_LOCAL}" = "kind" ]]; then
+    echo "Spinning up kind cluster and running upgrade tests against it..."
+    setup_kind_cluster
+    metallb
 else
     echo "Running against cluster that kubectl is configured for."
 fi


### PR DESCRIPTION
Gives the option to run the upgrade tests in kind with the `UPGRADE_DOWNGRADE_TEST_LOCAL=kind` flag. Boskos will still be used by default in Prow with this PR, but this allows us to move towards running this test in kind on Prow as well.