### PR TITLE
gobin no longer needed as of go1.16; can use go install instead

### DIFF
--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -100,9 +100,6 @@ ADD https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}
 RUN dpkg -i /tmp/gh_${GH_VERSION}_linux_amd64.deb
 RUN mv /usr/bin/gh ${OUTDIR}/usr/bin
 
-RUN go install github.com/myitcv/gobin@v0.0.14
-RUN mv /tmp/go/bin/gobin /usr/local/go/bin
-
 # Build and install a bunch of Go tools
 RUN go install github.com/golang/protobuf/protoc-gen-go@${GOLANG_PROTOBUF_VERSION}
 RUN go install github.com/gogo/protobuf/protoc-gen-gofast@${GOGO_PROTOBUF_VERSION}


### PR DESCRIPTION
gobin used to be used to install dependencies (e.g. protoc-gen-go) independently. As of go 1.16 users can perform `go install pkg@version` directly without affecting the main module. This was previously done, however, gobin is still being added to the image. It doesn't appear to be used anywhere.