### PR TITLE
cue-gen: make CRD schema creation faster

### DIFF
--- a/cmd/cue-gen/build.go
+++ b/cmd/cue-gen/build.go
@@ -27,7 +27,6 @@ import (
 	"cuelang.org/go/encoding/yaml"
 	"github.com/emicklei/proto"
 	"github.com/kr/pretty"
-
 	apiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/utils/pointer"
 )
@@ -100,6 +99,8 @@ type CrdGen struct {
 
 // CrdConfig contains the CRD for each proto type to be generated.
 type CrdConfig struct {
+	// Contains all directories of source schemas.
+	Directories []string
 	// Optional. Mapping of version to schema name if schema name
 	// not following the <package>.<version>.<name> format.
 	VersionToSchema map[string]string
@@ -257,6 +258,7 @@ func (c *Config) getCrdConfig(filename string) {
 						PreserveUnknownFields:    map[string][]string{},
 					}
 				}
+				c.Crd.CrdConfigs[t].Directories = append(c.Crd.CrdConfigs[t].Directories, filename)
 				d := c.Crd.CrdConfigs[t]
 				convertCrdConfig(v, t, d)
 				if crdToType == nil {

--- a/cmd/cue-gen/genoapi.go
+++ b/cmd/cue-gen/genoapi.go
@@ -393,7 +393,21 @@ func (x *builder) genCRD() {
 		Overlay: x.overlay,
 	}
 
-	instances := load.Instances([]string{"./..."}, cfg)
+	// Filter down to directories containing definitions for CRDs
+	dirset := map[string]struct{}{}
+	for _, v := range x.Crd.CrdConfigs {
+		for _, d := range v.Directories {
+			wd, _ := os.Getwd()
+			rp, _ := filepath.Rel(wd, filepath.Dir(d))
+			dirset["./"+rp] = struct{}{}
+		}
+	}
+	dirs := []string{}
+	for k := range dirset {
+		dirs = append(dirs, k)
+	}
+
+	instances := load.Instances(dirs, cfg)
 
 	frontMatterMap = make(map[string][]string)
 	extractFrontMatter(instances, frontMatterMap)


### PR DESCRIPTION
Currently, we build `./...`. This notable includes the operator. The
operator takes 1min+ to build since its schema is massive. We then throw
it away.

This changes the crd generation logic to just build CRDs we actually
reference in the final output. This drops the runtime from 1min to 3s on
my machine.

Running on istio/api shows no changes to generated output, although its
much faster.