### PR TITLE
change security perf test to use non telemetry mode

### DIFF
--- a/perf/benchmark/configs/istio/security_authz_ip/cpu_mem.yaml
+++ b/perf/benchmark/configs/istio/security_authz_ip/cpu_mem.yaml
@@ -1,7 +1,7 @@
 # Data: cpu/mem
 # Filter: metadata-exchange and stats filters
 # VM mode: nullvm
-telemetry_mode: "v2-stats-nullvm"
+telemetry_mode: "none"
 conn:
     - 16
 qps:

--- a/perf/benchmark/configs/istio/security_authz_ip/installation.yaml
+++ b/perf/benchmark/configs/istio/security_authz_ip/installation.yaml
@@ -1,0 +1,6 @@
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+spec:
+  values:
+    telemetry:
+      enabled: false

--- a/perf/benchmark/configs/istio/security_authz_ip/latency.yaml
+++ b/perf/benchmark/configs/istio/security_authz_ip/latency.yaml
@@ -1,7 +1,7 @@
 # Data: latency
 # Config: security_authz_ip
 # VM mode: nullvm
-telemetry_mode: "v2-stats-nullvm"
+telemetry_mode: "none"
 conn:
     - 2
     - 4

--- a/perf/benchmark/configs/istio/security_authz_jwt/cpu_mem.yaml
+++ b/perf/benchmark/configs/istio/security_authz_jwt/cpu_mem.yaml
@@ -1,7 +1,7 @@
 # Data: cpu/mem
 # Filter: metadata-exchange and stats filters
 # VM mode: nullvm
-telemetry_mode: "v2-stats-nullvm"
+telemetry_mode: "none"
 conn:
     - 16
 qps:

--- a/perf/benchmark/configs/istio/security_authz_jwt/installation.yaml
+++ b/perf/benchmark/configs/istio/security_authz_jwt/installation.yaml
@@ -1,0 +1,6 @@
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+spec:
+  values:
+    telemetry:
+      enabled: false

--- a/perf/benchmark/configs/istio/security_authz_jwt/latency.yaml
+++ b/perf/benchmark/configs/istio/security_authz_jwt/latency.yaml
@@ -1,7 +1,7 @@
 # Data: latency
 # Config: security_authz_jwt
 # VM mode: nullvm
-telemetry_mode: "v2-stats-nullvm"
+telemetry_mode: "none"
 conn:
     - 2
     - 4

--- a/perf/benchmark/configs/istio/security_authz_path/cpu_mem.yaml
+++ b/perf/benchmark/configs/istio/security_authz_path/cpu_mem.yaml
@@ -1,7 +1,7 @@
 # Data: cpu/mem
 # Filter: metadata-exchange and stats filters
 # VM mode: nullvm
-telemetry_mode: "v2-stats-nullvm"
+telemetry_mode: "none"
 conn:
     - 16
 qps:

--- a/perf/benchmark/configs/istio/security_authz_path/installation.yaml
+++ b/perf/benchmark/configs/istio/security_authz_path/installation.yaml
@@ -1,0 +1,6 @@
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+spec:
+  values:
+    telemetry:
+      enabled: false

--- a/perf/benchmark/configs/istio/security_authz_path/latency.yaml
+++ b/perf/benchmark/configs/istio/security_authz_path/latency.yaml
@@ -1,7 +1,7 @@
 # Data: latency
 # Config: security_authz_path
 # VM mode: nullvm
-telemetry_mode: "v2-stats-nullvm"
+telemetry_mode: "none"
 conn:
     - 2
     - 4

--- a/perf/benchmark/configs/istio/security_peer_authn/cpu_mem.yaml
+++ b/perf/benchmark/configs/istio/security_peer_authn/cpu_mem.yaml
@@ -1,7 +1,7 @@
 # Data: cpu/mem
 # Filter: metadata-exchange and stats filters
 # VM mode: nullvm
-telemetry_mode: "v2-stats-nullvm"
+telemetry_mode: "none"
 conn:
     - 16
 qps:

--- a/perf/benchmark/configs/istio/security_peer_authn/installation.yaml
+++ b/perf/benchmark/configs/istio/security_peer_authn/installation.yaml
@@ -1,0 +1,6 @@
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+spec:
+  values:
+    telemetry:
+      enabled: false

--- a/perf/benchmark/configs/istio/security_peer_authn/latency.yaml
+++ b/perf/benchmark/configs/istio/security_peer_authn/latency.yaml
@@ -1,7 +1,7 @@
 # Data: latency
 # Config: security_peer_authn
 # VM mode: nullvm
-telemetry_mode: "v2-stats-nullvm"
+telemetry_mode: "none"
 conn:
     - 2
     - 4


### PR DESCRIPTION
The previous security tests were using v2-stats-nullvm telemtry mode. Currently we decided to choose none mode for security test. 