### PR TITLE
Update Golang to pick up CVE

### DIFF
--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -25,7 +25,7 @@
 # Binary tools
 ################
 
-ARG GOLANG_IMAGE=golang:1.15.3
+ARG GOLANG_IMAGE=golang:1.15.5
 # hadolint ignore=DL3006
 FROM ${GOLANG_IMAGE} as binary_tools_context
 


### PR DESCRIPTION
Update Golang to 1.15.5

Waiting on Docker image to be available before making non-draft.