### PR TITLE
update to point to release 1.9

### DIFF
--- a/perf/other/multicluster-vpc/setup.sh
+++ b/perf/other/multicluster-vpc/setup.sh
@@ -104,7 +104,7 @@ function install_istio() {
 	pushd tmp/istio-${RELEASE}
 	# shellcheck disable=SC2086
 	for i in install/kubernetes/helm/istio-init/files/crd*yaml; do kubectl apply -f $i; done
-	helm repo add istio.io "https://storage.googleapis.com/istio-prerelease/daily-build/master-latest-daily/charts"
+	helm repo add istio.io "https://storage.googleapis.com/istio-prerelease/daily-build/release-1.9/charts"
 	helm dep update install/kubernetes/helm/istio
 	helm template install/kubernetes/helm/istio --name istio --namespace istio-system > ./istio_master.yaml
 	kubectl create ns istio-system

--- a/perf/stability/istio-chaos-partial/values.yaml
+++ b/perf/stability/istio-chaos-partial/values.yaml
@@ -1,4 +1,4 @@
 namespace: istio-chaos-partial
 chaosIntervalMinutes: 1
 components: istio-pilot istio-citadel istio-galley istio-policy istio-telemetry istio-tracing
-kubectlImage: gcr.io/istio-release/kubectl:master-latest-daily
+kubectlImage: gcr.io/istio-release/kubectl:release-1.9

--- a/perf/stability/istio-chaos-total/values.yaml
+++ b/perf/stability/istio-chaos-total/values.yaml
@@ -3,4 +3,4 @@ chaosIntervalMinutes: 2 # Must be greater than duration to avoid race conditions
 chaosDurationMinutes: 1
 chaosLevel: 3 # The maximum number of components to kill simultaneously, selected at random.
 components: istio-pilot istio-citadel istio-galley istio-policy istio-telemetry istio-tracing
-kubectlImage: gcr.io/istio-release/kubectl:master-latest-daily
+kubectlImage: gcr.io/istio-release/kubectl:release-1.9

--- a/perf/stability/istio-upgrader/values.yaml
+++ b/perf/stability/istio-upgrader/values.yaml
@@ -1,3 +1,3 @@
 namespace: istio-upgrader
 redployMinutes: 30
-kubectlImage: gcr.io/istio-release/kubectl:master-latest-daily
+kubectlImage: gcr.io/istio-release/kubectl:release-1.9

--- a/perf/stability/looper/templates/client.yaml
+++ b/perf/stability/looper/templates/client.yaml
@@ -14,7 +14,7 @@ spec:
       serviceAccount: looper-service-account
       containers:
       - name: client
-        image: gcr.io/istio-release/kubectl:master-latest-daily
+        image: gcr.io/istio-release/kubectl:release-1.9
         args:
           - bash
           - -c

--- a/setup/stability-extra/multicluster-vpn/setup.sh
+++ b/setup/stability-extra/multicluster-vpn/setup.sh
@@ -35,7 +35,7 @@
 # $ ISTIO_INSTALLER_PATH=~/works/installer \
 #   ISTIOCTL="go run istio.io/istio/istioctl/cmd/istioctl" \
 #   HUB=gcr.io/istio-release \
-#   TAG=master-latest-daily \
+#   TAG=release-1.9 \
 #   KUBECONTEXT1=gke_istio-test-230101_us-central1-a_mc-s \
 #   KUBECONTEXT2=gke_istio-test-230101_us-west1-a_mc-uswest \
 #   ./setup.sh
@@ -44,7 +44,7 @@
 set -e
 
 HUB="${HUB:-gcr.io/istio-release}"
-TAG="${TAG:-master-latest-daily}"
+TAG="${TAG:-release-1.9}"
 APPS_NAMESPACE="${APPS_NAMESPACE:-istio-stability-multicluster-vpn}"
 ISTIOCTL="${ISTIOCTL:-istioctl}"
 


### PR DESCRIPTION
As part of this step

> Update all repos that point to master branch of another repo to point to the release branch. master-latest-daily -> 1.9-dev (see https://discuss.istio.io/t/deprecation-notice-daily-builds/3991), latest -> 1.9-dev, git clone master to git clone release-1.9, etc.

Part of https://github.com/istio/istio/issues/29490#