### PR TITLE
Add Kind filtering and negation support to release notes

### DIFF
--- a/cmd/gen-release-notes/README.md
+++ b/cmd/gen-release-notes/README.md
@@ -56,11 +56,32 @@ indicating where content should be substituted. These are stored in the
 
 ### Filtering notes
 
-Notes can be substituted based on fields in the release notes files.
+Templates can be populated with release notes based on HTML comments that filter
+content from the release notes files.
 
-To substitute for release notes matching the `traffic-management` area, use the
+To populate a template with release notes matching the `traffic-management` area, use the
 following comment:
 
 ```html
 <!-- releaseNotes area:traffic-management -->
 ```
+
+To populate a templates with release notes matching kind `feature`, use:
+
+```html
+<!-- releaseNotes kind:feature -->
+```
+
+To populate a template with release notes matching the action `Deprecated`, use:
+
+```html
+<!-- releaseNotes action:Deprecated -->
+```
+
+Filters also support negation of fields. To include all release notes not
+matching the action `Deprecated`, use:
+
+```html
+<!-- releaseNotes action:!Deprecated -->
+```
+

--- a/cmd/gen-release-notes/main.go
+++ b/cmd/gen-release-notes/main.go
@@ -157,7 +157,7 @@ func getNotesForTemplateFormat(notes []Note, template Template) []string {
 
 	for _, note := range notes {
 		if template.Type == "releaseNotes" {
-			parsedNotes = append(parsedNotes, note.getReleaseNotes(template.Area, template.Action)...)
+			parsedNotes = append(parsedNotes, note.getReleaseNotes(template.Kind, template.Area, template.Action)...)
 		} else if template.Type == "upgradeNotes" {
 			parsedNotes = append(parsedNotes, note.getUpgradeNotes()...)
 		} else if template.Type == "securityNotes" {

--- a/cmd/gen-release-notes/note.go
+++ b/cmd/gen-release-notes/note.go
@@ -61,10 +61,25 @@ func (note Note) getDocs() string {
 	return docsString
 }
 
-func (note Note) getReleaseNotes(area string, action string) []string {
+func filterNote(templateFilter string, noteFilter string) bool {
+	if templateFilter == "" {
+		return true
+	} else if templateFilter == noteFilter {
+		return true
+	} else if templateFilter[0] == '!' && templateFilter[1:] != noteFilter {
+		return true
+	}
+	return false
+
+}
+
+func (note Note) getReleaseNotes(kind string, area string, action string) []string {
 	notes := make([]string, 0)
+
 	for _, releaseNote := range note.ReleaseNotes {
-		if (action == "" || releaseNote.Action == action) && (area == "" || note.Area == area) {
+		if filterNote(kind, note.Kind) &&
+			filterNote(area, note.Area) &&
+			filterNote(action, releaseNote.Action) {
 			noteEntry := fmt.Sprintf("%s %s %s\n", releaseNote, note.getDocs(), note.getIssues())
 			if noteEntry != "" {
 				notes = append(notes, noteEntry)

--- a/cmd/gen-release-notes/template.go
+++ b/cmd/gen-release-notes/template.go
@@ -24,26 +24,31 @@ type Template struct {
 	Area   string
 	Type   string
 	Action string
+	Kind   string
 }
 
 func (tmpl Template) parseAction(line string) string {
-	action := ""
 	actionRegexp := regexp.MustCompile("action:[a-zA-Z]*")
-	if match := actionRegexp.FindString(line); match != "" {
-		sections := strings.Split(match, ":")
-		action = sections[1]
-	}
-	return action
+	return parseField(line, *actionRegexp)
 }
 
 func (tmpl Template) parseArea(line string) string {
-	area := ""
-	areaRegexp := regexp.MustCompile("area:[a-zA-Z-]*")
-	if match := areaRegexp.FindString(line); match != "" {
+	areaRegexp := regexp.MustCompile("area:[!a-zA-Z-]*")
+	return parseField(line, *areaRegexp)
+}
+
+func (tmpl Template) parseKind(line string) string {
+	areaRegexp := regexp.MustCompile("kind:[!a-zA-Z-]*")
+	return parseField(line, *areaRegexp)
+}
+
+func parseField(line string, regex regexp.Regexp) string {
+	field := ""
+	if match := regex.FindString(line); match != "" {
 		sections := strings.Split(match, ":")
-		area = sections[1]
+		field = sections[1]
 	}
-	return area
+	return field
 }
 
 func (tmpl Template) parseType(line string) string {
@@ -60,11 +65,12 @@ func (tmpl Template) parseType(line string) string {
 func ParseTemplate(line string) (Template, error) {
 	var tmpl Template
 	tmpl.Area = tmpl.parseArea(line)
+	tmpl.Kind = tmpl.parseKind(line)
 	tmpl.Action = tmpl.parseAction(line)
 	tmpl.Type = tmpl.parseType(line)
 
 	if tmpl.Type != "" {
-		fmt.Printf("Processed template %s. Area:%s action:%s type:%s\n", line, tmpl.Area, tmpl.Action, tmpl.Type)
+		fmt.Printf("Processed template %s. Kind: %s Area:%s action:%s type:%s\n", line, tmpl.Kind, tmpl.Area, tmpl.Action, tmpl.Type)
 	} else {
 		return Template{}, fmt.Errorf("unable to process template: %s; ignoring", line)
 	}

--- a/cmd/gen-release-notes/templates/minorReleaseNotes.md
+++ b/cmd/gen-release-notes/templates/minorReleaseNotes.md
@@ -10,7 +10,9 @@ This is an automatically generated rough draft of the release notes and has not 
 
 # Release Notes
 
-## Deprecated
+## Deprecation Notices
+
+These notices describe functionality that will be removed in a future release according to [Istio's deprecation policy](/about/feature-stages/#feature-phase-definitions). Please consider upgrading your environment to remove the deprecated functionality.
 
 <!-- releaseNotes action:Deprecated -->
 

--- a/cmd/gen-release-notes/templates/minorReleaseNotes.md
+++ b/cmd/gen-release-notes/templates/minorReleaseNotes.md
@@ -10,13 +10,16 @@ This is an automatically generated rough draft of the release notes and has not 
 
 # Release Notes
 
+## Deprecated
+
+<!-- releaseNotes action:Deprecated -->
+
 ## Traffic Management
 
 <!-- releaseNotes area:traffic-management action:Promoted -->
 <!-- releaseNotes area:traffic-management action:Improved -->
 <!-- releaseNotes area:traffic-management action:Updated -->
 <!-- releaseNotes area:traffic-management action:Added -->
-<!-- releaseNotes area:traffic-management action:Deprecated -->
 <!-- releaseNotes area:traffic-management action:Enabled -->
 <!-- releaseNotes area:traffic-management action:Fixed -->
 <!-- releaseNotes area:traffic-management action:Upgraded -->
@@ -29,7 +32,6 @@ This is an automatically generated rough draft of the release notes and has not 
 <!-- releaseNotes area:security action:Improved -->
 <!-- releaseNotes area:security action:Updated -->
 <!-- releaseNotes area:security action:Added -->
-<!-- releaseNotes area:security action:Deprecated -->
 <!-- releaseNotes area:security action:Enabled -->
 <!-- releaseNotes area:security action:Fixed -->
 <!-- releaseNotes area:security action:Upgraded -->
@@ -42,7 +44,6 @@ This is an automatically generated rough draft of the release notes and has not 
 <!-- releaseNotes area:telemetry action:Improved -->
 <!-- releaseNotes area:telemetry action:Updated -->
 <!-- releaseNotes area:telemetry action:Added -->
-<!-- releaseNotes area:telemetry action:Deprecated -->
 <!-- releaseNotes area:telemetry action:Enabled -->
 <!-- releaseNotes area:telemetry action:Fixed -->
 <!-- releaseNotes area:telemetry action:Upgraded -->
@@ -55,7 +56,6 @@ This is an automatically generated rough draft of the release notes and has not 
 <!-- releaseNotes area:installation action:Improved -->
 <!-- releaseNotes area:installation action:Updated -->
 <!-- releaseNotes area:installation action:Added -->
-<!-- releaseNotes area:installation action:Deprecated -->
 <!-- releaseNotes area:installation action:Enabled -->
 <!-- releaseNotes area:installation action:Fixed -->
 <!-- releaseNotes area:installation action:Upgraded -->
@@ -68,7 +68,6 @@ This is an automatically generated rough draft of the release notes and has not 
 <!-- releaseNotes area:istioctl action:Improved -->
 <!-- releaseNotes area:istioctl action:Updated -->
 <!-- releaseNotes area:istioctl action:Added -->
-<!-- releaseNotes area:istioctl action:Deprecated -->
 <!-- releaseNotes area:istioctl action:Enabled -->
 <!-- releaseNotes area:istioctl action:Fixed -->
 <!-- releaseNotes area:istioctl action:Upgraded -->
@@ -81,7 +80,6 @@ This is an automatically generated rough draft of the release notes and has not 
 <!-- releaseNotes area:documentation action:Improved -->
 <!-- releaseNotes area:documentation action:Updated -->
 <!-- releaseNotes area:documentation action:Added -->
-<!-- releaseNotes area:documentation action:Deprecated -->
 <!-- releaseNotes area:documentation action:Enabled -->
 <!-- releaseNotes area:documentation action:Fixed -->
 <!-- releaseNotes area:documentation action:Upgraded -->


### PR DESCRIPTION
This adds support for filtering on Kind to the release notes. It also moves deprecation to its own section of the release notes. @frankbu @nmittler PTAL


For reference, I have attached the 1.9 release notes. With one of the notes set to deprecated. 

[minorReleaseNotes.md.txt](https://github.com/istio/tools/files/5698339/minorReleaseNotes.md.txt)

