### PR TITLE
Add home to centos

### DIFF
--- a/docker/build-tools/Dockerfile.centos
+++ b/docker/build-tools/Dockerfile.centos
@@ -46,3 +46,5 @@ ENV PATH=/opt/llvm/bin:/usr/local/google-cloud-sdk/bin:$PATH
 RUN cd /tmp && git clone https://gn.googlesource.com/gn && cd gn && \
     git checkout 5ed3c9cc67b090d5e311e4bd2aba072173e82db9 && \
     python build/gen.py && ninja -C out && cp out/gn /usr/bin && rm -rf /tmp/gn
+
+ENV HOME=/home


### PR DESCRIPTION
This fixes the HOME directory to be consistent with the normal docker images. To test this, I've created a shell using this container, and ran `make test_release_centos`