### PR TITLE
Make protoc plugins less sensative to inputs

### DIFF
--- a/cmd/protoc-gen-deepcopy/main.go
+++ b/cmd/protoc-gen-deepcopy/main.go
@@ -15,7 +15,6 @@
 package main
 
 import (
-	gogoplugin "github.com/gogo/protobuf/protoc-gen-gogo/plugin"
 	"github.com/gogo/protobuf/vanity/command"
 
 	"istio.io/tools/cmd/protoc-gen-deepcopy/deepcopy"
@@ -28,18 +27,5 @@ func main() {
 
 	response := command.GeneratePlugin(request, plugin, deepcopy.FileNameSuffix)
 
-	filterResponse(response, plugin.FilesWritten())
-
 	command.Write(response)
-}
-
-func filterResponse(response *gogoplugin.CodeGeneratorResponse, written map[string]interface{}) {
-	files := response.GetFile()
-	filtered := make([]*gogoplugin.CodeGeneratorResponse_File, 0, len(files))
-	for _, file := range files {
-		if _, ok := written[file.GetName()]; ok {
-			filtered = append(filtered, file)
-		}
-	}
-	response.File = filtered
 }

--- a/cmd/protoc-gen-jsonshim/main.go
+++ b/cmd/protoc-gen-jsonshim/main.go
@@ -15,7 +15,6 @@
 package main
 
 import (
-	gogoplugin "github.com/gogo/protobuf/protoc-gen-gogo/plugin"
 	"github.com/gogo/protobuf/vanity/command"
 
 	"istio.io/tools/cmd/protoc-gen-jsonshim/jsonshim"
@@ -28,18 +27,5 @@ func main() {
 
 	response := command.GeneratePlugin(request, plugin, jsonshim.FileNameSuffix)
 
-	filterResponse(response, plugin.FilesWritten())
-
 	command.Write(response)
-}
-
-func filterResponse(response *gogoplugin.CodeGeneratorResponse, written map[string]interface{}) {
-	files := response.GetFile()
-	filtered := make([]*gogoplugin.CodeGeneratorResponse_File, 0, len(files))
-	for _, file := range files {
-		if _, ok := written[file.GetName()]; ok {
-			filtered = append(filtered, file)
-		}
-	}
-	response.File = filtered
 }


### PR DESCRIPTION
Currently, we are filtering out places where the paths don't match. I
don't see why we do this, and it breaks some tools like `buf` which end
up passing things as relative or absolute (whatever the Makefile
currently does not do). This change makes `buf` work, while at the same
time having no impact on current istio/api `master` branch.