### PR TITLE
[release-1.8] Update Golang to 1.15.8

### DIFF
--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -25,7 +25,7 @@
 # Binary tools
 ################
 
-ARG GOLANG_IMAGE=golang:1.15.5
+ARG GOLANG_IMAGE=golang:1.15.8
 # hadolint ignore=DL3006
 FROM ${GOLANG_IMAGE} as binary_tools_context
 

--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -33,7 +33,6 @@ FROM ${GOLANG_IMAGE} as binary_tools_context
 ARG ISTIO_TOOLS_SHA
 
 # Pinned versions of stuff we pull in
-ENV FORTIO_VERSION=v1.3.1
 ENV GCR_AUTH_VERSION=1.5.0
 ENV GO_BINDATA_VERSION=v3.1.2
 ENV GO_JUNIT_REPORT_VERSION=af01ea7f8024089b458d804d5cdf190f962a9a0c
@@ -123,7 +122,6 @@ RUN gobin github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger@${PROTOC_GEN
 RUN gobin github.com/jstemmer/go-junit-report@${GO_JUNIT_REPORT_VERSION}
 RUN gobin sigs.k8s.io/kind@${KIND_VERSION}
 RUN gobin github.com/wadey/gocovmerge@${GOCOVMERGE_VERSION}
-RUN gobin github.com/fortio/fortio@${FORTIO_VERSION}
 RUN gobin github.com/imsky/junit-merger/src/junit-merger@${JUNIT_MERGER_VERSION}
 RUN gobin golang.org/x/perf/cmd/benchstat@${BENCHSTAT_VERSION}
 


### PR DESCRIPTION
This will need a follow-on common-files PR to use the build-tools image created when this is merged.