### PR TITLE
Use upstream envoy build image as base for proxy build tools.

### DIFF
--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -507,54 +507,6 @@ WORKDIR /
 
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint"]
 
-##############
-# Clang+LLVM
-##############
-
-FROM ubuntu:xenial as clang_context
-
-# hadolint ignore=DL3008
-RUN apt-get update && apt-get -y dist-upgrade && apt-get install -y --no-install-recommends \
-    xz-utils \
-    wget \
-    ca-certificates \
- && apt-get clean \
- && rm -rf /var/lib/apt/lists/*
-
-ENV LLVM_VERSION=10.0.1
-ENV LLVM_TARGET=x86_64-linux-gnu-ubuntu-16.04
-ENV LLVM_BASE_URL=https://github.com/llvm/llvm-project/releases/download/llvmorg-${LLVM_VERSION}
-ENV LLVM_ARCHIVE=clang+llvm-${LLVM_VERSION}-${LLVM_TARGET}
-ENV LLVM_URL=${LLVM_BASE_URL}/${LLVM_ARCHIVE}.tar.xz
-ENV LLVM_DIRECTORY=/usr/lib/llvm
-
-RUN wget ${LLVM_URL}
-RUN tar -xJf ${LLVM_ARCHIVE}.tar.xz -C /tmp
-RUN mkdir -p ${LLVM_DIRECTORY}
-RUN mv /tmp/${LLVM_ARCHIVE}/* ${LLVM_DIRECTORY}/
-
-###########
-# Bazel
-###########
-
-FROM ubuntu:xenial as bazel_context
-
-ENV BAZELISK_VERSION="v1.0"
-ENV BAZELISK_BASE_URL="https://github.com/bazelbuild/bazelisk/releases/download"
-ENV BAZELISK_BIN="bazelisk-linux-amd64"
-ENV BAZELISK_URL="${BAZELISK_BASE_URL}/${BAZELISK_VERSION}/${BAZELISK_BIN}"
-
-# hadolint ignore=DL3008
-RUN apt-get update && apt-get -y dist-upgrade && apt-get install -y --no-install-recommends \
-    wget \
-    ca-certificates \
- && apt-get clean \
- && rm -rf /var/lib/apt/lists/*
-
-RUN wget ${BAZELISK_URL}
-RUN chmod +x ${BAZELISK_BIN}
-RUN mv ${BAZELISK_BIN} /usr/local/bin/bazel
-
 ########################
 # Final image for proxy
 ########################

--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -548,6 +548,7 @@ ENV PATH=${LLVM_DIRECTORY}/bin:$PATH
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Add cmake repository, otherwise `apt-get update` will fail because envoy base image adds this.
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN curl -fsSL https://apt.kitware.com/keys/kitware-archive-latest.asc | apt-key add -
 RUN apt-add-repository "deb https://apt.kitware.com/ubuntu/ $(lsb_release -cs) main"
 

--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -559,7 +559,9 @@ RUN mv ${BAZELISK_BIN} /usr/local/bin/bazel
 # Final image for proxy
 ########################
 
-FROM ubuntu:xenial
+# Use upstream envoy build image as base.
+# Latest tag could be found https://hub.docker.com/r/envoyproxy/envoy-build-ubuntu/tags
+FROM envoyproxy/envoy-build-ubuntu:11efa5680d987fff33fde4af3cc5ece105015d04
 
 # Version from build arguments
 ARG VERSION
@@ -587,11 +589,15 @@ ENV GOBIN=/gobin
 ENV PATH=/usr/local/go/bin:/gobin:/usr/local/google-cloud-sdk/bin:$PATH
 
 # LLVM support
-ENV LLVM_DIRECTORY=/usr/lib/llvm
+ENV LLVM_DIRECTORY=/opt/llvm/bin
 ENV PATH=${LLVM_DIRECTORY}/bin:$PATH
 
 # Avoid interactive input when installing tshark
 ENV DEBIAN_FRONTEND=noninteractive
+
+# Add cmake repository, otherwise `apt-get update` will fail because envoy base image adds this.
+RUN curl -fsSL https://apt.kitware.com/keys/kitware-archive-latest.asc | apt-key add -
+RUN apt-add-repository "deb https://apt.kitware.com/ubuntu/ $(lsb_release -cs) main"
 
 # required for binary tools: ca-certificates, gcc, libc-dev, git, iptables, libltdl7
 # required for general build: make, wget, curl, ssh
@@ -624,7 +630,8 @@ RUN apt-get update && apt-get -y dist-upgrade && apt-get install -y --no-install
 ADD https://download.docker.com/linux/ubuntu/gpg /tmp/docker-key
 RUN apt-key add /tmp/docker-key
 RUN add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu xenial stable"
-RUN apt-get update && apt-get -y install --no-install-recommends \
+# Allow downgrades since envoy base image might have newer docker version.
+RUN apt-get update && apt-get -y install --allow-downgrades --no-install-recommends \
     docker-ce="${DOCKER_VERSION}" \
     docker-ce-cli="${DOCKER_VERSION}" \
     containerd.io="${CONTAINERD_VERSION}" \
@@ -635,35 +642,8 @@ RUN apt-get update && apt-get -y install --no-install-recommends \
 COPY prow-entrypoint.sh /usr/local/bin/entrypoint
 RUN chmod +x /usr/local/bin/entrypoint
 
-# CMake
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN curl -fsSL https://apt.kitware.com/keys/kitware-archive-latest.asc | apt-key add -
-RUN apt-add-repository "deb https://apt.kitware.com/ubuntu/ $(lsb_release -cs) main"
-
-# binary dependencies to build envoy at v1.12.0
-# https://github.com/envoyproxy/envoy/blob/v1.12.0/bazel/README.md
-# hadolint ignore=DL3008
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    autoconf \
-    automake \
-    cmake \
-    libtool \
-    ninja-build \
-    python \
-    unzip \
-    virtualenv \
- && apt-get clean \
- && rm -rf /var/lib/apt/lists/*
-
 COPY --from=binary_tools_context /out/ /
 COPY --from=binary_tools_context /usr/local/go /usr/local/go
-COPY --from=bazel_context /usr/local/bin /usr/local/bin
-COPY --from=clang_context ${LLVM_DIRECTORY}/lib ${LLVM_DIRECTORY}/lib
-COPY --from=clang_context ${LLVM_DIRECTORY}/bin ${LLVM_DIRECTORY}/bin
-COPY --from=clang_context ${LLVM_DIRECTORY}/include ${LLVM_DIRECTORY}/include
-
-RUN echo "${LLVM_DIRECTORY}/lib" | tee /etc/ld.so.conf.d/llvm.conf
-RUN ldconfig
 
 # su-exec is used in place of complex sudo setup operations
 RUN chmod u+sx /usr/bin/su-exec


### PR DESCRIPTION
Maintaining proxy build tools image has been a pain. Import envoy build image as base image for proxy build tools to avoid spending time on many toolchain related issue.