### PR TITLE
errorPercent key only available when RunType is HTTP

### DIFF
--- a/perf/benchmark/runner/fortio.py
+++ b/perf/benchmark/runner/fortio.py
@@ -172,9 +172,10 @@ def sync_fortio(url, table, selector=None, promUrl="", csv=None, csv_output="", 
             if promUrl:
                 sd = datetime.strptime(st[:19], "%Y-%m-%dT%H:%M:%S")
                 print("Fetching prometheus metrics for", sd, gd["Labels"])
-                if gd['errorPercent'] > 10:
-                    print("... Run resulted in", gd['errorPercent'], "% errors")
-                    continue
+                if data["RunType"] == "HTTP":
+                    if gd['errorPercent'] > 10:
+                        print("... Run resulted in", gd['errorPercent'], "% errors")
+                        continue
                 min_duration = METRICS_START_SKIP_DURATION + METRICS_END_SKIP_DURATION
                 if min_duration > gd['ActualDuration']:
                     print("... {} duration={}s is less than minimum {}s".format(


### PR DESCRIPTION
error:

```
Traceback (most recent call last):
  File "fortio.py", line 287, in <module>
    sys.exit(main(sys.argv[1:]))
  File "fortio.py", line 253, in main
    args.csv_output)
  File "fortio.py", line 175, in sync_fortio
    if gd['errorPercent'] > 10:
KeyError: 'errorPercent'
```