### PR TITLE
Add promoted to release notes

### DIFF
--- a/cmd/gen-release-notes/templates/minorReleaseNotes.md
+++ b/cmd/gen-release-notes/templates/minorReleaseNotes.md
@@ -12,6 +12,7 @@ This is an automatically generated rough draft of the release notes and has not 
 
 ## Traffic Management
 
+<!-- releaseNotes area:traffic-management action:Promoted -->
 <!-- releaseNotes area:traffic-management action:Improved -->
 <!-- releaseNotes area:traffic-management action:Updated -->
 <!-- releaseNotes area:traffic-management action:Added -->
@@ -24,6 +25,7 @@ This is an automatically generated rough draft of the release notes and has not 
 
 ## Security
 
+<!-- releaseNotes area:security action:Promoted -->
 <!-- releaseNotes area:security action:Improved -->
 <!-- releaseNotes area:security action:Updated -->
 <!-- releaseNotes area:security action:Added -->
@@ -36,6 +38,7 @@ This is an automatically generated rough draft of the release notes and has not 
 
 ## Telemetry
 
+<!-- releaseNotes area:telemetry action:Promoted -->
 <!-- releaseNotes area:telemetry action:Improved -->
 <!-- releaseNotes area:telemetry action:Updated -->
 <!-- releaseNotes area:telemetry action:Added -->
@@ -48,6 +51,7 @@ This is an automatically generated rough draft of the release notes and has not 
 
 ## Installation
 
+<!-- releaseNotes area:installation action:Promoted -->
 <!-- releaseNotes area:installation action:Improved -->
 <!-- releaseNotes area:installation action:Updated -->
 <!-- releaseNotes area:installation action:Added -->
@@ -60,6 +64,7 @@ This is an automatically generated rough draft of the release notes and has not 
 
 ## istioctl
 
+<!-- releaseNotes area:istioctl action:Promoted -->
 <!-- releaseNotes area:istioctl action:Improved -->
 <!-- releaseNotes area:istioctl action:Updated -->
 <!-- releaseNotes area:istioctl action:Added -->
@@ -72,6 +77,7 @@ This is an automatically generated rough draft of the release notes and has not 
 
 ## Documentation changes
 
+<!-- releaseNotes area:documentation action:Promoted -->
 <!-- releaseNotes area:documentation action:Improved -->
 <!-- releaseNotes area:documentation action:Updated -->
 <!-- releaseNotes area:documentation action:Added -->

--- a/cmd/gen-release-notes/templates/releaseNotes.md
+++ b/cmd/gen-release-notes/templates/releaseNotes.md
@@ -19,6 +19,7 @@ This release contains bug fixes to improve robustness. This release note describ
 
 # Changes
 
+<!-- releaseNotes action:Promoted -->
 <!-- releaseNotes action:Improved -->
 <!-- releaseNotes action:Updated -->
 <!-- releaseNotes action:Added -->


### PR DESCRIPTION
This adds the action "Promoted" to the release notes templates. 

FYI @GregHanson