### PR TITLE
Add tsan instrumented libcxx build to proxy build tools.

### DIFF
--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -665,6 +665,9 @@ COPY --from=clang_context ${LLVM_DIRECTORY}/include ${LLVM_DIRECTORY}/include
 RUN echo "${LLVM_DIRECTORY}/lib" | tee /etc/ld.so.conf.d/llvm.conf
 RUN ldconfig
 
+COPY proxy-tsan-instrumented-libcxx.sh proxy-tsan-instrumented-libcxx.sh
+RUN ./proxy-tsan-instrumented-libcxx.sh
+
 # su-exec is used in place of complex sudo setup operations
 RUN chmod u+sx /usr/bin/su-exec
 

--- a/docker/build-tools/proxy-tsan-instrumented-libcxx.sh
+++ b/docker/build-tools/proxy-tsan-instrumented-libcxx.sh
@@ -1,0 +1,32 @@
+# gcc-9, need to build instrumented LLVM libc++ for tsan testing.
+add-apt-repository -y ppa:ubuntu-toolchain-r/test
+apt-get update && apt-get install -y --no-install-recommends g++-9
+update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 1000
+update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 1000
+update-alternatives --config gcc
+update-alternatives --config g++
+
+# Instrumented libcxx built from LLVM source, used for tsan testing.
+# See envoy dev guide for more info: https://github.com/envoyproxy/envoy/blob/v1.17.0/bazel/README.md#sanitizers
+LLVM_VERSION=10.0.1
+LLVM_ARCHIVE=llvmorg-${LLVM_VERSION}.tar.gz
+LLVM_ARCHIVE_URL=https://github.com/llvm/llvm-project/archive/${LLVM_ARCHIVE}
+wget ${LLVM_ARCHIVE_URL}
+tar -xzf ${LLVM_ARCHIVE} -C /tmp
+mkdir tsan
+pushd tsan
+
+cmake \
+-GNinja \
+-DLLVM_ENABLE_PROJECTS="libcxxabi;libcxx" \
+-DLLVM_USE_LINKER=lld \
+-DLLVM_USE_SANITIZER=Thread \
+-DCMAKE_BUILD_TYPE=Release \
+-DCMAKE_C_COMPILER=clang \
+-DCMAKE_CXX_COMPILER=clang++ \
+-DCMAKE_INSTALL_PREFIX="/opt/libcxx_tsan" "/tmp/llvm-project-llvmorg-${LLVM_VERSION}/llvm"
+
+ninja install-cxx install-cxxabi
+
+rm -rf /opt/libcxx_tsan/include
+popd

--- a/docker/build-tools/proxy-tsan-instrumented-libcxx.sh
+++ b/docker/build-tools/proxy-tsan-instrumented-libcxx.sh
@@ -1,3 +1,21 @@
+#!/usr/bin/env bash
+
+# Copyright Istio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eux
+
 # gcc-9, need to build instrumented LLVM libc++ for tsan testing.
 add-apt-repository -y ppa:ubuntu-toolchain-r/test
 apt-get update && apt-get install -y --no-install-recommends g++-9
@@ -14,7 +32,7 @@ LLVM_ARCHIVE_URL=https://github.com/llvm/llvm-project/archive/${LLVM_ARCHIVE}
 wget ${LLVM_ARCHIVE_URL}
 tar -xzf ${LLVM_ARCHIVE} -C /tmp
 mkdir tsan
-pushd tsan
+pushd tsan || exit
 
 cmake \
 -GNinja \
@@ -29,4 +47,4 @@ cmake \
 ninja install-cxx install-cxxabi
 
 rm -rf /opt/libcxx_tsan/include
-popd
+popd || exit


### PR DESCRIPTION
This is needed to fix v8 build tsan failure. Example failure: https://storage.googleapis.com/istio-prow/pr-logs/pull/istio_proxy/3139/test-tsan_proxy/1347694956147380224/build-log.txt

For some reason I cannot make `RUN ninja  install-cxx install-cxxabi` work, so I wrapped relevant logic in a separate script.