### PR TITLE
Add security perf test for AuthZ, AuthN and RequestAuthn

### DIFF
--- a/perf/benchmark/configs/istio/security_authz_ip/config.json
+++ b/perf/benchmark/configs/istio/security_authz_ip/config.json
@@ -2,7 +2,6 @@
     "authZ":
     {
         "numPolicies": 1,
-        "numSourceIP":100,
-        "numPaths":100
+        "numSourceIP":1000
     }
 }

--- a/perf/benchmark/configs/istio/security_authz_ip/cpu_mem.yaml
+++ b/perf/benchmark/configs/istio/security_authz_ip/cpu_mem.yaml
@@ -1,0 +1,23 @@
+# Data: cpu/mem
+# Filter: metadata-exchange and stats filters
+# VM mode: nullvm
+telemetry_mode: "v2-stats-nullvm"
+conn:
+    - 16
+qps:
+    - 10
+    - 100
+    - 200
+    - 400
+    - 800
+    - 1000
+duration: 240
+perf_record: false
+run_bothsidecar: true
+run_serversidecar: false
+run_clientsidecar: false
+run_baseline: false
+
+extra_labels: "security_authz_ip"
+
+jitter: true

--- a/perf/benchmark/configs/istio/security_authz_ip/latency.yaml
+++ b/perf/benchmark/configs/istio/security_authz_ip/latency.yaml
@@ -1,9 +1,13 @@
 # Data: latency
-# Config: security_authz
+# Config: security_authz_ip
 telemetry_mode: "v2-stats-nullvm"
 conn:
     - 2
     - 4
+    - 8
+    - 16
+    - 32
+    - 64
 qps:
     - 1000
 duration: 240
@@ -13,6 +17,6 @@ run_serversidecar: false
 run_clientsidecar: false
 run_baseline: false
 
-extra_labels: "security_authz"
+extra_labels: "security_authz_ip"
 
 jitter: true

--- a/perf/benchmark/configs/istio/security_authz_ip/postrun.sh
+++ b/perf/benchmark/configs/istio/security_authz_ip/postrun.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Copyright Istio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+echo "Delete the Security Policies related config..."
+kubectl delete -f "${LOCAL_OUTPUT_DIR}/largeSecurityAuthzIPPolicy.yaml"
+
+rm "${LOCAL_OUTPUT_DIR}/generator"
+rm "${LOCAL_OUTPUT_DIR}/largeSecurityAuthzIPPolicy.yaml"

--- a/perf/benchmark/configs/istio/security_authz_ip/prerun.sh
+++ b/perf/benchmark/configs/istio/security_authz_ip/prerun.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Copyright Istio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+echo "Configure Security Policies..."
+POLICY_PATH="${WD}/security/generate_policies"
+
+echo "Build Security Policy Generator..."
+go build -o "${LOCAL_OUTPUT_DIR}/generator" "${POLICY_PATH}/generate_policies.go" "${POLICY_PATH}/generate.go" "${POLICY_PATH}/jwt.go"
+
+echo "Apply Security Policy to Cluster..."
+"${LOCAL_OUTPUT_DIR}/generator" -configFile="${CONFIG_DIR}/security_authz_ip/config.json" > "${LOCAL_OUTPUT_DIR}/largeSecurityAuthzIPPolicy.yaml"
+
+kubectl apply -f "${LOCAL_OUTPUT_DIR}/largeSecurityAuthzIPPolicy.yaml"

--- a/perf/benchmark/configs/istio/security_authz_jwt/config.json
+++ b/perf/benchmark/configs/istio/security_authz_jwt/config.json
@@ -1,0 +1,12 @@
+{
+    "authZ":
+    {
+        "numPolicies": 1,
+        "numRequestPrincipals":1000
+    },
+    "requestAuthN":
+    {
+        "numPolicies": 1,
+        "NumJwks":1
+    }
+}

--- a/perf/benchmark/configs/istio/security_authz_jwt/cpu_mem.yaml
+++ b/perf/benchmark/configs/istio/security_authz_jwt/cpu_mem.yaml
@@ -1,0 +1,23 @@
+# Data: cpu/mem
+# Filter: metadata-exchange and stats filters
+# VM mode: nullvm
+telemetry_mode: "v2-stats-nullvm"
+conn:
+    - 16
+qps:
+    - 10
+    - 100
+    - 200
+    - 400
+    - 800
+    - 1000
+duration: 240
+perf_record: false
+run_bothsidecar: true
+run_serversidecar: false
+run_clientsidecar: false
+run_baseline: false
+
+extra_labels: "security_authz_jwt"
+
+jitter: true

--- a/perf/benchmark/configs/istio/security_authz_jwt/latency.yaml
+++ b/perf/benchmark/configs/istio/security_authz_jwt/latency.yaml
@@ -1,0 +1,24 @@
+# Data: latency
+# Config: security_authz_jwt
+telemetry_mode: "v2-stats-nullvm"
+conn:
+    - 2
+    - 4
+    - 8
+    - 16
+    - 32
+    - 64
+qps:
+    - 1000
+duration: 240
+perf_record: true
+run_bothsidecar: true
+run_serversidecar: false
+run_clientsidecar: false
+run_baseline: false
+
+extra_labels: "security_authz_jwt"
+
+jitter: true
+
+header: $SECURITY_REQUEST_AUTHN_TOKEN

--- a/perf/benchmark/configs/istio/security_authz_jwt/postrun.sh
+++ b/perf/benchmark/configs/istio/security_authz_jwt/postrun.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Copyright Istio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+echo "Delete the Security Policies related config..."
+kubectl delete -f "${LOCAL_OUTPUT_DIR}/largeSecurityRequestAuthzJwtPolicy.yaml"
+
+rm "${LOCAL_OUTPUT_DIR}/generator"
+rm "${LOCAL_OUTPUT_DIR}/largeSecurityRequestAuthzJwtPolicy.yaml"
+cp "${LOCAL_OUTPUT_DIR}/latency.yaml" "${CONFIG_DIR}/security_authz_jwt/latency.yaml"

--- a/perf/benchmark/configs/istio/security_authz_jwt/prerun.sh
+++ b/perf/benchmark/configs/istio/security_authz_jwt/prerun.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Copyright Istio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+echo "Configure Security Policies..."
+POLICY_PATH="${WD}/security/generate_policies"
+
+echo "Build Security Policy Generator..."
+go build -o "${LOCAL_OUTPUT_DIR}/generator" "${POLICY_PATH}/generate_policies.go" "${POLICY_PATH}/generate.go" "${POLICY_PATH}/jwt.go"
+
+echo "Apply Security Policy to Cluster..."
+./"${LOCAL_OUTPUT_DIR}/generator" -configFile="${CONFIG_DIR}/security_authz_jwt/config.json" > "${LOCAL_OUTPUT_DIR}/largeSecurityRequestAuthnPolicy.yaml"
+
+cp "${CONFIG_DIR}/security_authz_jwt/latency.yaml" "${LOCAL_OUTPUT_DIR}/latency.yaml"
+
+SECURITY_REQUEST_AUTHN_TOKEN=$(<token.txt)
+echo "Generate Security Token for Requests:"
+echo "$SECURITY_REQUEST_AUTHN_TOKEN"
+
+envsubst < "${LOCAL_OUTPUT_DIR}/latency.yaml" > "${CONFIG_DIR}/security_request_authn/latency.yaml"
+
+kubectl apply -f "${LOCAL_OUTPUT_DIR}/largeSecurityRequestAuthzJwtPolicy.yaml"

--- a/perf/benchmark/configs/istio/security_authz_path/config.json
+++ b/perf/benchmark/configs/istio/security_authz_path/config.json
@@ -1,0 +1,7 @@
+{
+    "authZ":
+    {
+        "numPolicies": 1,
+        "numPaths":1000
+    }
+}

--- a/perf/benchmark/configs/istio/security_authz_path/cpu_mem.yaml
+++ b/perf/benchmark/configs/istio/security_authz_path/cpu_mem.yaml
@@ -1,0 +1,23 @@
+# Data: cpu/mem
+# Filter: metadata-exchange and stats filters
+# VM mode: nullvm
+telemetry_mode: "v2-stats-nullvm"
+conn:
+    - 16
+qps:
+    - 10
+    - 100
+    - 200
+    - 400
+    - 800
+    - 1000
+duration: 240
+perf_record: false
+run_bothsidecar: true
+run_serversidecar: false
+run_clientsidecar: false
+run_baseline: false
+
+extra_labels: "security_authz_path"
+
+jitter: true

--- a/perf/benchmark/configs/istio/security_authz_path/latency.yaml
+++ b/perf/benchmark/configs/istio/security_authz_path/latency.yaml
@@ -1,0 +1,22 @@
+# Data: latency
+# Config: security_authz_path
+telemetry_mode: "v2-stats-nullvm"
+conn:
+    - 2
+    - 4
+    - 8
+    - 16
+    - 32
+    - 64
+qps:
+    - 1000
+duration: 240
+perf_record: true
+run_bothsidecar: true
+run_serversidecar: false
+run_clientsidecar: false
+run_baseline: false
+
+extra_labels: "security_authz_path"
+
+jitter: true

--- a/perf/benchmark/configs/istio/security_authz_path/postrun.sh
+++ b/perf/benchmark/configs/istio/security_authz_path/postrun.sh
@@ -14,13 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-echo "Configure Security Policies..."
-POLICY_PATH="${WD}/security/generate_policies"
+echo "Delete the Security Policies related config..."
+kubectl delete -f "${LOCAL_OUTPUT_DIR}/largeSecurityAuthzPathPolicy.yaml"
 
-echo "Build Security Policy Generator..."
-go build -o "${LOCAL_OUTPUT_DIR}/generator" "${POLICY_PATH}/generate_policies.go" "${POLICY_PATH}/generate.go" "${POLICY_PATH}/jwt.go"
-
-echo "Apply Security Policy to Cluster..."
-./"${LOCAL_OUTPUT_DIR}/generator" -configFile="${CONFIG_DIR}/security_authz/config.json" > "${LOCAL_OUTPUT_DIR}/largeSecurityPolicy.yaml"
-
-kubectl apply -f "${LOCAL_OUTPUT_DIR}/largeSecurityPolicy.yaml"
+rm "${LOCAL_OUTPUT_DIR}/generator"
+rm "${LOCAL_OUTPUT_DIR}/largeSecurityAuthzPathPolicy.yaml"

--- a/perf/benchmark/configs/istio/security_authz_path/prerun.sh
+++ b/perf/benchmark/configs/istio/security_authz_path/prerun.sh
@@ -14,8 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-echo "Delete the Security Policies related config..."
-kubectl delete -f "${LOCAL_OUTPUT_DIR}/largeSecurityPolicy.yaml"
+echo "Configure Security Policies..."
+POLICY_PATH="${WD}/security/generate_policies"
 
-rm "${LOCAL_OUTPUT_DIR}/generator"
-rm "${LOCAL_OUTPUT_DIR}/largeSecurityPolicy.yaml"
+echo "Build Security Policy Generator..."
+go build -o "${LOCAL_OUTPUT_DIR}/generator" "${POLICY_PATH}/generate_policies.go" "${POLICY_PATH}/generate.go" "${POLICY_PATH}/jwt.go"
+
+echo "Apply Security Policy to Cluster..."
+"${LOCAL_OUTPUT_DIR}/generator" -configFile="${CONFIG_DIR}/security_authz_path/config.json" > "${LOCAL_OUTPUT_DIR}/largeSecurityAuthzPathPolicy.yaml"
+
+kubectl apply -f "${LOCAL_OUTPUT_DIR}/largeSecurityAuthzPathPolicy.yaml"

--- a/perf/benchmark/configs/istio/security_peer_authn/config.json
+++ b/perf/benchmark/configs/istio/security_peer_authn/config.json
@@ -1,0 +1,7 @@
+{
+    "peerAuthN":
+    {
+        "numPolicies": 2000,
+        "mtlsMode":"STRICT"
+    }
+}

--- a/perf/benchmark/configs/istio/security_peer_authn/cpu_mem.yaml
+++ b/perf/benchmark/configs/istio/security_peer_authn/cpu_mem.yaml
@@ -1,0 +1,23 @@
+# Data: cpu/mem
+# Filter: metadata-exchange and stats filters
+# VM mode: nullvm
+telemetry_mode: "v2-stats-nullvm"
+conn:
+    - 16
+qps:
+    - 10
+    - 100
+    - 200
+    - 400
+    - 800
+    - 1000
+duration: 240
+perf_record: false
+run_bothsidecar: true
+run_serversidecar: false
+run_clientsidecar: false
+run_baseline: false
+
+extra_labels: "security_peer_authn"
+
+jitter: true

--- a/perf/benchmark/configs/istio/security_peer_authn/latency.yaml
+++ b/perf/benchmark/configs/istio/security_peer_authn/latency.yaml
@@ -1,0 +1,22 @@
+# Data: latency
+# Config: security_peer_authn
+telemetry_mode: "v2-stats-nullvm"
+conn:
+    - 2
+    - 4
+    - 8
+    - 16
+    - 32
+    - 64
+qps:
+    - 1000
+duration: 240
+perf_record: true
+run_bothsidecar: true
+run_serversidecar: false
+run_clientsidecar: false
+run_baseline: false
+
+extra_labels: "security_peer_authn"
+
+jitter: true

--- a/perf/benchmark/configs/istio/security_peer_authn/postrun.sh
+++ b/perf/benchmark/configs/istio/security_peer_authn/postrun.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Copyright Istio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+echo "Delete the Security Policies related config..."
+kubectl delete -f "${LOCAL_OUTPUT_DIR}/largeSecurityAuthnPolicy.yaml"
+
+rm "${LOCAL_OUTPUT_DIR}/generator"
+rm "${LOCAL_OUTPUT_DIR}/largeSecurityAuthnPolicy.yaml"

--- a/perf/benchmark/configs/istio/security_peer_authn/prerun.sh
+++ b/perf/benchmark/configs/istio/security_peer_authn/prerun.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Copyright Istio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+echo "Configure Security Policies..."
+POLICY_PATH="${WD}/security/generate_policies"
+
+echo "Build Security Policy Generator..."
+go build -o "${LOCAL_OUTPUT_DIR}/generator" "${POLICY_PATH}/generate_policies.go" "${POLICY_PATH}/generate.go" "${POLICY_PATH}/jwt.go"
+
+echo "Apply Security Policy to Cluster..."
+"${LOCAL_OUTPUT_DIR}/generator" -configFile="${CONFIG_DIR}/security_peer_authn/config.json" > "${LOCAL_OUTPUT_DIR}/largeSecurityAuthnPolicy.yaml"
+
+kubectl apply -f "${LOCAL_OUTPUT_DIR}/largeSecurityAuthnPolicy.yaml"

--- a/perf/benchmark/configs/run_perf_test.conf
+++ b/perf/benchmark/configs/run_perf_test.conf
@@ -1,9 +1,12 @@
 none=true
 none_tcp=true
 plaintext=false
-security_authz=true
 telemetryv2_sd_full=true
 telemetryv2_sd_full_accesslogpolicy=false
 telemetryv2_sd_nologging=true
 telemetryv2_stats=true
 telemetryv2_statswasm=true
+security_authz_ip=true
+security_authz_path=true
+security_peer_authn=true
+security_authz_jwt=true


### PR DESCRIPTION
Add 4 more config folders for Security Perf test. Enabled them all in `run_perf_test.conf`. 

Each config generates security policy with [generator](https://github.com/istio/tools/tree/master/perf/benchmark/security/generate_policies), deploy the policy in prerun, test latency and CPU_mem, and then clear up the generator image and policy yaml in temp folder .

security_authz_ip
security_authz_path
security_peer_authn
security_authz_jwt