### PR TITLE
Sync minor release metadata

### DIFF
--- a/cmd/gen-release-notes/templates/minorReleaseNotes.md
+++ b/cmd/gen-release-notes/templates/minorReleaseNotes.md
@@ -1,7 +1,13 @@
 ---
 title: Change Notes
+linktitle: <!--newRelease-->
+subtitle: Minor Release
 description: Istio <!--newRelease--> release notes.
+publishdate: 2020-07-29
+release: <!--newRelease-->
 weight: 10
+aliases:
+    - /news/announcing-<!--newRelease-->
 ---
 
 {{< warning >}}


### PR DESCRIPTION
Minor releases weren't having publication dates added. This fixes it. This syncs the metadata for minor releases with that of patch releases. 

See also  https://github.com/istio/istio.io/pull/9649