### PR TITLE
Add VM test

### DIFF
--- a/perf/load/bootstrap-vm.sh
+++ b/perf/load/bootstrap-vm.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+
+# Copyright Istio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eux
+
+red='\[\033[0;31m\]'
+clr='\[\033[0m\]'
+
+VM_APP="${VM_APP:?}"
+VM_NAME="${VM_NAME:-${VM_APP}}"
+VM_NAMESPACE="${VM_NAMESPACE:?}"
+PROJECT="${PROJECT:-mixologist-142215}"
+ZONE="${ZONE:-us-central1-c}"
+WORK_DIR=/tmp/vm
+SERVICE_ACCOUNT=default
+export CLOUDSDK_COMPUTE_ZONE="${ZONE}"
+export CLOUDSDK_CORE_PROJECT="${PROJECT}"
+
+docker-copy() {
+    image="${1:?image}"
+    src="${2:?src}"
+    dst="${3:?dst}"
+    docker create --rm --name temp-docker-copy "${image}"
+    docker cp temp-docker-copy:"${src}" "${dst}"
+    docker stop temp-docker-copy
+    docker rm temp-docker-copy
+}
+
+gcloud compute instances describe "${VM_APP:?}" > /dev/null 2>&1 && { echo "${red}Instance already configured! Warning: script will not update VM.${clr}"; exit 0; }
+
+gcloud compute instances create "${VM_NAME}" \
+  --image-family debian-10 --image-project debian-cloud \
+  --machine-type e2-standard-2
+
+kubectl create namespace "${VM_NAMESPACE}" || true
+kubectl create serviceaccount "${SERVICE_ACCOUNT}" -n "${VM_NAMESPACE}" || true
+
+kubectl get cm -n "${VM_NAMESPACE}" service-graph-config -ojsonpath='{.data.service-graph}' > "${WORK_DIR}"/service-graph.yaml
+
+istioctl x workload group create --name "${VM_APP}" --namespace "${VM_NAMESPACE}" --labels app="${VM_APP}" --serviceAccount "${SERVICE_ACCOUNT}" >  "${WORK_DIR}"/workloadgroup.yaml
+cat <<EOF > "${WORK_DIR}"/workloadgroup.yaml
+apiVersion: networking.istio.io/v1alpha3
+kind: WorkloadGroup
+metadata:
+  name: "${VM_APP}"
+  namespace: "${VM_NAMESPACE}"
+spec:
+  metadata:
+    labels:
+      app: "${VM_APP}"
+  template:
+    serviceAccount: "${SERVICE_ACCOUNT}"
+  probe:
+    httpGet:
+      path: /metrics
+      port: 8080
+    initialDelaySeconds: 5
+    periodSeconds: 5
+EOF
+
+kubectl --namespace "${VM_NAMESPACE}" apply -f "${WORK_DIR}"/workloadgroup.yaml
+
+istioctl x workload entry configure -f "${WORK_DIR}"/workloadgroup.yaml -o "${WORK_DIR}" --autoregister
+
+# Wait until we can ssh
+sleep 15
+
+cat <<EOF > "${WORK_DIR}"/isotope.service
+[Unit]
+Description=Isotope
+After=network.target
+StartLimitIntervalSec=0
+[Service]
+Type=simple
+Restart=always
+Environment="SERVICE_NAME=${VM_APP}"
+RestartSec=1
+ExecStart=/usr/bin/isotope_service --max-idle-connections-per-host=32
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+docker-copy gcr.io/istio-testing/isotope:0.0.1 /usr/local/bin/isotope_service  "${WORK_DIR}"/isotope_service
+
+gcloud compute scp "${WORK_DIR}"/* "${VM_APP}":
+gcloud compute ssh  "${VM_APP}" -- sudo bash -c '"
+mkdir -p /etc/certs /var/run/secrets/tokens /etc/istio/config/ /etc/istio/proxy /etc/config
+curl -LO https://storage.googleapis.com/istio-build/dev/1.10-alpha.45c5661eb8c96cebe8fcb467b4c1be3262b0de4c/deb/istio-sidecar.deb
+sudo dpkg -i istio-sidecar.deb
+cp root-cert.pem /etc/certs/root-cert.pem
+cp istio-token /var/run/secrets/tokens/istio-token
+cp cluster.env /var/lib/istio/envoy/cluster.env
+cp mesh.yaml /etc/istio/config/mesh
+cp service-graph.yaml /etc/config/service-graph.yaml
+cp isotope_service /usr/bin/isotope_service
+cp isotope.service /etc/systemd/system/isotope.service
+chmod 777 /etc/config/service-graph.yaml
+cat hosts >> /etc/hosts
+chown -R istio-proxy /var/lib/istio /etc/certs /etc/istio/proxy /etc/istio/config /var/run/secrets /etc/certs/root-cert.pem
+systemctl start istio
+systemctl start isotope
+"'

--- a/perf/load/bootstrap-vm.sh
+++ b/perf/load/bootstrap-vm.sh
@@ -22,12 +22,15 @@ clr='\[\033[0m\]'
 VM_APP="${VM_APP:?}"
 VM_NAME="${VM_NAME:-${VM_APP}}"
 VM_NAMESPACE="${VM_NAMESPACE:?}"
+VERSION="${VERSION:?"version, like 1.10-alpha.45c5661eb8c96cebe8fcb467b4c1be3262b0de4c"}"
 PROJECT="${PROJECT:-mixologist-142215}"
 ZONE="${ZONE:-us-central1-c}"
 WORK_DIR=/tmp/vm
 SERVICE_ACCOUNT=default
 export CLOUDSDK_COMPUTE_ZONE="${ZONE}"
 export CLOUDSDK_CORE_PROJECT="${PROJECT}"
+
+mkdir -p "${WORK_DIR}"
 
 docker-copy() {
     image="${1:?image}"
@@ -97,9 +100,9 @@ EOF
 docker-copy gcr.io/istio-testing/isotope:0.0.1 /usr/local/bin/isotope_service  "${WORK_DIR}"/isotope_service
 
 gcloud compute scp "${WORK_DIR}"/* "${VM_APP}":
-gcloud compute ssh  "${VM_APP}" -- sudo bash -c '"
+gcloud compute ssh  "${VM_APP}" -- sudo bash -c "\"
 mkdir -p /etc/certs /var/run/secrets/tokens /etc/istio/config/ /etc/istio/proxy /etc/config
-curl -LO https://storage.googleapis.com/istio-build/dev/1.10-alpha.45c5661eb8c96cebe8fcb467b4c1be3262b0de4c/deb/istio-sidecar.deb
+curl -LO https://storage.googleapis.com/istio-build/dev/${VERSION}/deb/istio-sidecar.deb
 sudo dpkg -i istio-sidecar.deb
 cp root-cert.pem /etc/certs/root-cert.pem
 cp istio-token /var/run/secrets/tokens/istio-token
@@ -113,4 +116,4 @@ cat hosts >> /etc/hosts
 chown -R istio-proxy /var/lib/istio /etc/certs /etc/istio/proxy /etc/istio/config /var/run/secrets /etc/certs/root-cert.pem
 systemctl start istio
 systemctl start isotope
-"'
+\""

--- a/perf/load/common.sh
+++ b/perf/load/common.sh
@@ -27,6 +27,7 @@ function run_test() {
   MULTI_CLUSTER=${MULTI_CLUSTER:-"false"}
   CLUSTER1=${CLUSTER1:-"false"}
   CLUSTER2=${CLUSTER2:-"false"}
+  VM_ENABLED="${VM_ENABLED:-false}"
   YAML=$(mktemp).yml
   # shellcheck disable=SC2086
   helm -n ${ns} template \
@@ -39,6 +40,7 @@ function run_test() {
           --set multicluster.enabled="${MULTI_CLUSTER}" \
           --set multicluster.cluster1="${CLUSTER1}" \
           --set multicluster.cluster2="${CLUSTER2}" \
+          --set vm.enabled="${VM_ENABLED}" \
           . > "${YAML}"
   echo "Wrote ${YAML}"
 
@@ -51,6 +53,10 @@ function run_test() {
   else
     kubectl -n "${ns}" delete -f "${YAML}" || true
     kubectl delete ns "${ns}"
+  fi
+  if [[ "${VM_ENABLED}" == "true" ]]; then
+    VM_NAMESPACE="${ns}" VM_APP="${prefix}0-9"  ./bootstrap-vm.sh
+    VM_NAMESPACE="${ns}" VM_APP="${prefix}0-9-0"  ./bootstrap-vm.sh
   fi
 }
 
@@ -70,6 +76,6 @@ function start_servicegraphs() {
       ${CMD} run_test "${ns}" "${prefix}"
     fi
 
-    sleep 30
+    sleep "${PERF_NAMESPACE_DELAY:-30}"
   }
 }

--- a/perf/load/templates/service-graph.gen.yaml
+++ b/perf/load/templates/service-graph.gen.yaml
@@ -37,6 +37,11 @@ data:
         - call:
             service: {{ .Values.serviceNamePrefix }}0-8
             size: {{ .Values.requestSize }}
+        {{- if .Values.vm.enabled }}
+        - call:
+            service: {{ .Values.serviceNamePrefix }}0-9
+            size: {{ .Values.requestSize }}
+        {{- end}}
       type: http
     - name: {{ .Values.serviceNamePrefix }}0-0
       numReplicas: {{ .Values.replicas }}
@@ -109,7 +114,17 @@ data:
       - - call:
             service: {{ .Values.serviceNamePrefix }}0-8-0
             size: {{ .Values.requestSize }}
+    {{- if .Values.vm.enabled }}
+    - name: {{ .Values.serviceNamePrefix }}0-9
+      numReplicas: {{ .Values.replicas }}
+      responseSize: {{ .Values.responseSize }}
       type: http
+      script:
+      - - call:
+            service: {{ .Values.serviceNamePrefix }}0-9-0
+            size: {{ .Values.requestSize }}
+      type: http
+    {{- end }}
     - name: {{ .Values.serviceNamePrefix }}0-0-0
       numReplicas: {{ .Values.replicas }}
       responseSize: {{ .Values.responseSize }}
@@ -146,6 +161,12 @@ data:
       numReplicas: {{ .Values.replicas }}
       responseSize: {{ .Values.responseSize }}
       type: http
+    {{- if .Values.vm.enabled }}
+    - name: {{ .Values.serviceNamePrefix }}0-9-0
+      numReplicas: {{ .Values.replicas }}
+      responseSize: {{ .Values.responseSize }}
+      type: http
+    {{- end }}
 kind: ConfigMap
 metadata:
   labels:
@@ -1477,3 +1498,59 @@ spec:
     app: {{ .Values.serviceNamePrefix }}0-8-0
 status:
 {{- end}}
+---
+{{- if .Values.vm.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: service-graph
+  name: {{ .Values.serviceNamePrefix }}0-9
+spec:
+  ports:
+  - name: {{ .Values.httpPortName }}
+    port: 8080
+  selector:
+    app: {{ .Values.serviceNamePrefix }}0-9
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: WorkloadGroup
+metadata:
+  name: {{ .Values.serviceNamePrefix }}0-9
+spec:
+  metadata:
+    labels:
+      app:  {{ .Values.serviceNamePrefix }}0-9
+  template: {}
+  {{- if .Values.readinessProbe }}
+  probe:
+    {{ toJson .Values.readinessProbe }}
+  {{- end}}
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: WorkloadGroup
+metadata:
+  name: {{ .Values.serviceNamePrefix }}0-9-0
+spec:
+  metadata:
+    labels:
+      app:  {{ .Values.serviceNamePrefix }}0-9-0
+  template: {}
+  {{- if .Values.readinessProbe }}
+  probe:
+    {{ toJson .Values.readinessProbe }}
+  {{- end}}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: service-graph
+  name: {{ .Values.serviceNamePrefix }}0-9-0
+spec:
+  ports:
+  - name: tcp-web
+    port: 8080
+  selector:
+    app: {{ .Values.serviceNamePrefix }}0-9-0
+{{- end }}

--- a/perf/load/values.yaml
+++ b/perf/load/values.yaml
@@ -26,6 +26,9 @@ multicluster:
   cluster1: false
   cluster2: false
 
+vm:
+  enabled: false
+
 # time between config changes
 configSleep: 120
 


### PR DESCRIPTION
This adds ability to add a VM. When enabled (off by default), we will add two new services which will be satisfied by VMs. VMs will be created in the setup script using gcloud commands. In the future we may explore better ways to provision these, but this was the best I was able to do in <10 hours - open to ideas for future improvements.
