### PR TITLE
Add patch dependency for Ubuntu: envoyproxy/envoy/pull/15454

### DIFF
--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -668,6 +668,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python \
     unzip \
     virtualenv \
+    patch \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
The istio/proxy builds, https://prow.istio.io/job-history/gs/istio-prow/pr-logs/directory/release-centos-test_proxy, started failing 5/1 with:
```
ERROR: /home/.cache/bazel/_bazel_root/45ae47b4a0e12d1e81c831ece04d820d/external/com_googlesource_chromium_v8/BUILD.bazel:34:8: Executing genrule @com_googlesource_chromium_v8//:build failed (Exit 1): bash failed: error 
```
Need to check with @istio/wg-networking-maintainers-data-plane to see what the fix is. First thought I noticed was this might be related to https://github.com/envoyproxy/envoy/pull/15454, and thus this PR.