### PR TITLE
Disable plaintext perf run

### DIFF
--- a/perf/benchmark/configs/run_perf_test.conf
+++ b/perf/benchmark/configs/run_perf_test.conf
@@ -1,6 +1,6 @@
 none=true
 none_tcp=true
-plaintext=true
+plaintext=false
 telemetryv2_sd_full=true
 telemetryv2_sd_full_accesslogpolicy=false
 telemetryv2_sd_nologging=true

--- a/perf_dashboard/static/js/cpu_conn.js
+++ b/perf_dashboard/static/js/cpu_conn.js
@@ -41,6 +41,7 @@ new Chart(document.getElementById("cpu-client-conn-release"), {
                 backgroundColor: "rgba(52, 235, 219, 0.2)",
                 borderColor: "rgba(52, 235, 219, 1)",
                 data: cpu_client_none_plaintext_both,
+                hidden: true,
                 fill: false
             }, {
                 label: "v2-stats-nullvm_both",
@@ -96,6 +97,7 @@ new Chart(document.getElementById("cpu-client-conn-master"), {
                 backgroundColor: "rgba(52, 235, 219, 0.2)",
                 borderColor: "rgba(52, 235, 219, 1)",
                 data: cpu_client_none_plaintext_both_master,
+                hidden: true,
                 fill: false
             }, {
                 label: "v2-stats-nullvm_both",
@@ -151,6 +153,7 @@ new Chart(document.getElementById("cpu-server-conn-release"), {
                 backgroundColor: "rgba(52, 235, 219, 0.2)",
                 borderColor: "rgba(52, 235, 219, 1)",
                 data: cpu_server_none_plaintext_both,
+                hidden: true,
                 fill: false
             }, {
                 label: "v2-stats-nullvm_both",
@@ -206,6 +209,7 @@ new Chart(document.getElementById("cpu-server-conn-master"), {
                 backgroundColor: "rgba(52, 235, 219, 0.2)",
                 borderColor: "rgba(52, 235, 219, 1)",
                 data: cpu_server_none_plaintext_both_master,
+                hidden: true,
                 fill: false
             }, {
                 label: "v2-stats-nullvm_both",
@@ -261,6 +265,7 @@ new Chart(document.getElementById("cpu-ingressgw-conn-release"), {
                 backgroundColor: "rgba(52, 235, 219, 0.2)",
                 borderColor: "rgba(52, 235, 219, 1)",
                 data: cpu_ingressgw_none_plaintext_both,
+                hidden: true,
                 fill: false
             }, {
                 label: "v2-stats-nullvm_both",
@@ -316,6 +321,7 @@ new Chart(document.getElementById("cpu-ingressgw-conn-master"), {
                 backgroundColor: "rgba(52, 235, 219, 0.2)",
                 borderColor: "rgba(52, 235, 219, 1)",
                 data: cpu_ingressgw_none_plaintext_both_master,
+                hidden: true,
                 fill: false
             }, {
                 label: "v2-stats-nullvm_both",

--- a/perf_dashboard/static/js/cpu_qps.js
+++ b/perf_dashboard/static/js/cpu_qps.js
@@ -41,6 +41,7 @@ new Chart(document.getElementById("cpu-client-qps-release"), {
                 backgroundColor: "rgba(52, 235, 219, 0.2)",
                 borderColor: "rgba(52, 235, 219, 1)",
                 data: cpu_client_none_plaintext_both,
+                hidden: true,
                 fill: false
             }, {
                 label: "v2-stats-nullvm_both",
@@ -96,6 +97,7 @@ new Chart(document.getElementById("cpu-client-qps-master"), {
                 backgroundColor: "rgba(52, 235, 219, 0.2)",
                 borderColor: "rgba(52, 235, 219, 1)",
                 data: cpu_client_none_plaintext_both_master,
+                hidden: true,
                 fill: false
             }, {
                 label: "v2-stats-nullvm_both",
@@ -151,6 +153,7 @@ new Chart(document.getElementById("cpu-server-qps-release"), {
                 backgroundColor: "rgba(52, 235, 219, 0.2)",
                 borderColor: "rgba(52, 235, 219, 1)",
                 data: cpu_server_none_plaintext_both,
+                hidden: true,
                 fill: false
             }, {
                 label: "v2-stats-nullvm_both",
@@ -206,6 +209,7 @@ new Chart(document.getElementById("cpu-server-qps-master"), {
                 backgroundColor: "rgba(52, 235, 219, 0.2)",
                 borderColor: "rgba(52, 235, 219, 1)",
                 data: cpu_server_none_plaintext_both_master,
+                hidden: true,
                 fill: false
             }, {
                 label: "v2-stats-nullvm_both",
@@ -261,6 +265,7 @@ new Chart(document.getElementById("cpu-ingressgw-qps-release"), {
                 backgroundColor: "rgba(52, 235, 219, 0.2)",
                 borderColor: "rgba(52, 235, 219, 1)",
                 data: cpu_ingressgw_none_plaintext_both,
+                hidden: true,
                 fill: false
             }, {
                 label: "v2-stats-nullvm_both",
@@ -316,6 +321,7 @@ new Chart(document.getElementById("cpu-ingressgw-qps-master"), {
                 backgroundColor: "rgba(52, 235, 219, 0.2)",
                 borderColor: "rgba(52, 235, 219, 1)",
                 data: cpu_ingressgw_none_plaintext_both_master,
+                hidden: true,
                 fill: false
             }, {
                 label: "v2-stats-nullvm_both",

--- a/perf_dashboard/static/js/latency_common_func.js
+++ b/perf_dashboard/static/js/latency_common_func.js
@@ -119,6 +119,7 @@ window.generateLatencyChartByID = function(chartID, xNum, modesData, options) {
                 backgroundColor: "rgba(52, 235, 219, 0.2)",
                 borderColor: "rgba(52, 235, 219, 1)",
                 data: modesData[2],
+                hidden: true,
                 fill: false
             }, {
                 label: "v2-stats-nullvm_both",

--- a/perf_dashboard/static/js/mem_conn.js
+++ b/perf_dashboard/static/js/mem_conn.js
@@ -41,6 +41,7 @@ new Chart(document.getElementById("mem-client-conn-release"), {
                 backgroundColor: "rgba(52, 235, 219, 0.2)",
                 borderColor: "rgba(52, 235, 219, 1)",
                 data: mem_client_none_plaintext_both,
+                hidden: true,
                 fill: false
             }, {
                 label: "v2-stats-nullvm_both",
@@ -96,6 +97,7 @@ new Chart(document.getElementById("mem-client-conn-master"), {
                 backgroundColor: "rgba(52, 235, 219, 0.2)",
                 borderColor: "rgba(52, 235, 219, 1)",
                 data: mem_client_none_plaintext_both_master,
+                hidden: true,
                 fill: false
             }, {
                 label: "v2-stats-nullvm_both",
@@ -151,6 +153,7 @@ new Chart(document.getElementById("mem-server-conn-release"), {
                 backgroundColor: "rgba(52, 235, 219, 0.2)",
                 borderColor: "rgba(52, 235, 219, 1)",
                 data: mem_server_none_plaintext_both,
+                hidden: true,
                 fill: false
             }, {
                 label: "v2-stats-nullvm_both",
@@ -206,6 +209,7 @@ new Chart(document.getElementById("mem-server-conn-master"), {
                 backgroundColor: "rgba(52, 235, 219, 0.2)",
                 borderColor: "rgba(52, 235, 219, 1)",
                 data: mem_server_none_plaintext_both_master,
+                hidden: true,
                 fill: false
             }, {
                 label: "v2-stats-nullvm_both",
@@ -261,6 +265,7 @@ new Chart(document.getElementById("mem-ingressgw-conn-release"), {
                 backgroundColor: "rgba(52, 235, 219, 0.2)",
                 borderColor: "rgba(52, 235, 219, 1)",
                 data: mem_ingressgw_none_plaintext_both,
+                hidden: true,
                 fill: false
             }, {
                 label: "v2-stats-nullvm_both",
@@ -316,6 +321,7 @@ new Chart(document.getElementById("mem-ingressgw-conn-master"), {
                 backgroundColor: "rgba(52, 235, 219, 0.2)",
                 borderColor: "rgba(52, 235, 219, 1)",
                 data: mem_ingressgw_none_plaintext_both_master,
+                hidden: true,
                 fill: false
             }, {
                 label: "v2-stats-nullvm_both",

--- a/perf_dashboard/static/js/mem_qps.js
+++ b/perf_dashboard/static/js/mem_qps.js
@@ -41,6 +41,7 @@ new Chart(document.getElementById("mem-client-qps-release"), {
                 backgroundColor: "rgba(52, 235, 219, 0.2)",
                 borderColor: "rgba(52, 235, 219, 1)",
                 data: mem_client_none_plaintext_both,
+                hidden: true,
                 fill: false
             }, {
                 label: "v2-stats-nullvm_both",
@@ -96,6 +97,7 @@ new Chart(document.getElementById("mem-client-qps-master"), {
                 backgroundColor: "rgba(52, 235, 219, 0.2)",
                 borderColor: "rgba(52, 235, 219, 1)",
                 data: mem_client_none_plaintext_both_master,
+                hidden: true,
                 fill: false
             }, {
                 label: "v2-stats-nullvm_both",
@@ -151,6 +153,7 @@ new Chart(document.getElementById("mem-server-qps-release"), {
                 backgroundColor: "rgba(52, 235, 219, 0.2)",
                 borderColor: "rgba(52, 235, 219, 1)",
                 data: mem_server_none_plaintext_both,
+                hidden: true,
                 fill: false
             }, {
                 label: "v2-stats-nullvm_both",
@@ -206,6 +209,7 @@ new Chart(document.getElementById("mem-server-qps-master"), {
                 backgroundColor: "rgba(52, 235, 219, 0.2)",
                 borderColor: "rgba(52, 235, 219, 1)",
                 data: mem_server_none_plaintext_both_master,
+                hidden: true,
                 fill: false
             }, {
                 label: "v2-stats-nullvm_both",
@@ -261,6 +265,7 @@ new Chart(document.getElementById("mem-ingressgw-qps-release"), {
                 backgroundColor: "rgba(52, 235, 219, 0.2)",
                 borderColor: "rgba(52, 235, 219, 1)",
                 data: mem_ingressgw_none_plaintext_both,
+                hidden: true,
                 fill: false
             }, {
                 label: "v2-stats-nullvm_both",
@@ -316,6 +321,7 @@ new Chart(document.getElementById("mem-ingressgw-qps-master"), {
                 backgroundColor: "rgba(52, 235, 219, 0.2)",
                 borderColor: "rgba(52, 235, 219, 1)",
                 data: mem_ingressgw_none_plaintext_both_master,
+                hidden: true,
                 fill: false
             }, {
                 label: "v2-stats-nullvm_both",


### PR DESCRIPTION
As we already collected enough data from Dec 2nd for plaintext, this PR is to disable its running from pipeline. @incfly will made a following fix for the none_mtls vs plaintext issues. 