### PR TITLE
Add ingressgateway perf number to dashboard

### DIFF
--- a/perf/benchmark/configs/run_perf_test.conf
+++ b/perf/benchmark/configs/run_perf_test.conf
@@ -1,5 +1,5 @@
 none=true
-none_tcp=true
+none_tcp=false
 plaintext=true
 telemetryv2_sd_full=true
 telemetryv2_sd_full_accesslogpolicy=false

--- a/perf_dashboard/benchmarks/templates/cpu_vs_conn.html
+++ b/perf_dashboard/benchmarks/templates/cpu_vs_conn.html
@@ -103,6 +103,18 @@
           </div>
         </div>
       </div>
+        <div class="row">
+        <div class="col-lg-6">
+          <div class="card">
+            <div class="card-header d-flex align-items-center">
+              <h4>Ingressgateway: {{ current_release|first }} CPUs, 1000QPS over 240 seconds</h4>
+            </div>
+            <div class="card-body">
+              <canvas id="cpu-ingressgw-conn-release"></canvas>
+            </div>
+          </div>
+        </div>
+      </div>
 
       <div class="row">
         <div class="col-lg-12">
@@ -150,6 +162,18 @@
           </div>
         </div>
       </div>
+        <div class="row">
+        <div class="col-lg-6">
+          <div class="card">
+            <div class="card-header d-flex align-items-center">
+              <h4>Ingressgateway: CPU usage, 1000QPS over 240 seconds</h4>
+            </div>
+            <div class="card-body">
+              <canvas id="cpu-ingressgw-conn-master"></canvas>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
 </section>
 {% endblock page_content %}
@@ -179,6 +203,14 @@
         cpu_server_v2_sd_nologging_nullvm_both = {{ cpu_server_v2_sd_nologging_nullvm_both|safe }}
         cpu_server_v2_sd_full_nullvm_both = {{ cpu_server_v2_sd_full_nullvm_both|safe }}
 
+        cpu_ingressgw_none_mtls_base = {{ cpu_ingressgw_none_mtls_base|safe }}
+        cpu_ingressgw_none_mtls_both = {{ cpu_ingressgw_none_mtls_both|safe }}
+        cpu_ingressgw_none_plaintext_both = {{ cpu_ingressgw_none_plaintext_both|safe }}
+        cpu_ingressgw_v2_stats_nullvm_both = {{ cpu_ingressgw_v2_stats_nullvm_both|safe }}
+        cpu_ingressgw_v2_stats_wasm_both = {{ cpu_ingressgw_v2_stats_wasm_both|safe }}
+        cpu_ingressgw_v2_sd_nologging_nullvm_both = {{ cpu_ingressgw_v2_sd_nologging_nullvm_both|safe }}
+        cpu_ingressgw_v2_sd_full_nullvm_both = {{ cpu_ingressgw_v2_sd_full_nullvm_both|safe }}
+
         cpu_client_none_mtls_base_master = {{ cpu_client_none_mtls_base_master|safe }}
         cpu_client_none_mtls_both_master = {{ cpu_client_none_mtls_both_master|safe }}
         cpu_client_none_plaintext_both_master = {{ cpu_client_none_plaintext_both_master|safe }}
@@ -194,6 +226,14 @@
         cpu_server_v2_stats_wasm_both_master = {{ cpu_server_v2_stats_wasm_both_master|safe }}
         cpu_server_v2_sd_nologging_nullvm_both_master = {{ cpu_server_v2_sd_nologging_nullvm_both_master| safe }}
         cpu_server_v2_sd_full_nullvm_both_master = {{ cpu_server_v2_sd_full_nullvm_both_master|safe }}
+
+        cpu_ingressgw_none_mtls_base_master = {{ cpu_ingressgw_none_mtls_base_master|safe }}
+        cpu_ingressgw_none_mtls_both_master = {{ cpu_ingressgw_none_mtls_both_master|safe }}
+        cpu_ingressgw_none_plaintext_both_master = {{ cpu_ingressgw_none_plaintext_both_master|safe }}
+        cpu_ingressgw_v2_stats_nullvm_both_master = {{ cpu_ingressgw_v2_stats_nullvm_both_master|safe }}
+        cpu_ingressgw_v2_stats_wasm_both_master = {{ cpu_ingressgw_v2_stats_wasm_both_master|safe }}
+        cpu_ingressgw_v2_sd_nologging_nullvm_both_master = {{ cpu_ingressgw_v2_sd_nologging_nullvm_both_master| safe }}
+        cpu_ingressgw_v2_sd_full_nullvm_both_master = {{ cpu_ingressgw_v2_sd_full_nullvm_both_master|safe }}
     </script>
 {% endblock page_data %}
 

--- a/perf_dashboard/benchmarks/templates/cpu_vs_conn.html
+++ b/perf_dashboard/benchmarks/templates/cpu_vs_conn.html
@@ -150,6 +150,7 @@
           </div>
         </div>
       </div>
+    </div>
 </section>
 {% endblock page_content %}
 

--- a/perf_dashboard/benchmarks/templates/cpu_vs_conn.html
+++ b/perf_dashboard/benchmarks/templates/cpu_vs_conn.html
@@ -103,18 +103,6 @@
           </div>
         </div>
       </div>
-        <div class="row">
-        <div class="col-lg-6">
-          <div class="card">
-            <div class="card-header d-flex align-items-center">
-              <h4>Ingressgateway: {{ current_release|first }} CPUs, 1000QPS over 240 seconds</h4>
-            </div>
-            <div class="card-body">
-              <canvas id="cpu-ingressgw-conn-release"></canvas>
-            </div>
-          </div>
-        </div>
-      </div>
 
       <div class="row">
         <div class="col-lg-12">
@@ -162,19 +150,6 @@
           </div>
         </div>
       </div>
-        <div class="row">
-        <div class="col-lg-6">
-          <div class="card">
-            <div class="card-header d-flex align-items-center">
-              <h4>Ingressgateway: CPU usage, 1000QPS over 240 seconds</h4>
-            </div>
-            <div class="card-body">
-              <canvas id="cpu-ingressgw-conn-master"></canvas>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
 </section>
 {% endblock page_content %}
 

--- a/perf_dashboard/benchmarks/templates/cpu_vs_qps.html
+++ b/perf_dashboard/benchmarks/templates/cpu_vs_qps.html
@@ -80,7 +80,8 @@
                 <div class="line"></div>
           </form>
         </div>
-    </div>
+      </div>
+
       <div class="row">
         <div class="col-lg-6">
           <div class="card">
@@ -99,6 +100,19 @@
             </div>
             <div class="card-body">
               <canvas id="cpu-server-qps-release"></canvas>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-lg-6">
+          <div class="card">
+            <div class="card-header d-flex align-items-center">
+              <h4>Ingressgateway: {{ current_release|first }} CPUs, 16 connections over 240 seconds</h4>
+            </div>
+            <div class="card-body">
+              <canvas id="cpu-ingressgw-qps-release"></canvas>
             </div>
           </div>
         </div>
@@ -128,7 +142,8 @@
                 </form>
         </div>
     </div>
-      <div class="row">
+
+        <div class="row">
         <div class="col-lg-6">
           <div class="card">
             <div class="card-header d-flex align-items-center">
@@ -150,6 +165,20 @@
           </div>
         </div>
       </div>
+
+        <div class="row">
+        <div class="col-lg-6">
+          <div class="card">
+            <div class="card-header d-flex align-items-center">
+              <h4>Ingressgateway: CPUs, 16 connections over 240 seconds</h4>
+            </div>
+            <div class="card-body">
+              <canvas id="cpu-ingressgw-qps-master"></canvas>
+            </div>
+          </div>
+        </div>
+      </div>
+
     </div>
 </section>
 {% endblock page_content %}
@@ -179,6 +208,14 @@
         cpu_server_v2_sd_nologging_nullvm_both = {{ cpu_server_v2_sd_nologging_nullvm_both|safe }}
         cpu_server_v2_sd_full_nullvm_both = {{ cpu_server_v2_sd_full_nullvm_both|safe }}
 
+        cpu_ingressgw_none_mtls_base = {{ cpu_ingressgw_none_mtls_base|safe }}
+        cpu_ingressgw_none_mtls_both = {{ cpu_ingressgw_none_mtls_both|safe }}
+        cpu_ingressgw_none_plaintext_both = {{ cpu_ingressgw_none_plaintext_both|safe }}
+        cpu_ingressgw_v2_stats_nullvm_both = {{ cpu_ingressgw_v2_stats_nullvm_both|safe }}
+        cpu_ingressgw_v2_stats_wasm_both = {{ cpu_ingressgw_v2_stats_wasm_both|safe }}
+        cpu_ingressgw_v2_sd_nologging_nullvm_both = {{ cpu_ingressgw_v2_sd_nologging_nullvm_both|safe }}
+        cpu_ingressgw_v2_sd_full_nullvm_both = {{ cpu_ingressgw_v2_sd_full_nullvm_both|safe }}
+
         cpu_client_none_mtls_base_master = {{ cpu_client_none_mtls_base_master|safe }}
         cpu_client_none_mtls_both_master = {{ cpu_client_none_mtls_both_master|safe }}
         cpu_client_none_plaintext_both_master = {{ cpu_client_none_plaintext_both_master|safe }}
@@ -194,6 +231,14 @@
         cpu_server_v2_stats_wasm_both_master = {{ cpu_server_v2_stats_wasm_both_master|safe }}
         cpu_server_v2_sd_nologging_nullvm_both_master = {{ cpu_server_v2_sd_nologging_nullvm_both_master| safe }}
         cpu_server_v2_sd_full_nullvm_both_master = {{ cpu_server_v2_sd_full_nullvm_both_master|safe }}
+
+        cpu_ingressgw_none_mtls_base_master = {{ cpu_ingressgw_none_mtls_base_master|safe }}
+        cpu_ingressgw_none_mtls_both_master = {{ cpu_ingressgw_none_mtls_both_master|safe }}
+        cpu_ingressgw_none_plaintext_both_master = {{ cpu_ingressgw_none_plaintext_both_master|safe }}
+        cpu_ingressgw_v2_stats_nullvm_both_master = {{ cpu_ingressgw_v2_stats_nullvm_both_master|safe }}
+        cpu_ingressgw_v2_stats_wasm_both_master = {{ cpu_ingressgw_v2_stats_wasm_both_master|safe }}
+        cpu_ingressgw_v2_sd_nologging_nullvm_both_master = {{ cpu_ingressgw_v2_sd_nologging_nullvm_both_master| safe }}
+        cpu_ingressgw_v2_sd_full_nullvm_both_master = {{ cpu_ingressgw_v2_sd_full_nullvm_both_master|safe }}
     </script>
 {% endblock page_data %}
 

--- a/perf_dashboard/benchmarks/templates/mem_vs_conn.html
+++ b/perf_dashboard/benchmarks/templates/mem_vs_conn.html
@@ -103,6 +103,18 @@
           </div>
         </div>
       </div>
+        <div class="row">
+        <div class="col-lg-6">
+          <div class="card">
+            <div class="card-header d-flex align-items-center">
+              <h4>Ingressgateway: {{ current_release|first }} Memory, 1000QPS over 240 seconds</h4>
+            </div>
+            <div class="card-body">
+              <canvas id="mem-ingressgw-conn-release"></canvas>
+            </div>
+          </div>
+        </div>
+      </div>
 
       <div class="row">
         <div class="col-lg-12">
@@ -150,6 +162,19 @@
           </div>
         </div>
       </div>
+
+        <div class="row">
+        <div class="col-lg-6">
+          <div class="card">
+            <div class="card-header d-flex align-items-center">
+              <h4>Ingressgateway: Memory usage, 1000QPS over 240 seconds</h4>
+            </div>
+            <div class="card-body">
+              <canvas id="mem-ingressgw-conn-master"></canvas>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
 </section>
 {% endblock page_content %}
@@ -179,6 +204,14 @@
         mem_server_v2_sd_nologging_nullvm_both = {{ mem_server_v2_sd_nologging_nullvm_both|safe }}
         mem_server_v2_sd_full_nullvm_both = {{ mem_server_v2_sd_full_nullvm_both|safe }}
 
+        mem_ingressgw_none_mtls_base = {{ mem_ingressgw_none_mtls_base|safe }}
+        mem_ingressgw_none_mtls_both = {{ mem_ingressgw_none_mtls_both|safe }}
+        mem_ingressgw_none_plaintext_both = {{ mem_ingressgw_none_plaintext_both|safe }}
+        mem_ingressgw_v2_stats_nullvm_both = {{ mem_ingressgw_v2_stats_nullvm_both|safe }}
+        mem_ingressgw_v2_stats_wasm_both = {{ mem_ingressgw_v2_stats_wasm_both|safe }}
+        mem_ingressgw_v2_sd_nologging_nullvm_both = {{ mem_ingressgw_v2_sd_nologging_nullvm_both|safe }}
+        mem_ingressgw_v2_sd_full_nullvm_both = {{ mem_ingressgw_v2_sd_full_nullvm_both|safe }}
+
         mem_client_none_mtls_base_master = {{ mem_client_none_mtls_base_master|safe }}
         mem_client_none_mtls_both_master = {{ mem_client_none_mtls_both_master|safe }}
         mem_client_none_plaintext_both_master = {{ mem_client_none_plaintext_both_master|safe }}
@@ -194,6 +227,14 @@
         mem_server_v2_stats_wasm_both_master = {{ mem_server_v2_stats_wasm_both_master|safe }}
         mem_server_v2_sd_nologging_nullvm_both_master = {{ mem_server_v2_sd_nologging_nullvm_both_master| safe }}
         mem_server_v2_sd_full_nullvm_both_master = {{ mem_server_v2_sd_full_nullvm_both_master|safe }}
+
+        mem_ingressgw_none_mtls_base_master = {{ mem_ingressgw_none_mtls_base_master|safe }}
+        mem_ingressgw_none_mtls_both_master = {{ mem_ingressgw_none_mtls_both_master|safe }}
+        mem_ingressgw_none_plaintext_both_master = {{ mem_ingressgw_none_plaintext_both_master|safe }}
+        mem_ingressgw_v2_stats_nullvm_both_master = {{ mem_ingressgw_v2_stats_nullvm_both_master|safe }}
+        mem_ingressgw_v2_stats_wasm_both_master = {{ mem_ingressgw_v2_stats_wasm_both_master|safe }}
+        mem_ingressgw_v2_sd_nologging_nullvm_both_master = {{ mem_ingressgw_v2_sd_nologging_nullvm_both_master| safe }}
+        mem_ingressgw_v2_sd_full_nullvm_both_master = {{ mem_ingressgw_v2_sd_full_nullvm_both_master|safe }}
     </script>
 {% endblock page_data %}
 

--- a/perf_dashboard/benchmarks/templates/mem_vs_qps.html
+++ b/perf_dashboard/benchmarks/templates/mem_vs_qps.html
@@ -104,6 +104,19 @@
         </div>
       </div>
 
+        <div class="row">
+        <div class="col-lg-6">
+          <div class="card">
+            <div class="card-header d-flex align-items-center">
+              <h4>Ingressgateway: {{ current_release|first }} Memory, 16 connections over 240 seconds</h4>
+            </div>
+            <div class="card-body">
+              <canvas id="mem-ingressgw-qps-release"></canvas>
+            </div>
+          </div>
+        </div>
+      </div>
+
       <div class="row">
         <div class="col-lg-12">
           <form class="form-horizontal" action="" method="post">
@@ -150,6 +163,19 @@
           </div>
         </div>
       </div>
+
+        <div class="row">
+        <div class="col-lg-6">
+          <div class="card">
+            <div class="card-header d-flex align-items-center">
+              <h4>Ingressgateway: Memory usage, 16 connections over 240 seconds</h4>
+            </div>
+            <div class="card-body">
+              <canvas id="mem-ingressgw-qps-master"></canvas>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
 </section>
 {% endblock page_content %}
@@ -179,6 +205,14 @@
         mem_server_v2_sd_nologging_nullvm_both = {{ mem_server_v2_sd_nologging_nullvm_both|safe }}
         mem_server_v2_sd_full_nullvm_both = {{ mem_server_v2_sd_full_nullvm_both|safe }}
 
+        mem_ingressgw_none_mtls_base = {{ mem_ingressgw_none_mtls_base|safe }}
+        mem_ingressgw_none_mtls_both = {{ mem_ingressgw_none_mtls_both|safe }}
+        mem_ingressgw_none_plaintext_both = {{ mem_ingressgw_none_plaintext_both|safe }}
+        mem_ingressgw_v2_stats_nullvm_both = {{ mem_ingressgw_v2_stats_nullvm_both|safe }}
+        mem_ingressgw_v2_stats_wasm_both = {{ mem_ingressgw_v2_stats_wasm_both|safe }}
+        mem_ingressgw_v2_sd_nologging_nullvm_both = {{ mem_ingressgw_v2_sd_nologging_nullvm_both|safe }}
+        mem_ingressgw_v2_sd_full_nullvm_both = {{ mem_ingressgw_v2_sd_full_nullvm_both|safe }}
+
         mem_client_none_mtls_base_master = {{ mem_client_none_mtls_base_master|safe }}
         mem_client_none_mtls_both_master = {{ mem_client_none_mtls_both_master|safe }}
         mem_client_none_plaintext_both_master = {{ mem_client_none_plaintext_both_master|safe }}
@@ -194,6 +228,14 @@
         mem_server_v2_stats_wasm_both_master = {{ mem_server_v2_stats_wasm_both_master|safe }}
         mem_server_v2_sd_nologging_nullvm_both_master = {{ mem_server_v2_sd_nologging_nullvm_both_master| safe }}
         mem_server_v2_sd_full_nullvm_both_master = {{ mem_server_v2_sd_full_nullvm_both_master|safe }}
+
+        mem_ingressgw_none_mtls_base_master = {{ mem_ingressgw_none_mtls_base_master|safe }}
+        mem_ingressgw_none_mtls_both_master = {{ mem_ingressgw_none_mtls_both_master|safe }}
+        mem_ingressgw_none_plaintext_both_master = {{ mem_ingressgw_none_plaintext_both_master|safe }}
+        mem_ingressgw_v2_stats_nullvm_both_master = {{ mem_ingressgw_v2_stats_nullvm_both_master|safe }}
+        mem_ingressgw_v2_stats_wasm_both_master = {{ mem_ingressgw_v2_stats_wasm_both_master|safe }}
+        mem_ingressgw_v2_sd_nologging_nullvm_both_master = {{ mem_ingressgw_v2_sd_nologging_nullvm_both_master| safe }}
+        mem_ingressgw_v2_sd_full_nullvm_both_master = {{ mem_ingressgw_v2_sd_full_nullvm_both_master|safe }}
     </script>
 {% endblock page_data %}
 

--- a/perf_dashboard/benchmarks/views.py
+++ b/perf_dashboard/benchmarks/views.py
@@ -29,11 +29,13 @@ cpu_cur_selected_release = []
 cpu_master_selected_release = []
 cpu_client_metric_name = 'cpu_mili_avg_istio_proxy_fortioclient'
 cpu_server_metric_name = 'cpu_mili_avg_istio_proxy_fortioserver'
+cpu_ingressgw_metric_name = 'cpu_mili_avg_istio_proxy_istio-ingressgateway'
 
 mem_cur_selected_release = []
 mem_master_selected_release = []
 mem_client_metric_name = 'mem_Mi_avg_istio_proxy_fortioclient'
 mem_server_metric_name = 'mem_Mi_avg_istio_proxy_fortioserver'
+mem_ingressgw_metric_name = 'mem_Mi_avg_istio_proxy_istio-ingressgateway'
 
 conn_query_list = [2, 4, 8, 16, 32, 64]
 conn_query_str = 'ActualQPS == 1000 and NumThreads == @ql and Labels.str.endswith(@telemetry_mode)'
@@ -346,6 +348,14 @@ def cpu_vs_qps(request, uploaded_csv_url=None):
         cpu_server_v2_sd_nologging_nullvm_both_master = get_cpu_vs_qps_y_series(df, '_v2-sd-nologging-nullvm_both', cpu_server_metric_name)
         cpu_server_v2_sd_full_nullvm_both_master = get_cpu_vs_qps_y_series(df, '_v2-sd-full-nullvm_both', cpu_server_metric_name)
 
+        cpu_ingressgw_none_mtls_base_master = get_cpu_vs_qps_y_series(df, '_none_mtls_baseline', cpu_ingressgw_metric_name)
+        cpu_ingressgw_none_mtls_both_master = get_cpu_vs_qps_y_series(df, '_none_mtls_both', cpu_ingressgw_metric_name)
+        cpu_ingressgw_none_plaintext_both_master = get_cpu_vs_qps_y_series(df, '_none_plaintext_both', cpu_ingressgw_metric_name)
+        cpu_ingressgw_v2_stats_nullvm_both_master = get_cpu_vs_qps_y_series(df, '_v2-stats-nullvm_both', cpu_ingressgw_metric_name)
+        cpu_ingressgw_v2_stats_wasm_both_master = get_cpu_vs_qps_y_series(df, '_v2-stats-wasm_both', cpu_ingressgw_metric_name)
+        cpu_ingressgw_v2_sd_nologging_nullvm_both_master = get_cpu_vs_qps_y_series(df, '_v2-sd-nologging-nullvm_both', cpu_ingressgw_metric_name)
+        cpu_ingressgw_v2_sd_full_nullvm_both_master = get_cpu_vs_qps_y_series(df, '_v2-sd-full-nullvm_both', cpu_ingressgw_metric_name)
+
         other_context = {'current_release': current_release,
                          'cpu_cur_selected_release': cpu_cur_selected_release,
                          'cpu_master_selected_release': cpu_master_selected_release,
@@ -367,6 +377,13 @@ def cpu_vs_qps(request, uploaded_csv_url=None):
                           'cpu_server_v2_stats_wasm_both_master': cpu_server_v2_stats_wasm_both_master,
                           'cpu_server_v2_sd_nologging_nullvm_both_master': cpu_server_v2_sd_nologging_nullvm_both_master,
                           'cpu_server_v2_sd_full_nullvm_both_master': cpu_server_v2_sd_full_nullvm_both_master,
+                          'cpu_ingressgw_none_mtls_base_master': cpu_ingressgw_none_mtls_base_master,
+                          'cpu_ingressgw_none_mtls_both_master': cpu_ingressgw_none_mtls_both_master,
+                          'cpu_ingressgw_none_plaintext_both_master': cpu_ingressgw_none_plaintext_both_master,
+                          'cpu_ingressgw_v2_stats_nullvm_both_master': cpu_ingressgw_v2_stats_nullvm_both_master,
+                          'cpu_ingressgw_v2_stats_wasm_both_master': cpu_ingressgw_v2_stats_wasm_both_master,
+                          'cpu_ingressgw_v2_sd_nologging_nullvm_both_master': cpu_ingressgw_v2_sd_nologging_nullvm_both_master,
+                          'cpu_ingressgw_v2_sd_full_nullvm_both_master': cpu_ingressgw_v2_sd_full_nullvm_both_master,
                           }
         context = reduce(lambda x, y: dict(x, **y), (other_context, release_context, master_context))
         return render(request, "cpu_vs_qps.html", context=context)
@@ -430,6 +447,14 @@ def cpu_vs_conn(request, uploaded_csv_url=None):
         cpu_server_v2_sd_nologging_nullvm_both_master = get_cpu_vs_conn_y_series(df, '_v2-sd-nologging-nullvm_both', cpu_server_metric_name)
         cpu_server_v2_sd_full_nullvm_both_master = get_cpu_vs_conn_y_series(df, '_v2-sd-full-nullvm_both', cpu_server_metric_name)
 
+        cpu_ingressgw_none_mtls_base_master = get_cpu_vs_conn_y_series(df, '_none_mtls_baseline', cpu_ingressgw_metric_name)
+        cpu_ingressgw_none_mtls_both_master = get_cpu_vs_conn_y_series(df, '_none_mtls_both', cpu_ingressgw_metric_name)
+        cpu_ingressgw_none_plaintext_both_master = get_cpu_vs_conn_y_series(df, '_none_plaintext_both', cpu_ingressgw_metric_name)
+        cpu_ingressgw_v2_stats_nullvm_both_master = get_cpu_vs_conn_y_series(df, '_v2-stats-nullvm_both', cpu_ingressgw_metric_name)
+        cpu_ingressgw_v2_stats_wasm_both_master = get_cpu_vs_conn_y_series(df, '_v2-stats-wasm_both', cpu_ingressgw_metric_name)
+        cpu_ingressgw_v2_sd_nologging_nullvm_both_master = get_cpu_vs_conn_y_series(df, '_v2-sd-nologging-nullvm_both', cpu_ingressgw_metric_name)
+        cpu_ingressgw_v2_sd_full_nullvm_both_master = get_cpu_vs_conn_y_series(df, '_v2-sd-full-nullvm_both', cpu_ingressgw_metric_name)
+
         other_context = {'current_release': current_release,
                          'cpu_cur_selected_release': cpu_cur_selected_release,
                          'cpu_master_selected_release': cpu_master_selected_release,
@@ -451,9 +476,17 @@ def cpu_vs_conn(request, uploaded_csv_url=None):
                           'cpu_server_v2_stats_wasm_both_master': cpu_server_v2_stats_wasm_both_master,
                           'cpu_server_v2_sd_nologging_nullvm_both_master': cpu_server_v2_sd_nologging_nullvm_both_master,
                           'cpu_server_v2_sd_full_nullvm_both_master': cpu_server_v2_sd_full_nullvm_both_master,
+                          'cpu_ingressgw_none_mtls_base_master': cpu_ingressgw_none_mtls_base_master,
+                          'cpu_ingressgw_none_mtls_both_master': cpu_ingressgw_none_mtls_both_master,
+                          'cpu_ingressgw_none_plaintext_both_master': cpu_ingressgw_none_plaintext_both_master,
+                          'cpu_ingressgw_v2_stats_nullvm_both_master': cpu_ingressgw_v2_stats_nullvm_both_master,
+                          'cpu_ingressgw_v2_stats_wasm_both_master': cpu_ingressgw_v2_stats_wasm_both_master,
+                          'cpu_ingressgw_v2_sd_nologging_nullvm_both_master': cpu_ingressgw_v2_sd_nologging_nullvm_both_master,
+                          'cpu_ingressgw_v2_sd_full_nullvm_both_master': cpu_ingressgw_v2_sd_full_nullvm_both_master,
                           }
 
         context = reduce(lambda x, y: dict(x, **y), (other_context, release_context, master_context))
+        print(context)
         return render(request, "cpu_vs_conn.html", context=context)
 
 
@@ -515,6 +548,14 @@ def mem_vs_qps(request, uploaded_csv_url=None):
         mem_server_v2_sd_nologging_nullvm_both_master = get_mem_vs_qps_y_series(df, '_v2-sd-nologging-nullvm_both', mem_server_metric_name)
         mem_server_v2_sd_full_nullvm_both_master = get_mem_vs_qps_y_series(df, '_v2-sd-full-nullvm_both', mem_server_metric_name)
 
+        mem_ingressgw_none_mtls_base_master = get_mem_vs_qps_y_series(df, '_none_mtls_baseline', mem_ingressgw_metric_name)
+        mem_ingressgw_none_mtls_both_master = get_mem_vs_qps_y_series(df, '_none_mtls_both', mem_ingressgw_metric_name)
+        mem_ingressgw_none_plaintext_both_master = get_mem_vs_qps_y_series(df, '_none_plaintext_both', mem_ingressgw_metric_name)
+        mem_ingressgw_v2_stats_nullvm_both_master = get_mem_vs_qps_y_series(df, '_v2-stats-nullvm_both', mem_ingressgw_metric_name)
+        mem_ingressgw_v2_stats_wasm_both_master = get_mem_vs_qps_y_series(df, '_v2-stats-wasm_both', mem_ingressgw_metric_name)
+        mem_ingressgw_v2_sd_nologging_nullvm_both_master = get_mem_vs_qps_y_series(df, '_v2-sd-nologging-nullvm_both', mem_ingressgw_metric_name)
+        mem_ingressgw_v2_sd_full_nullvm_both_master = get_mem_vs_qps_y_series(df, '_v2-sd-full-nullvm_both', mem_ingressgw_metric_name)
+
         other_context = {'current_release': current_release,
                          'mem_cur_selected_release': mem_cur_selected_release,
                          'mem_master_selected_release': mem_master_selected_release,
@@ -536,6 +577,13 @@ def mem_vs_qps(request, uploaded_csv_url=None):
                           'mem_server_v2_stats_wasm_both_master': mem_server_v2_stats_wasm_both_master,
                           'mem_server_v2_sd_nologging_nullvm_both_master': mem_server_v2_sd_nologging_nullvm_both_master,
                           'mem_server_v2_sd_full_nullvm_both_master': mem_server_v2_sd_full_nullvm_both_master,
+                          'mem_ingressgw_none_mtls_base_master': mem_ingressgw_none_mtls_base_master,
+                          'mem_ingressgw_none_mtls_both_master': mem_ingressgw_none_mtls_both_master,
+                          'mem_ingressgw_none_plaintext_both_master': mem_ingressgw_none_plaintext_both_master,
+                          'mem_ingressgw_v2_stats_nullvm_both_master': mem_ingressgw_v2_stats_nullvm_both_master,
+                          'mem_ingressgw_v2_stats_wasm_both_master': mem_ingressgw_v2_stats_wasm_both_master,
+                          'mem_ingressgw_v2_sd_nologging_nullvm_both_master': mem_ingressgw_v2_sd_nologging_nullvm_both_master,
+                          'mem_ingressgw_v2_sd_full_nullvm_both_master': mem_ingressgw_v2_sd_full_nullvm_both_master,
                           }
 
         context = reduce(lambda x, y: dict(x, **y), (other_context, release_context, master_context))
@@ -600,6 +648,14 @@ def mem_vs_conn(request, uploaded_csv_url=None):
         mem_server_v2_sd_nologging_nullvm_both_master = get_mem_vs_conn_y_series(df, '_v2-sd-nologging-nullvm_both', mem_server_metric_name)
         mem_server_v2_sd_full_nullvm_both_master = get_mem_vs_conn_y_series(df, '_v2-sd-full-nullvm_both', mem_server_metric_name)
 
+        mem_ingressgw_none_mtls_base_master = get_mem_vs_qps_y_series(df, '_none_mtls_baseline', mem_ingressgw_metric_name)
+        mem_ingressgw_none_mtls_both_master = get_mem_vs_qps_y_series(df, '_none_mtls_both', mem_ingressgw_metric_name)
+        mem_ingressgw_none_plaintext_both_master = get_mem_vs_qps_y_series(df, '_none_plaintext_both', mem_ingressgw_metric_name)
+        mem_ingressgw_v2_stats_nullvm_both_master = get_mem_vs_qps_y_series(df, '_v2-stats-nullvm_both', mem_ingressgw_metric_name)
+        mem_ingressgw_v2_stats_wasm_both_master = get_mem_vs_qps_y_series(df, '_v2-stats-wasm_both', mem_ingressgw_metric_name)
+        mem_ingressgw_v2_sd_nologging_nullvm_both_master = get_mem_vs_qps_y_series(df, '_v2-sd-nologging-nullvm_both', mem_ingressgw_metric_name)
+        mem_ingressgw_v2_sd_full_nullvm_both_master = get_mem_vs_qps_y_series(df, '_v2-sd-full-nullvm_both', mem_ingressgw_metric_name)
+
         other_context = {'current_release': current_release,
                          'mem_cur_selected_release': mem_cur_selected_release,
                          'mem_master_selected_release': mem_master_selected_release,
@@ -621,6 +677,13 @@ def mem_vs_conn(request, uploaded_csv_url=None):
                           'mem_server_v2_stats_wasm_both_master': mem_server_v2_stats_wasm_both_master,
                           'mem_server_v2_sd_nologging_nullvm_both_master': mem_server_v2_sd_nologging_nullvm_both_master,
                           'mem_server_v2_sd_full_nullvm_both_master': mem_server_v2_sd_full_nullvm_both_master,
+                          'mem_ingressgw_none_mtls_base_master': mem_ingressgw_none_mtls_base_master,
+                          'mem_ingressgw_none_mtls_both_master': mem_ingressgw_none_mtls_both_master,
+                          'mem_ingressgw_none_plaintext_both_master': mem_ingressgw_none_plaintext_both_master,
+                          'mem_ingressgw_v2_stats_nullvm_both_master': mem_ingressgw_v2_stats_nullvm_both_master,
+                          'mem_ingressgw_v2_stats_wasm_both_master': mem_ingressgw_v2_stats_wasm_both_master,
+                          'mem_ingressgw_v2_sd_nologging_nullvm_both_master': mem_ingressgw_v2_sd_nologging_nullvm_both_master,
+                          'mem_ingressgw_v2_sd_full_nullvm_both_master': mem_ingressgw_v2_sd_full_nullvm_both_master,
                           }
 
         context = reduce(lambda x, y: dict(x, **y), (other_context, release_context, master_context))
@@ -774,6 +837,14 @@ def get_cpu_vs_qps_context(df):
     cpu_server_v2_sd_nologging_nullvm_both = get_cpu_vs_qps_y_series(df, '_v2-sd-nologging-nullvm_both', cpu_server_metric_name)
     cpu_server_v2_sd_full_nullvm_both = get_cpu_vs_qps_y_series(df, '_v2-sd-full-nullvm_both', cpu_server_metric_name)
 
+    cpu_ingressgw_none_mtls_base = get_cpu_vs_qps_y_series(df, '_none_mtls_baseline', cpu_ingressgw_metric_name)
+    cpu_ingressgw_none_mtls_both = get_cpu_vs_qps_y_series(df, '_none_mtls_both', cpu_ingressgw_metric_name)
+    cpu_ingressgw_none_plaintext_both = get_cpu_vs_qps_y_series(df, '_none_plaintext_both', cpu_ingressgw_metric_name)
+    cpu_ingressgw_v2_stats_nullvm_both = get_cpu_vs_qps_y_series(df, '_v2-stats-nullvm_both', cpu_ingressgw_metric_name)
+    cpu_ingressgw_v2_stats_wasm_both = get_cpu_vs_qps_y_series(df, '_v2-stats-wasm_both', cpu_ingressgw_metric_name)
+    cpu_ingressgw_v2_sd_nologging_nullvm_both = get_cpu_vs_qps_y_series(df, '_v2-sd-nologging-nullvm_both', cpu_ingressgw_metric_name)
+    cpu_ingressgw_v2_sd_full_nullvm_both = get_cpu_vs_qps_y_series(df, '_v2-sd-full-nullvm_both', cpu_ingressgw_metric_name)
+
     context = {'cpu_client_none_mtls_base': cpu_client_none_mtls_base,
                'cpu_client_none_mtls_both': cpu_client_none_mtls_both,
                'cpu_client_none_plaintext_both': cpu_client_none_plaintext_both,
@@ -788,6 +859,13 @@ def get_cpu_vs_qps_context(df):
                'cpu_server_v2_stats_wasm_both': cpu_server_v2_stats_wasm_both,
                'cpu_server_v2_sd_nologging_nullvm_both': cpu_server_v2_sd_nologging_nullvm_both,
                'cpu_server_v2_sd_full_nullvm_both': cpu_server_v2_sd_full_nullvm_both,
+               'cpu_ingressgw_none_mtls_base': cpu_ingressgw_none_mtls_base,
+               'cpu_ingressgw_none_mtls_both': cpu_ingressgw_none_mtls_both,
+               'cpu_ingressgw_none_plaintext_both': cpu_ingressgw_none_plaintext_both,
+               'cpu_ingressgw_v2_stats_nullvm_both': cpu_ingressgw_v2_stats_nullvm_both,
+               'cpu_ingressgw_v2_stats_wasm_both': cpu_ingressgw_v2_stats_wasm_both,
+               'cpu_ingressgw_v2_sd_nologging_nullvm_both': cpu_ingressgw_v2_sd_nologging_nullvm_both,
+               'cpu_ingressgw_v2_sd_full_nullvm_both': cpu_ingressgw_v2_sd_full_nullvm_both,
                }
     return context
 
@@ -809,6 +887,14 @@ def get_cpu_vs_conn_context(df):
     cpu_server_v2_sd_nologging_nullvm_both = get_cpu_vs_conn_y_series(df, '_v2-sd-nologging-nullvm_both', cpu_server_metric_name)
     cpu_server_v2_sd_full_nullvm_both = get_cpu_vs_conn_y_series(df, '_v2-sd-full-nullvm_both', cpu_server_metric_name)
 
+    cpu_ingressgw_none_mtls_base = get_cpu_vs_conn_y_series(df, '_none_mtls_baseline', cpu_ingressgw_metric_name)
+    cpu_ingressgw_none_mtls_both = get_cpu_vs_conn_y_series(df, '_none_mtls_both', cpu_ingressgw_metric_name)
+    cpu_ingressgw_none_plaintext_both = get_cpu_vs_conn_y_series(df, '_none_plaintext_both', cpu_ingressgw_metric_name)
+    cpu_ingressgw_v2_stats_nullvm_both = get_cpu_vs_conn_y_series(df, '_v2-stats-nullvm_both', cpu_ingressgw_metric_name)
+    cpu_ingressgw_v2_stats_wasm_both = get_cpu_vs_conn_y_series(df, '_v2-stats-wasm_both', cpu_ingressgw_metric_name)
+    cpu_ingressgw_v2_sd_nologging_nullvm_both = get_cpu_vs_conn_y_series(df, '_v2-sd-nologging-nullvm_both', cpu_ingressgw_metric_name)
+    cpu_ingressgw_v2_sd_full_nullvm_both = get_cpu_vs_conn_y_series(df, '_v2-sd-full-nullvm_both', cpu_ingressgw_metric_name)
+
     context = {'cpu_client_none_mtls_base': cpu_client_none_mtls_base,
                'cpu_client_none_mtls_both': cpu_client_none_mtls_both,
                'cpu_client_none_plaintext_both': cpu_client_none_plaintext_both,
@@ -823,6 +909,13 @@ def get_cpu_vs_conn_context(df):
                'cpu_server_v2_stats_wasm_both': cpu_server_v2_stats_wasm_both,
                'cpu_server_v2_sd_nologging_nullvm_both': cpu_server_v2_sd_nologging_nullvm_both,
                'cpu_server_v2_sd_full_nullvm_both': cpu_server_v2_sd_full_nullvm_both,
+               'cpu_ingressgw_none_mtls_base': cpu_ingressgw_none_mtls_base,
+               'cpu_ingressgw_none_mtls_both': cpu_ingressgw_none_mtls_both,
+               'cpu_ingressgw_none_plaintext_both': cpu_ingressgw_none_plaintext_both,
+               'cpu_ingressgw_v2_stats_nullvm_both': cpu_ingressgw_v2_stats_nullvm_both,
+               'cpu_ingressgw_v2_stats_wasm_both': cpu_ingressgw_v2_stats_wasm_both,
+               'cpu_ingressgw_v2_sd_nologging_nullvm_both': cpu_ingressgw_v2_sd_nologging_nullvm_both,
+               'cpu_ingressgw_v2_sd_full_nullvm_both': cpu_ingressgw_v2_sd_full_nullvm_both,
                }
     return context
 
@@ -844,6 +937,14 @@ def get_mem_vs_qps_context(df):
     mem_server_v2_sd_nologging_nullvm_both = get_mem_vs_qps_y_series(df, '_v2-sd-nologging-nullvm_both', mem_server_metric_name)
     mem_server_v2_sd_full_nullvm_both = get_mem_vs_qps_y_series(df, '_v2-sd-full-nullvm_both', mem_server_metric_name)
 
+    mem_ingressgw_none_mtls_base = get_mem_vs_qps_y_series(df, '_none_mtls_baseline', mem_ingressgw_metric_name)
+    mem_ingressgw_none_mtls_both = get_mem_vs_qps_y_series(df, '_none_mtls_both', mem_ingressgw_metric_name)
+    mem_ingressgw_none_plaintext_both = get_mem_vs_qps_y_series(df, '_none_plaintext_both', mem_ingressgw_metric_name)
+    mem_ingressgw_v2_stats_nullvm_both = get_mem_vs_qps_y_series(df, '_v2-stats-nullvm_both', mem_ingressgw_metric_name)
+    mem_ingressgw_v2_stats_wasm_both = get_mem_vs_qps_y_series(df, '_v2-stats-wasm_both', mem_ingressgw_metric_name)
+    mem_ingressgw_v2_sd_nologging_nullvm_both = get_mem_vs_qps_y_series(df, '_v2-sd-nologging-nullvm_both', mem_ingressgw_metric_name)
+    mem_ingressgw_v2_sd_full_nullvm_both = get_mem_vs_qps_y_series(df, '_v2-sd-full-nullvm_both', mem_ingressgw_metric_name)
+
     context = {'mem_client_none_mtls_base': mem_client_none_mtls_base,
                'mem_client_none_mtls_both': mem_client_none_mtls_both,
                'mem_client_none_plaintext_both': mem_client_none_plaintext_both,
@@ -858,6 +959,13 @@ def get_mem_vs_qps_context(df):
                'mem_server_v2_stats_wasm_both': mem_server_v2_stats_wasm_both,
                'mem_server_v2_sd_nologging_nullvm_both': mem_server_v2_sd_nologging_nullvm_both,
                'mem_server_v2_sd_full_nullvm_both': mem_server_v2_sd_full_nullvm_both,
+               'mem_ingressgw_none_mtls_base': mem_ingressgw_none_mtls_base,
+               'mem_ingressgw_none_mtls_both': mem_ingressgw_none_mtls_both,
+               'mem_ingressgw_none_plaintext_both': mem_ingressgw_none_plaintext_both,
+               'mem_ingressgw_v2_stats_nullvm_both': mem_ingressgw_v2_stats_nullvm_both,
+               'mem_ingressgw_v2_stats_wasm_both': mem_ingressgw_v2_stats_wasm_both,
+               'mem_ingressgw_v2_sd_nologging_nullvm_both': mem_ingressgw_v2_sd_nologging_nullvm_both,
+               'mem_ingressgw_v2_sd_full_nullvm_both': mem_ingressgw_v2_sd_full_nullvm_both,
                }
     return context
 
@@ -879,6 +987,14 @@ def get_mem_vs_conn_context(df):
     mem_server_v2_sd_nologging_nullvm_both = get_mem_vs_conn_y_series(df, '_v2-sd-nologging-nullvm_both', mem_server_metric_name)
     mem_server_v2_sd_full_nullvm_both = get_mem_vs_conn_y_series(df, '_v2-sd-full-nullvm_both', mem_server_metric_name)
 
+    mem_ingressgw_none_mtls_base = get_mem_vs_conn_y_series(df, '_none_mtls_baseline', mem_ingressgw_metric_name)
+    mem_ingressgw_none_mtls_both = get_mem_vs_conn_y_series(df, '_none_mtls_both', mem_ingressgw_metric_name)
+    mem_ingressgw_none_plaintext_both = get_mem_vs_conn_y_series(df, '_none_plaintext_both', mem_ingressgw_metric_name)
+    mem_ingressgw_v2_stats_nullvm_both = get_mem_vs_conn_y_series(df, '_v2-stats-nullvm_both', mem_ingressgw_metric_name)
+    mem_ingressgw_v2_stats_wasm_both = get_mem_vs_conn_y_series(df, '_v2-stats-wasm_both', mem_ingressgw_metric_name)
+    mem_ingressgw_v2_sd_nologging_nullvm_both = get_mem_vs_conn_y_series(df, '_v2-sd-nologging-nullvm_both', mem_ingressgw_metric_name)
+    mem_ingressgw_v2_sd_full_nullvm_both = get_mem_vs_conn_y_series(df, '_v2-sd-full-nullvm_both', mem_ingressgw_metric_name)
+
     context = {'mem_client_none_mtls_base': mem_client_none_mtls_base,
                'mem_client_none_mtls_both': mem_client_none_mtls_both,
                'mem_client_none_plaintext_both': mem_client_none_plaintext_both,
@@ -893,6 +1009,13 @@ def get_mem_vs_conn_context(df):
                'mem_server_v2_stats_wasm_both': mem_server_v2_stats_wasm_both,
                'mem_server_v2_sd_nologging_nullvm_both': mem_server_v2_sd_nologging_nullvm_both,
                'mem_server_v2_sd_full_nullvm_both': mem_server_v2_sd_full_nullvm_both,
+               'mem_ingressgw_none_mtls_base': mem_ingressgw_none_mtls_base,
+               'mem_ingressgw_none_mtls_both': mem_ingressgw_none_mtls_both,
+               'mem_ingressgw_none_plaintext_both': mem_ingressgw_none_plaintext_both,
+               'mem_ingressgw_v2_stats_nullvm_both': mem_ingressgw_v2_stats_nullvm_both,
+               'mem_ingressgw_v2_stats_wasm_both': mem_ingressgw_v2_stats_wasm_both,
+               'mem_ingressgw_v2_sd_nologging_nullvm_both': mem_ingressgw_v2_sd_nologging_nullvm_both,
+               'mem_ingressgw_v2_sd_full_nullvm_both': mem_ingressgw_v2_sd_full_nullvm_both,
                }
     return context
 

--- a/perf_dashboard/static/js/cpu_conn.js
+++ b/perf_dashboard/static/js/cpu_conn.js
@@ -238,3 +238,113 @@ new Chart(document.getElementById("cpu-server-conn-master"), {
     }),
     options: cpuOptions
 });
+
+new Chart(document.getElementById("cpu-ingressgw-conn-release"), {
+    type: 'line',
+    data: convertData({
+        labels: connNum,
+        datasets: [
+            {
+                label: "baseline",
+                backgroundColor: "rgba(236, 66, 53, 0.2)",
+                borderColor: "rgba(236, 66, 53, 1)",
+                data: cpu_ingressgw_none_mtls_base,
+                fill: false
+            }, {
+                label: "none-mtls_both",
+                backgroundColor: "rgba(0, 0, 0, 0.2)",
+                borderColor: "rgba(0, 0, 0, 1)",
+                data: cpu_ingressgw_none_mtls_both,
+                fill: false
+            }, {
+                label: "none-plaintext_both",
+                backgroundColor: "rgba(52, 235, 219, 0.2)",
+                borderColor: "rgba(52, 235, 219, 1)",
+                data: cpu_ingressgw_none_plaintext_both,
+                fill: false
+            }, {
+                label: "v2-stats-nullvm_both",
+                backgroundColor: "rgba(252, 123, 3, 0.2)",
+                borderColor: "rgba(252, 123, 3, 1)",
+                data: cpu_ingressgw_v2_stats_nullvm_both,
+                fill: false
+            }, {
+                label: "v2-stats-wasm_both",
+                backgroundColor: "rgba(242, 245, 66, 0.2)",
+                borderColor: "rgba(242, 245, 66, 1)",
+                data: cpu_ingressgw_v2_stats_wasm_both,
+                fill: false
+            }, {
+                label: "v2-sd-nologging-nullvm_both",
+                backgroundColor: "rgba(52, 168, 85, 0.2)",
+                borderColor: "rgba(52, 168, 85, 1)",
+                data: cpu_ingressgw_v2_sd_nologging_nullvm_both,
+                hidden: true,
+                fill: false
+            }, {
+                label: "v2-sd-full-nullvm_both",
+                backgroundColor: "rgba(168, 50, 168, 0.2)",
+                borderColor: "rgba(168, 50, 168, 1)",
+                data: cpu_ingressgw_v2_sd_full_nullvm_both,
+                hidden: true,
+                fill: false
+            }
+        ]
+    }),
+    options: cpuOptions
+});
+
+new Chart(document.getElementById("cpu-ingressgw-conn-master"), {
+    type: 'line',
+    data: convertData({
+        labels: connNum,
+        datasets: [
+            {
+                label: "baseline",
+                backgroundColor: "rgba(236, 66, 53, 0.2)",
+                borderColor: "rgba(236, 66, 53, 1)",
+                data: cpu_ingressgw_none_mtls_base_master,
+                fill: false
+            }, {
+                label: "none-mtls_both",
+                backgroundColor: "rgba(0, 0, 0, 0.2)",
+                borderColor: "rgba(0, 0, 0, 1)",
+                data: cpu_ingressgw_none_mtls_both_master,
+                fill: false
+            }, {
+                label: "none-plaintext_both",
+                backgroundColor: "rgba(52, 235, 219, 0.2)",
+                borderColor: "rgba(52, 235, 219, 1)",
+                data: cpu_ingressgw_none_plaintext_both_master,
+                fill: false
+            }, {
+                label: "v2-stats-nullvm_both",
+                backgroundColor: "rgba(252, 123, 3, 0.2)",
+                borderColor: "rgba(252, 123, 3, 1)",
+                data: cpu_ingressgw_v2_stats_nullvm_both_master,
+                fill: false
+            }, {
+                label: "v2-stats-wasm_both",
+                backgroundColor: "rgba(242, 245, 66, 0.2)",
+                borderColor: "rgba(242, 245, 66, 1)",
+                data: cpu_ingressgw_v2_stats_wasm_both_master,
+                fill: false
+            }, {
+                label: "v2-sd-nologging-nullvm_both",
+                backgroundColor: "rgba(52, 168, 85, 0.2)",
+                borderColor: "rgba(52, 168, 85, 1)",
+                data: cpu_ingressgw_v2_sd_nologging_nullvm_both_master,
+                hidden: true,
+                fill: false
+            }, {
+                label: "v2-sd-full-nullvm_both",
+                backgroundColor: "rgba(168, 50, 168, 0.2)",
+                borderColor: "rgba(168, 50, 168, 1)",
+                data: cpu_ingressgw_v2_sd_full_nullvm_both_master,
+                hidden: true,
+                fill: false
+            }
+        ]
+    }),
+    options: cpuOptions
+});

--- a/perf_dashboard/static/js/cpu_qps.js
+++ b/perf_dashboard/static/js/cpu_qps.js
@@ -238,3 +238,113 @@ new Chart(document.getElementById("cpu-server-qps-master"), {
     }),
     options: cpuOptions
 });
+
+new Chart(document.getElementById("cpu-ingressgw-qps-release"), {
+    type: 'line',
+    data: convertData({
+        labels: qpsNum,
+        datasets: [
+            {
+                label: "baseline",
+                backgroundColor: "rgba(236, 66, 53, 0.2)",
+                borderColor: "rgba(236, 66, 53, 1)",
+                data: cpu_ingressgw_none_mtls_base,
+                fill: false
+            }, {
+                label: "none-mtls_both",
+                backgroundColor: "rgba(0, 0, 0, 0.2)",
+                borderColor: "rgba(0, 0, 0, 1)",
+                data: cpu_ingressgw_none_mtls_both,
+                fill: false
+            }, {
+                label: "none-plaintext_both",
+                backgroundColor: "rgba(52, 235, 219, 0.2)",
+                borderColor: "rgba(52, 235, 219, 1)",
+                data: cpu_ingressgw_none_plaintext_both,
+                fill: false
+            }, {
+                label: "v2-stats-nullvm_both",
+                backgroundColor: "rgba(252, 123, 3, 0.2)",
+                borderColor: "rgba(252, 123, 3, 1)",
+                data: cpu_ingressgw_v2_stats_nullvm_both,
+                fill: false
+            }, {
+                label: "v2-stats-wasn_both",
+                backgroundColor: "rgba(242, 245, 66, 0.2)",
+                borderColor: "rgba(242, 245, 66, 1)",
+                data: cpu_ingressgw_v2_stats_wasm_both,
+                fill: false
+            }, {
+                label: "v2-sd-nologging-nullvm_both",
+                backgroundColor: "rgba(52, 168, 85, 0.2)",
+                borderColor: "rgba(52, 168, 85, 1)",
+                data: cpu_ingressgw_v2_sd_nologging_nullvm_both,
+                hidden: true,
+                fill: false
+            }, {
+                label: "v2-sd-full-nullvm_both",
+                backgroundColor: "rgba(168, 50, 168, 0.2)",
+                borderColor: "rgba(168, 50, 168, 1)",
+                data: cpu_ingressgw_v2_sd_full_nullvm_both,
+                hidden: true,
+                fill: false
+            }
+        ]
+    }),
+    options: cpuOptions
+});
+
+new Chart(document.getElementById("cpu-ingressgw-qps-master"), {
+    type: 'line',
+    data: convertData({
+        labels: qpsNum,
+        datasets: [
+            {
+                label: "baseline",
+                backgroundColor: "rgba(236, 66, 53, 0.2)",
+                borderColor: "rgba(236, 66, 53, 1)",
+                data: cpu_ingressgw_none_mtls_base_master,
+                fill: false
+            }, {
+                label: "none-mtls_both",
+                backgroundColor: "rgba(0, 0, 0, 0.2)",
+                borderColor: "rgba(0, 0, 0, 1)",
+                data: cpu_ingressgw_none_mtls_both_master,
+                fill: false
+            }, {
+                label: "none-plaintext_both",
+                backgroundColor: "rgba(52, 235, 219, 0.2)",
+                borderColor: "rgba(52, 235, 219, 1)",
+                data: cpu_ingressgw_none_plaintext_both_master,
+                fill: false
+            }, {
+                label: "v2-stats-nullvm_both",
+                backgroundColor: "rgba(252, 123, 3, 0.2)",
+                borderColor: "rgba(252, 123, 3, 1)",
+                data: cpu_ingressgw_v2_stats_nullvm_both_master,
+                fill: false
+            }, {
+                label: "v2-stats-wasm_both",
+                backgroundColor: "rgba(242, 245, 66, 0.2)",
+                borderColor: "rgba(242, 245, 66, 1)",
+                data: cpu_ingressgw_v2_stats_wasm_both_master,
+                fill: false
+            }, {
+                label: "v2-sd-nologging-nullvm_both",
+                backgroundColor: "rgba(52, 168, 85, 0.2)",
+                borderColor: "rgba(52, 168, 85, 1)",
+                data: cpu_ingressgw_v2_sd_nologging_nullvm_both_master,
+                hidden: true,
+                fill: false
+            }, {
+                label: "v2-sd-full-nullvm_both",
+                backgroundColor: "rgba(168, 50, 168, 0.2)",
+                borderColor: "rgba(168, 50, 168, 1)",
+                data: cpu_ingressgw_v2_sd_full_nullvm_both_master,
+                hidden: true,
+                fill: false
+            }
+        ]
+    }),
+    options: cpuOptions
+});

--- a/perf_dashboard/static/js/mem_conn.js
+++ b/perf_dashboard/static/js/mem_conn.js
@@ -238,3 +238,113 @@ new Chart(document.getElementById("mem-server-conn-master"), {
     }),
     options: memOptions
 });
+
+new Chart(document.getElementById("mem-ingressgw-conn-release"), {
+    type: 'line',
+    data: convertData({
+        labels: connNum,
+        datasets: [
+            {
+                label: "baseline",
+                backgroundColor: "rgba(236, 66, 53, 0.2)",
+                borderColor: "rgba(236, 66, 53, 1)",
+                data: mem_ingressgw_none_mtls_base,
+                fill: false
+            }, {
+                label: "none-mtls_both",
+                backgroundColor: "rgba(0, 0, 0, 0.2)",
+                borderColor: "rgba(0, 0, 0, 1)",
+                data: mem_ingressgw_none_mtls_both,
+                fill: false
+            }, {
+                label: "none-plaintext_both",
+                backgroundColor: "rgba(52, 235, 219, 0.2)",
+                borderColor: "rgba(52, 235, 219, 1)",
+                data: mem_ingressgw_none_plaintext_both,
+                fill: false
+            }, {
+                label: "v2-stats-nullvm_both",
+                backgroundColor: "rgba(252, 123, 3, 0.2)",
+                borderColor: "rgba(252, 123, 3, 1)",
+                data: mem_ingressgw_v2_stats_nullvm_both,
+                fill: false
+            }, {
+                label: "v2-stats-wasm_both",
+                backgroundColor: "rgba(242, 245, 66, 0.2)",
+                borderColor: "rgba(242, 245, 66, 1)",
+                data: mem_ingressgw_v2_stats_wasm_both,
+                fill: false
+            },{
+                label: "v2-sd-nologging-nullvm_both",
+                backgroundColor: "rgba(52, 168, 85, 0.2)",
+                borderColor: "rgba(52, 168, 85, 1)",
+                data: mem_ingressgw_v2_sd_nologging_nullvm_both,
+                hidden: true,
+                fill: false
+            }, {
+                label: "v2-sd-full-nullvm_both",
+                backgroundColor: "rgba(168, 50, 168, 0.2)",
+                borderColor: "rgba(168, 50, 168, 1)",
+                data: mem_ingressgw_v2_sd_full_nullvm_both,
+                hidden: true,
+                fill: false
+            }
+        ]
+    }),
+    options: memOptions
+});
+
+new Chart(document.getElementById("mem-ingressgw-conn-master"), {
+    type: 'line',
+    data: convertData({
+        labels: connNum,
+        datasets: [
+            {
+                label: "baseline",
+                backgroundColor: "rgba(236, 66, 53, 0.2)",
+                borderColor: "rgba(236, 66, 53, 1)",
+                data: mem_ingressgw_none_mtls_base_master,
+                fill: false
+            }, {
+                label: "none-mtls_both",
+                backgroundColor: "rgba(0, 0, 0, 0.2)",
+                borderColor: "rgba(0, 0, 0, 1)",
+                data: mem_ingressgw_none_mtls_both_master,
+                fill: false
+            }, {
+                label: "none-plaintext_both",
+                backgroundColor: "rgba(52, 235, 219, 0.2)",
+                borderColor: "rgba(52, 235, 219, 1)",
+                data: mem_ingressgw_none_plaintext_both_master,
+                fill: false
+            }, {
+                label: "v2-stats-nullvm_both",
+                backgroundColor: "rgba(252, 123, 3, 0.2)",
+                borderColor: "rgba(252, 123, 3, 1)",
+                data: mem_ingressgw_v2_stats_nullvm_both_master,
+                fill: false
+            }, {
+                label: "v2-stats-wasm_both",
+                backgroundColor: "rgba(242, 245, 66, 0.2)",
+                borderColor: "rgba(242, 245, 66, 1)",
+                data: mem_ingressgw_v2_stats_wasm_both_master,
+                fill: false
+            }, {
+                label: "v2-sd-nologging-nullvm_both",
+                backgroundColor: "rgba(52, 168, 85, 0.2)",
+                borderColor: "rgba(52, 168, 85, 1)",
+                data: mem_ingressgw_v2_sd_nologging_nullvm_both_master,
+                hidden: true,
+                fill: false
+            }, {
+                label: "v2-sd-full-nullvm_both",
+                backgroundColor: "rgba(168, 50, 168, 0.2)",
+                borderColor: "rgba(168, 50, 168, 1)",
+                data: mem_ingressgw_v2_sd_full_nullvm_both_master,
+                hidden: true,
+                fill: false
+            }
+        ]
+    }),
+    options: memOptions
+});

--- a/perf_dashboard/static/js/mem_qps.js
+++ b/perf_dashboard/static/js/mem_qps.js
@@ -238,3 +238,113 @@ new Chart(document.getElementById("mem-server-qps-master"), {
     }),
     options: memOptions
 });
+
+new Chart(document.getElementById("mem-ingressgw-qps-release"), {
+    type: 'line',
+    data: convertData({
+        labels: qpsNum,
+        datasets: [
+            {
+                label: "baseline",
+                backgroundColor: "rgba(236, 66, 53, 0.2)",
+                borderColor: "rgba(236, 66, 53, 1)",
+                data: mem_ingressgw_none_mtls_base,
+                fill: false
+            }, {
+                label: "none-mtls_both",
+                backgroundColor: "rgba(0, 0, 0, 0.2)",
+                borderColor: "rgba(0, 0, 0, 1)",
+                data: mem_ingressgw_none_mtls_both,
+                fill: false
+            }, {
+                label: "none-plaintext_both",
+                backgroundColor: "rgba(52, 235, 219, 0.2)",
+                borderColor: "rgba(52, 235, 219, 1)",
+                data: mem_ingressgw_none_plaintext_both,
+                fill: false
+            }, {
+                label: "v2-stats-nullvm_both",
+                backgroundColor: "rgba(252, 123, 3, 0.2)",
+                borderColor: "rgba(252, 123, 3, 1)",
+                data: mem_ingressgw_v2_stats_nullvm_both,
+                fill: false
+            }, {
+                label: "v2-stats-wasm_both",
+                backgroundColor: "rgba(242, 245, 66, 0.2)",
+                borderColor: "rgba(242, 245, 66, 1)",
+                data: mem_ingressgw_v2_stats_wasm_both,
+                fill: false
+            }, {
+                label: "v2-sd-nologging-nullvm_both",
+                backgroundColor: "rgba(52, 168, 85, 0.2)",
+                borderColor: "rgba(52, 168, 85, 1)",
+                data: mem_ingressgw_v2_sd_nologging_nullvm_both,
+                hidden: true,
+                fill: false
+            }, {
+                label: "v2-sd-full-nullvm_both",
+                backgroundColor: "rgba(168, 50, 168, 0.2)",
+                borderColor: "rgba(168, 50, 168, 1)",
+                data: mem_ingressgw_v2_sd_full_nullvm_both,
+                hidden: true,
+                fill: false
+            }
+        ]
+    }),
+    options: memOptions
+});
+
+new Chart(document.getElementById("mem-ingressgw-qps-master"), {
+    type: 'line',
+    data: convertData({
+        labels: qpsNum,
+        datasets: [
+            {
+                label: "baseline",
+                backgroundColor: "rgba(236, 66, 53, 0.2)",
+                borderColor: "rgba(236, 66, 53, 1)",
+                data: mem_ingressgw_none_mtls_base_master,
+                fill: false
+            }, {
+                label: "none-mtls_both",
+                backgroundColor: "rgba(0, 0, 0, 0.2)",
+                borderColor: "rgba(0, 0, 0, 1)",
+                data: mem_ingressgw_none_mtls_both_master,
+                fill: false
+            }, {
+                label: "none-plaintext_both",
+                backgroundColor: "rgba(52, 235, 219, 0.2)",
+                borderColor: "rgba(52, 235, 219, 1)",
+                data: mem_ingressgw_none_plaintext_both_master,
+                fill: false
+            }, {
+                label: "v2-stats-nullvm_both",
+                backgroundColor: "rgba(252, 123, 3, 0.2)",
+                borderColor: "rgba(252, 123, 3, 1)",
+                data: mem_ingressgw_v2_stats_nullvm_both_master,
+                fill: false
+            }, {
+                label: "v2-stats-wasm_both",
+                backgroundColor: "rgba(242, 245, 66, 0.2)",
+                borderColor: "rgba(242, 245, 66, 1)",
+                data: mem_ingressgw_v2_stats_wasm_both_master,
+                fill: false
+            }, {
+                label: "v2-sd-nologging-nullvm_both",
+                backgroundColor: "rgba(52, 168, 85, 0.2)",
+                borderColor: "rgba(52, 168, 85, 1)",
+                data: mem_ingressgw_v2_sd_nologging_nullvm_both_master,
+                hidden: true,
+                fill: false
+            }, {
+                label: "v2-sd-full-nullvm_both",
+                backgroundColor: "rgba(168, 50, 168, 0.2)",
+                borderColor: "rgba(168, 50, 168, 1)",
+                data: mem_ingressgw_v2_sd_full_nullvm_both_master,
+                hidden: true,
+                fill: false
+            }
+        ]
+    }),
+    options: memOptions
+});


### PR DESCRIPTION
- add ingressgateway section
cpu-conn for ingressgateway section is not included in this PR, since the parsing or data transfer parts is kind of broken, I will give a fix in next pr.

- disabled none-tcp from perf pipeline to unblock pipeline
since we have fortio json parsing issue, i will give a fix along with the above issue.