### PR TITLE
add prestop to service graph

### DIFF
--- a/cmd/goc/instrument.go
+++ b/cmd/goc/instrument.go
@@ -23,7 +23,7 @@ import (
 	"path"
 	"strings"
 
-	// nolint: staticcheck - SA1019: package golang.org/x/tools/go/loader is deprecated
+	// nolint: staticcheck
 	"golang.org/x/tools/go/loader"
 )
 

--- a/isotope/service/Dockerfile
+++ b/isotope/service/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /build
 
 RUN GOARCH=amd64 CGO_ENABLED=0 GOOS=linux go build -o isotope_service ./service
 
-FROM alpine
+FROM alpine:3.12
 
 COPY --from=builder /build/isotope_service /usr/local/bin/isotope_service
 

--- a/isotope/service/Dockerfile
+++ b/isotope/service/Dockerfile
@@ -1,7 +1,7 @@
 # Note: this image must be built from the root of the repository for access to
 # the vendor folder.
 
-FROM golang:1.13.8 AS builder
+FROM golang:1.16.0 AS builder
 
 RUN mkdir /build
 
@@ -11,7 +11,7 @@ WORKDIR /build
 
 RUN GOARCH=amd64 CGO_ENABLED=0 GOOS=linux go build -o isotope_service ./service
 
-FROM scratch
+FROM alpine
 
 COPY --from=builder /build/isotope_service /usr/local/bin/isotope_service
 

--- a/perf/load/bootstrap-vm.sh
+++ b/perf/load/bootstrap-vm.sh
@@ -97,7 +97,7 @@ ExecStart=/usr/bin/isotope_service --max-idle-connections-per-host=32
 WantedBy=multi-user.target
 EOF
 
-docker-copy gcr.io/istio-testing/isotope:0.0.1 /usr/local/bin/isotope_service  "${WORK_DIR}"/isotope_service
+docker-copy gcr.io/istio-testing/isotope:0.0.2 /usr/local/bin/isotope_service  "${WORK_DIR}"/isotope_service
 
 gcloud compute scp "${WORK_DIR}"/* "${VM_APP}":
 gcloud compute ssh  "${VM_APP}" -- sudo bash -c "\"

--- a/perf/load/templates/service-graph.gen.yaml
+++ b/perf/load/templates/service-graph.gen.yaml
@@ -366,7 +366,6 @@ spec:
     port: 8080
   selector:
     app: {{ .Values.serviceNamePrefix }}0-0
-status:
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -436,7 +435,6 @@ spec:
     port: 8080
   selector:
     app: {{ .Values.serviceNamePrefix }}0-1
-status:
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -506,7 +504,6 @@ spec:
     port: 8080
   selector:
     app: {{ .Values.serviceNamePrefix }}0-2
-status:
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -576,7 +573,6 @@ spec:
     port: 8080
   selector:
     app: {{ .Values.serviceNamePrefix }}0-3
-status:
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -646,7 +642,6 @@ spec:
     port: 8080
   selector:
     app: {{ .Values.serviceNamePrefix }}0-4
-status:
 ---
 apiVersion: v1
 kind: Service
@@ -660,7 +655,6 @@ spec:
     port: 8080
   selector:
     app: {{ .Values.serviceNamePrefix }}0-5
-status:
 ---
 apiVersion: v1
 kind: Service
@@ -674,7 +668,6 @@ spec:
     port: 8080
   selector:
     app: {{ .Values.serviceNamePrefix }}0-6
-status:
 ---
 apiVersion: v1
 kind: Service
@@ -688,7 +681,6 @@ spec:
     port: 8080
   selector:
     app: {{ .Values.serviceNamePrefix }}0-7
-status:
 ---
 apiVersion: v1
 kind: Service
@@ -702,7 +694,6 @@ spec:
     port: 8080
   selector:
     app: {{ .Values.serviceNamePrefix }}0-8
-status:
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -772,7 +763,6 @@ spec:
     port: 8080
   selector:
     app: {{ .Values.serviceNamePrefix }}0-0-0
-status:
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -842,7 +832,6 @@ spec:
     port: 8080
   selector:
     app: {{ .Values.serviceNamePrefix }}0-1-0
-status:
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -912,7 +901,6 @@ spec:
     port: 8080
   selector:
     app: {{ .Values.serviceNamePrefix }}0-2-0
-status:
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -982,7 +970,6 @@ spec:
     port: 8080
   selector:
     app: {{ .Values.serviceNamePrefix }}0-3-0
-status:
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -1052,7 +1039,6 @@ spec:
     port: 8080
   selector:
     app: {{ .Values.serviceNamePrefix }}0-4-0
-status:
 
 {{- end}}
 ---
@@ -1082,13 +1068,13 @@ spec:
     spec:
       containers:
       - args:
-          - --max-idle-connections-per-host=32
-          lifecycle:
-            preStop:
-              exec:
-                command: # Do not shut the application down immediately
-                  - "sleep"
-                  - "10s"
+        - --max-idle-connections-per-host=32
+        lifecycle:
+          preStop:
+            exec:
+              command: # Do not shut the application down immediately
+                - "sleep"
+                - "10s"
         env:
           - name: SERVICE_NAME
             value: {{ .Values.serviceNamePrefix }}0-5
@@ -1126,7 +1112,6 @@ spec:
     port: 8080
   selector:
     app: {{ .Values.serviceNamePrefix }}0-5
-status:
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -1152,13 +1137,13 @@ spec:
     spec:
       containers:
       - args:
-          - --max-idle-connections-per-host=32
-          lifecycle:
-            preStop:
-              exec:
-                command: # Do not shut the application down immediately
-                  - "sleep"
-                  - "10s"
+        - --max-idle-connections-per-host=32
+        lifecycle:
+          preStop:
+            exec:
+              command: # Do not shut the application down immediately
+                - "sleep"
+                - "10s"
         env:
           - name: SERVICE_NAME
             value: {{ .Values.serviceNamePrefix }}0-6
@@ -1196,7 +1181,6 @@ spec:
       port: 8080
   selector:
     app: {{ .Values.serviceNamePrefix }}0-6
-status:
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -1222,13 +1206,13 @@ spec:
     spec:
       containers:
       - args:
-          - --max-idle-connections-per-host=32
-          lifecycle:
-            preStop:
-              exec:
-                command: # Do not shut the application down immediately
-                  - "sleep"
-                  - "10s"
+        - --max-idle-connections-per-host=32
+        lifecycle:
+          preStop:
+            exec:
+              command: # Do not shut the application down immediately
+                - "sleep"
+                - "10s"
         env:
           - name: SERVICE_NAME
             value: {{ .Values.serviceNamePrefix }}0-7
@@ -1266,7 +1250,6 @@ spec:
     port: 8080
   selector:
     app: {{ .Values.serviceNamePrefix }}0-7
-status:
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -1292,13 +1275,13 @@ spec:
     spec:
       containers:
         - args:
-            - --max-idle-connections-per-host=32
-            lifecycle:
-              preStop:
-                exec:
-                  command: # Do not shut the application down immediately
-                    - "sleep"
-                    - "10s"
+          - --max-idle-connections-per-host=32
+          lifecycle:
+            preStop:
+              exec:
+                command: # Do not shut the application down immediately
+                  - "sleep"
+                  - "10s"
           env:
             - name: SERVICE_NAME
               value: {{ .Values.serviceNamePrefix }}0-8
@@ -1336,7 +1319,6 @@ spec:
       port: 8080
   selector:
     app: {{ .Values.serviceNamePrefix }}0-8
-  status:
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -1406,7 +1388,6 @@ spec:
       port: 8080
   selector:
     app: {{ .Values.serviceNamePrefix }}0-5-0
-status:
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -1476,7 +1457,6 @@ spec:
     port: 8080
   selector:
     app: {{ .Values.serviceNamePrefix }}0-6-0
-status:
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -1546,7 +1526,6 @@ spec:
     port: 8080
   selector:
     app: {{ .Values.serviceNamePrefix }}0-7-0
-status:
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -1616,7 +1595,6 @@ spec:
     port: 8080
   selector:
     app: {{ .Values.serviceNamePrefix }}0-8-0
-status:
 {{- end}}
 ---
 {{- if .Values.vm.enabled }}

--- a/perf/load/templates/service-graph.gen.yaml
+++ b/perf/load/templates/service-graph.gen.yaml
@@ -198,6 +198,12 @@ spec:
       containers:
       - args:
         - --max-idle-connections-per-host=32
+        lifecycle:
+          preStop:
+            exec:
+              command: # Do not shut the application down immediately
+                - "sleep"
+                - "10s"
         env:
         - name: SERVICE_NAME
           value: {{ .Values.serviceNamePrefix }}0
@@ -248,6 +254,12 @@ spec:
       containers:
       - args:
         - --max-idle-connections-per-host=32
+        lifecycle:
+          preStop:
+            exec:
+              command: # Do not shut the application down immediately
+                - "sleep"
+                - "10s"
         env:
         - name: SERVICE_NAME
           value: {{ .Values.serviceNamePrefix }}0
@@ -311,6 +323,12 @@ spec:
       containers:
       - args:
         - --max-idle-connections-per-host=32
+        lifecycle:
+          preStop:
+            exec:
+              command: # Do not shut the application down immediately
+                - "sleep"
+                - "10s"
         env:
         - name: SERVICE_NAME
           value: {{ .Values.serviceNamePrefix }}0-0
@@ -375,6 +393,12 @@ spec:
       containers:
       - args:
         - --max-idle-connections-per-host=32
+        lifecycle:
+          preStop:
+            exec:
+              command: # Do not shut the application down immediately
+                - "sleep"
+                - "10s"
         env:
         - name: SERVICE_NAME
           value: {{ .Values.serviceNamePrefix }}0-1
@@ -439,6 +463,12 @@ spec:
       containers:
       - args:
         - --max-idle-connections-per-host=32
+        lifecycle:
+          preStop:
+            exec:
+              command: # Do not shut the application down immediately
+                - "sleep"
+                - "10s"
         env:
         - name: SERVICE_NAME
           value: {{ .Values.serviceNamePrefix }}0-2
@@ -503,6 +533,12 @@ spec:
       containers:
       - args:
         - --max-idle-connections-per-host=32
+        lifecycle:
+          preStop:
+            exec:
+              command: # Do not shut the application down immediately
+                - "sleep"
+                - "10s"
         env:
         - name: SERVICE_NAME
           value: {{ .Values.serviceNamePrefix }}0-3
@@ -567,6 +603,12 @@ spec:
       containers:
       - args:
         - --max-idle-connections-per-host=32
+        lifecycle:
+          preStop:
+            exec:
+              command: # Do not shut the application down immediately
+                - "sleep"
+                - "10s"
         env:
         - name: SERVICE_NAME
           value: {{ .Values.serviceNamePrefix }}0-4
@@ -687,6 +729,12 @@ spec:
       containers:
       - args:
         - --max-idle-connections-per-host=32
+        lifecycle:
+          preStop:
+            exec:
+              command: # Do not shut the application down immediately
+                - "sleep"
+                - "10s"
         env:
         - name: SERVICE_NAME
           value: {{ .Values.serviceNamePrefix }}0-0-0
@@ -751,6 +799,12 @@ spec:
       containers:
       - args:
         - --max-idle-connections-per-host=32
+        lifecycle:
+          preStop:
+            exec:
+              command: # Do not shut the application down immediately
+                - "sleep"
+                - "10s"
         env:
         - name: SERVICE_NAME
           value: {{ .Values.serviceNamePrefix }}0-1-0
@@ -815,6 +869,12 @@ spec:
       containers:
       - args:
         - --max-idle-connections-per-host=32
+        lifecycle:
+          preStop:
+            exec:
+              command: # Do not shut the application down immediately
+                - "sleep"
+                - "10s"
         env:
         - name: SERVICE_NAME
           value: {{ .Values.serviceNamePrefix }}0-2-0
@@ -879,6 +939,12 @@ spec:
       containers:
       - args:
         - --max-idle-connections-per-host=32
+        lifecycle:
+          preStop:
+            exec:
+              command: # Do not shut the application down immediately
+                - "sleep"
+                - "10s"
         env:
         - name: SERVICE_NAME
           value: {{ .Values.serviceNamePrefix }}0-3-0
@@ -943,6 +1009,12 @@ spec:
       containers:
       - args:
         - --max-idle-connections-per-host=32
+        lifecycle:
+          preStop:
+            exec:
+              command: # Do not shut the application down immediately
+                - "sleep"
+                - "10s"
         env:
         - name: SERVICE_NAME
           value: {{ .Values.serviceNamePrefix }}0-4-0
@@ -1011,6 +1083,12 @@ spec:
       containers:
       - args:
           - --max-idle-connections-per-host=32
+          lifecycle:
+            preStop:
+              exec:
+                command: # Do not shut the application down immediately
+                  - "sleep"
+                  - "10s"
         env:
           - name: SERVICE_NAME
             value: {{ .Values.serviceNamePrefix }}0-5
@@ -1075,6 +1153,12 @@ spec:
       containers:
       - args:
           - --max-idle-connections-per-host=32
+          lifecycle:
+            preStop:
+              exec:
+                command: # Do not shut the application down immediately
+                  - "sleep"
+                  - "10s"
         env:
           - name: SERVICE_NAME
             value: {{ .Values.serviceNamePrefix }}0-6
@@ -1139,6 +1223,12 @@ spec:
       containers:
       - args:
           - --max-idle-connections-per-host=32
+          lifecycle:
+            preStop:
+              exec:
+                command: # Do not shut the application down immediately
+                  - "sleep"
+                  - "10s"
         env:
           - name: SERVICE_NAME
             value: {{ .Values.serviceNamePrefix }}0-7
@@ -1203,6 +1293,12 @@ spec:
       containers:
         - args:
             - --max-idle-connections-per-host=32
+            lifecycle:
+              preStop:
+                exec:
+                  command: # Do not shut the application down immediately
+                    - "sleep"
+                    - "10s"
           env:
             - name: SERVICE_NAME
               value: {{ .Values.serviceNamePrefix }}0-8
@@ -1267,6 +1363,12 @@ spec:
       containers:
       - args:
         - --max-idle-connections-per-host=32
+        lifecycle:
+          preStop:
+            exec:
+              command: # Do not shut the application down immediately
+                - "sleep"
+                - "10s"
         env:
         - name: SERVICE_NAME
           value: {{ .Values.serviceNamePrefix }}0-5-0
@@ -1331,6 +1433,12 @@ spec:
       containers:
       - args:
         - --max-idle-connections-per-host=32
+        lifecycle:
+          preStop:
+            exec:
+              command: # Do not shut the application down immediately
+                - "sleep"
+                - "10s"
         env:
         - name: SERVICE_NAME
           value: {{ .Values.serviceNamePrefix }}0-6-0
@@ -1395,6 +1503,12 @@ spec:
       containers:
       - args:
         - --max-idle-connections-per-host=32
+        lifecycle:
+          preStop:
+            exec:
+              command: # Do not shut the application down immediately
+                - "sleep"
+                - "10s"
         env:
         - name: SERVICE_NAME
           value: {{ .Values.serviceNamePrefix }}0-7-0
@@ -1459,6 +1573,12 @@ spec:
       containers:
       - args:
         - --max-idle-connections-per-host=32
+        lifecycle:
+          preStop:
+            exec:
+              command: # Do not shut the application down immediately
+                - "sleep"
+                - "10s"
         env:
         - name: SERVICE_NAME
           value: {{ .Values.serviceNamePrefix }}0-8-0

--- a/perf/load/values.yaml
+++ b/perf/load/values.yaml
@@ -1,4 +1,4 @@
-serviceGraphImage: gcr.io/istio-testing/isotope:0.0.1
+serviceGraphImage: gcr.io/istio-testing/isotope:0.0.2
 serviceNamePrefix: svc-
 requestSize: 128B
 responseSize: 1KiB


### PR DESCRIPTION
This reduces 503s not caused by Istio - the apps shuts down immediately and we cannot do anything about that.

The new image is needed to add `sleep` to the binary.