### PR TITLE
[release-1.6] update kubetest2 version

### DIFF
--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -62,6 +62,8 @@ ENV SU_EXEC_VERSION=0.2
 ENV UPX_VERSION=3.95
 ENV YQ_VERSION=3.3.0
 ENV GCLOUD_VERSION=317.0.0
+ENV KUBETEST2_VERSION=7e3048643e9b1bc5ffee41b016b67e5efe0d3201
+ENV BOSKOSCTL_VERSION=c6d730e323f06da1b56dfa14bdab6d7d5dc22e2a
 
 ENV GO111MODULE=on
 ENV GOPROXY=https://proxy.golang.org
@@ -136,10 +138,10 @@ RUN rm -rf /tmp/go/pkg/mod/cache/download/k8s.io
 # Install istio/test-infra tools
 RUN gobin istio.io/test-infra/boskos/cmd/mason_client
 RUN gobin k8s.io/test-infra/robots/pr-creator
-RUN gobin sigs.k8s.io/kubetest2
-RUN gobin sigs.k8s.io/kubetest2/kubetest2-gke
-RUN gobin sigs.k8s.io/kubetest2/kubetest2-tester-exec
-RUN gobin sigs.k8s.io/boskos/cmd/boskosctl
+RUN gobin sigs.k8s.io/kubetest2@${KUBETEST2_VERSION}
+RUN gobin sigs.k8s.io/kubetest2/kubetest2-gke@${KUBETEST2_VERSION}
+RUN gobin sigs.k8s.io/kubetest2/kubetest2-tester-exec@${KUBETEST2_VERSION}
+RUN gobin sigs.k8s.io/boskos/cmd/boskosctl@${BOSKOSCTL_VERSION}
 
 # gobin does not seem to be compatible with this pesky code-generator repo
 # Install the code generator tools, and hopefully only these tools, this way


### PR DESCRIPTION
This is a manual cherrypick of #1394 due to the merge conflicts when using the cherrypick plugin.