### PR TITLE
Make docs plugin behave more like other plugins

### DIFF
--- a/cmd/protoc-gen-docs/main.go
+++ b/cmd/protoc-gen-docs/main.go
@@ -21,11 +21,10 @@ import (
 	"strings"
 
 	"github.com/client9/gospell"
+	plugin "github.com/golang/protobuf/protoc-gen-go/plugin"
 
 	"istio.io/tools/pkg/protocgen"
 	"istio.io/tools/pkg/protomodel"
-
-	plugin "github.com/golang/protobuf/protoc-gen-go/plugin"
 )
 
 // Breaks the comma-separated list of key=value pairs
@@ -124,8 +123,6 @@ func generate(request plugin.CodeGeneratorRequest) (*plugin.CodeGeneratorRespons
 			dictionary = v
 		} else if k == "custom_word_list" {
 			customWordList = v
-		} else {
-			return nil, fmt.Errorf("unknown argument '%s' specified", k)
 		}
 	}
 


### PR DESCRIPTION
Currently, the docs plugin behaves a bit odd, expecting different input
format/output format from other plugins. This makes usage of the plugin
require custom tooling, which is a bit of a pain.

With the changes here, standard tooling like prototool, buf, or simpler
makefiles can easily be used.

Rather than requiring a different option per-folder based on the
expected docs output, the `mode` configuration is moved inline.