### PR TITLE
Cherry-pick Security perf test to release-1.10

### DIFF
--- a/perf/benchmark/configs/istio/security_authz_ip/cpu_mem.yaml
+++ b/perf/benchmark/configs/istio/security_authz_ip/cpu_mem.yaml
@@ -1,7 +1,7 @@
 # Data: cpu/mem
 # Filter: metadata-exchange and stats filters
 # VM mode: nullvm
-telemetry_mode: "v2-stats-nullvm"
+telemetry_mode: "none"
 conn:
     - 16
 qps:
@@ -12,7 +12,7 @@ qps:
     - 800
     - 1000
 duration: 240
-perf_record: false
+perf_record: true
 run_bothsidecar: true
 run_serversidecar: false
 run_clientsidecar: false

--- a/perf/benchmark/configs/istio/security_authz_ip/installation.yaml
+++ b/perf/benchmark/configs/istio/security_authz_ip/installation.yaml
@@ -1,0 +1,6 @@
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+spec:
+  values:
+    telemetry:
+      enabled: false

--- a/perf/benchmark/configs/istio/security_authz_ip/latency.yaml
+++ b/perf/benchmark/configs/istio/security_authz_ip/latency.yaml
@@ -1,6 +1,7 @@
 # Data: latency
 # Config: security_authz_ip
-telemetry_mode: "v2-stats-nullvm"
+# VM mode: nullvm
+telemetry_mode: "none"
 conn:
     - 2
     - 4

--- a/perf/benchmark/configs/istio/security_authz_jwt/cpu_mem.yaml
+++ b/perf/benchmark/configs/istio/security_authz_jwt/cpu_mem.yaml
@@ -1,7 +1,7 @@
 # Data: cpu/mem
 # Filter: metadata-exchange and stats filters
 # VM mode: nullvm
-telemetry_mode: "v2-stats-nullvm"
+telemetry_mode: "none"
 conn:
     - 16
 qps:
@@ -12,7 +12,7 @@ qps:
     - 800
     - 1000
 duration: 240
-perf_record: false
+perf_record: true
 run_bothsidecar: true
 run_serversidecar: false
 run_clientsidecar: false
@@ -21,3 +21,5 @@ run_baseline: false
 extra_labels: "security_authz_jwt"
 
 jitter: true
+
+header: $SECURITY_REQUEST_AUTHN_TOKEN

--- a/perf/benchmark/configs/istio/security_authz_jwt/installation.yaml
+++ b/perf/benchmark/configs/istio/security_authz_jwt/installation.yaml
@@ -1,0 +1,6 @@
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+spec:
+  values:
+    telemetry:
+      enabled: false

--- a/perf/benchmark/configs/istio/security_authz_jwt/latency.yaml
+++ b/perf/benchmark/configs/istio/security_authz_jwt/latency.yaml
@@ -1,6 +1,7 @@
 # Data: latency
 # Config: security_authz_jwt
-telemetry_mode: "v2-stats-nullvm"
+# VM mode: nullvm
+telemetry_mode: "none"
 conn:
     - 2
     - 4

--- a/perf/benchmark/configs/istio/security_authz_jwt/postrun.sh
+++ b/perf/benchmark/configs/istio/security_authz_jwt/postrun.sh
@@ -17,6 +17,8 @@
 echo "Delete the Security Policies related config..."
 kubectl delete -f "${LOCAL_OUTPUT_DIR}/largeSecurityRequestAuthzJwtPolicy.yaml"
 
+cp "${LOCAL_OUTPUT_DIR}/latency.yaml" "${CONFIG_DIR}/security_authz_jwt/latency.yaml"
+cp "${LOCAL_OUTPUT_DIR}/cpu_mem.yaml" "${CONFIG_DIR}/security_authz_jwt/cpu_mem.yaml"
+
 rm "${LOCAL_OUTPUT_DIR}/generator"
 rm "${LOCAL_OUTPUT_DIR}/largeSecurityRequestAuthzJwtPolicy.yaml"
-cp "${LOCAL_OUTPUT_DIR}/latency.yaml" "${CONFIG_DIR}/security_authz_jwt/latency.yaml"

--- a/perf/benchmark/configs/istio/security_authz_jwt/prerun.sh
+++ b/perf/benchmark/configs/istio/security_authz_jwt/prerun.sh
@@ -19,16 +19,18 @@ POLICY_PATH="${WD}/security/generate_policies"
 
 echo "Build Security Policy Generator..."
 go build -o "${LOCAL_OUTPUT_DIR}/generator" "${POLICY_PATH}/generate_policies.go" "${POLICY_PATH}/generate.go" "${POLICY_PATH}/jwt.go"
-
-echo "Apply Security Policy to Cluster..."
-./"${LOCAL_OUTPUT_DIR}/generator" -configFile="${CONFIG_DIR}/security_authz_jwt/config.json" > "${LOCAL_OUTPUT_DIR}/largeSecurityRequestAuthnPolicy.yaml"
+"${LOCAL_OUTPUT_DIR}/generator" -configFile="${CONFIG_DIR}/security_authz_jwt/config.json" > "${LOCAL_OUTPUT_DIR}/largeSecurityRequestAuthzJwtPolicy.yaml"
 
 cp "${CONFIG_DIR}/security_authz_jwt/latency.yaml" "${LOCAL_OUTPUT_DIR}/latency.yaml"
+cp "${CONFIG_DIR}/security_authz_jwt/cpu_mem.yaml" "${LOCAL_OUTPUT_DIR}/cpu_mem.yaml"
 
-SECURITY_REQUEST_AUTHN_TOKEN=$(<token.txt)
 echo "Generate Security Token for Requests:"
-echo "$SECURITY_REQUEST_AUTHN_TOKEN"
+SECURITY_REQUEST_AUTHN_TOKEN=$(<token.txt)
+echo "${SECURITY_REQUEST_AUTHN_TOKEN}"
+rm token.txt
 
-envsubst < "${LOCAL_OUTPUT_DIR}/latency.yaml" > "${CONFIG_DIR}/security_request_authn/latency.yaml"
+envsubst < "${LOCAL_OUTPUT_DIR}/latency.yaml" > "${CONFIG_DIR}/security_authz_jwt/latency.yaml"
+envsubst < "${LOCAL_OUTPUT_DIR}/cpu_mem.yaml" > "${CONFIG_DIR}/security_authz_jwt/cpu_mem.yaml"
 
+echo "Apply Security Policy to Cluster..."
 kubectl apply -f "${LOCAL_OUTPUT_DIR}/largeSecurityRequestAuthzJwtPolicy.yaml"

--- a/perf/benchmark/configs/istio/security_authz_path/cpu_mem.yaml
+++ b/perf/benchmark/configs/istio/security_authz_path/cpu_mem.yaml
@@ -1,7 +1,7 @@
 # Data: cpu/mem
 # Filter: metadata-exchange and stats filters
 # VM mode: nullvm
-telemetry_mode: "v2-stats-nullvm"
+telemetry_mode: "none"
 conn:
     - 16
 qps:
@@ -12,7 +12,7 @@ qps:
     - 800
     - 1000
 duration: 240
-perf_record: false
+perf_record: true
 run_bothsidecar: true
 run_serversidecar: false
 run_clientsidecar: false

--- a/perf/benchmark/configs/istio/security_authz_path/installation.yaml
+++ b/perf/benchmark/configs/istio/security_authz_path/installation.yaml
@@ -1,0 +1,6 @@
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+spec:
+  values:
+    telemetry:
+      enabled: false

--- a/perf/benchmark/configs/istio/security_authz_path/latency.yaml
+++ b/perf/benchmark/configs/istio/security_authz_path/latency.yaml
@@ -1,6 +1,7 @@
 # Data: latency
 # Config: security_authz_path
-telemetry_mode: "v2-stats-nullvm"
+# VM mode: nullvm
+telemetry_mode: "none"
 conn:
     - 2
     - 4

--- a/perf/benchmark/configs/istio/security_peer_authn/cpu_mem.yaml
+++ b/perf/benchmark/configs/istio/security_peer_authn/cpu_mem.yaml
@@ -1,7 +1,7 @@
 # Data: cpu/mem
 # Filter: metadata-exchange and stats filters
 # VM mode: nullvm
-telemetry_mode: "v2-stats-nullvm"
+telemetry_mode: "none"
 conn:
     - 16
 qps:
@@ -12,7 +12,7 @@ qps:
     - 800
     - 1000
 duration: 240
-perf_record: false
+perf_record: true
 run_bothsidecar: true
 run_serversidecar: false
 run_clientsidecar: false

--- a/perf/benchmark/configs/istio/security_peer_authn/installation.yaml
+++ b/perf/benchmark/configs/istio/security_peer_authn/installation.yaml
@@ -1,0 +1,6 @@
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+spec:
+  values:
+    telemetry:
+      enabled: false

--- a/perf/benchmark/configs/istio/security_peer_authn/latency.yaml
+++ b/perf/benchmark/configs/istio/security_peer_authn/latency.yaml
@@ -1,6 +1,7 @@
 # Data: latency
 # Config: security_peer_authn
-telemetry_mode: "v2-stats-nullvm"
+# VM mode: nullvm
+telemetry_mode: "none"
 conn:
     - 2
     - 4

--- a/perf_dashboard/benchmarks/templates/cpu_vs_conn.html
+++ b/perf_dashboard/benchmarks/templates/cpu_vs_conn.html
@@ -194,6 +194,10 @@
         cpu_client_v2_stats_wasm_both = {{ cpu_client_v2_stats_wasm_both|safe }}
         cpu_client_v2_sd_nologging_nullvm_both = {{ cpu_client_v2_sd_nologging_nullvm_both|safe }}
         cpu_client_v2_sd_full_nullvm_both = {{ cpu_client_v2_sd_full_nullvm_both|safe }}
+        cpu_client_none_security_authz_ip_both = {{ cpu_client_none_security_authz_ip_both|safe }}
+        cpu_client_none_security_authz_path_both = {{ cpu_client_none_security_authz_path_both|safe }}
+        cpu_client_none_security_authz_jwt_both = {{ cpu_client_none_security_authz_jwt_both|safe }}
+        cpu_client_none_security_peer_authn_both = {{ cpu_client_none_security_peer_authn_both|safe }}
 
         cpu_server_none_mtls_base = {{ cpu_server_none_mtls_base|safe }}
         cpu_server_none_mtls_both = {{ cpu_server_none_mtls_both|safe }}
@@ -202,6 +206,10 @@
         cpu_server_v2_stats_wasm_both = {{ cpu_server_v2_stats_wasm_both|safe }}
         cpu_server_v2_sd_nologging_nullvm_both = {{ cpu_server_v2_sd_nologging_nullvm_both|safe }}
         cpu_server_v2_sd_full_nullvm_both = {{ cpu_server_v2_sd_full_nullvm_both|safe }}
+        cpu_server_none_security_authz_ip_both = {{ cpu_server_none_security_authz_ip_both|safe }}
+        cpu_server_none_security_authz_path_both = {{ cpu_server_none_security_authz_path_both|safe }}
+        cpu_server_none_security_authz_jwt_both = {{ cpu_server_none_security_authz_jwt_both|safe }}
+        cpu_server_none_security_peer_authn_both = {{ cpu_server_none_security_peer_authn_both|safe }}
 
         cpu_ingressgw_none_mtls_base = {{ cpu_ingressgw_none_mtls_base|safe }}
         cpu_ingressgw_none_mtls_both = {{ cpu_ingressgw_none_mtls_both|safe }}
@@ -218,6 +226,10 @@
         cpu_client_v2_stats_wasm_both_master = {{ cpu_client_v2_stats_wasm_both_master|safe }}
         cpu_client_v2_sd_nologging_nullvm_both_master = {{ cpu_client_v2_sd_nologging_nullvm_both_master| safe }}
         cpu_client_v2_sd_full_nullvm_both_master = {{ cpu_client_v2_sd_full_nullvm_both_master|safe }}
+        cpu_client_none_security_authz_ip_both_master = {{ cpu_client_none_security_authz_ip_both_master|safe }}
+        cpu_client_none_security_authz_path_both_master = {{ cpu_client_none_security_authz_path_both_master|safe }}
+        cpu_client_none_security_authz_jwt_both_master = {{ cpu_client_none_security_authz_jwt_both_master|safe }}
+        cpu_client_none_security_peer_authn_both_master = {{ cpu_client_none_security_peer_authn_both_master|safe }}
 
         cpu_server_none_mtls_base_master = {{ cpu_server_none_mtls_base_master|safe }}
         cpu_server_none_mtls_both_master = {{ cpu_server_none_mtls_both_master|safe }}
@@ -226,6 +238,10 @@
         cpu_server_v2_stats_wasm_both_master = {{ cpu_server_v2_stats_wasm_both_master|safe }}
         cpu_server_v2_sd_nologging_nullvm_both_master = {{ cpu_server_v2_sd_nologging_nullvm_both_master| safe }}
         cpu_server_v2_sd_full_nullvm_both_master = {{ cpu_server_v2_sd_full_nullvm_both_master|safe }}
+        cpu_server_none_security_authz_ip_both_master = {{ cpu_server_none_security_authz_ip_both_master|safe }}
+        cpu_server_none_security_authz_path_both_master = {{ cpu_server_none_security_authz_path_both_master|safe }}
+        cpu_server_none_security_authz_jwt_both_master = {{ cpu_server_none_security_authz_jwt_both_master|safe }}
+        cpu_server_none_security_peer_authn_both_master = {{ cpu_server_none_security_peer_authn_both_master|safe }}
 
         cpu_ingressgw_none_mtls_base_master = {{ cpu_ingressgw_none_mtls_base_master|safe }}
         cpu_ingressgw_none_mtls_both_master = {{ cpu_ingressgw_none_mtls_both_master|safe }}

--- a/perf_dashboard/benchmarks/templates/cpu_vs_qps.html
+++ b/perf_dashboard/benchmarks/templates/cpu_vs_qps.html
@@ -199,6 +199,10 @@
         cpu_client_v2_stats_wasm_both = {{ cpu_client_v2_stats_wasm_both|safe }}
         cpu_client_v2_sd_nologging_nullvm_both = {{ cpu_client_v2_sd_nologging_nullvm_both|safe }}
         cpu_client_v2_sd_full_nullvm_both = {{ cpu_client_v2_sd_full_nullvm_both|safe }}
+        cpu_client_none_security_authz_ip_both = {{ cpu_client_none_security_authz_ip_both|safe }}
+        cpu_client_none_security_authz_path_both = {{ cpu_client_none_security_authz_path_both|safe }}
+        cpu_client_none_security_authz_jwt_both = {{ cpu_client_none_security_authz_jwt_both|safe }}
+        cpu_client_none_security_peer_authn_both = {{ cpu_client_none_security_peer_authn_both|safe }}
 
         cpu_server_none_mtls_base = {{ cpu_server_none_mtls_base|safe }}
         cpu_server_none_mtls_both = {{ cpu_server_none_mtls_both|safe }}
@@ -207,6 +211,10 @@
         cpu_server_v2_stats_wasm_both = {{ cpu_server_v2_stats_wasm_both|safe }}
         cpu_server_v2_sd_nologging_nullvm_both = {{ cpu_server_v2_sd_nologging_nullvm_both|safe }}
         cpu_server_v2_sd_full_nullvm_both = {{ cpu_server_v2_sd_full_nullvm_both|safe }}
+        cpu_server_none_security_authz_ip_both = {{ cpu_server_none_security_authz_ip_both|safe }}
+        cpu_server_none_security_authz_path_both = {{ cpu_server_none_security_authz_path_both|safe }}
+        cpu_server_none_security_authz_jwt_both = {{ cpu_server_none_security_authz_jwt_both|safe }}
+        cpu_server_none_security_peer_authn_both = {{ cpu_server_none_security_peer_authn_both|safe }}
 
         cpu_ingressgw_none_mtls_base = {{ cpu_ingressgw_none_mtls_base|safe }}
         cpu_ingressgw_none_mtls_both = {{ cpu_ingressgw_none_mtls_both|safe }}
@@ -223,6 +231,10 @@
         cpu_client_v2_stats_wasm_both_master = {{ cpu_client_v2_stats_wasm_both_master|safe }}
         cpu_client_v2_sd_nologging_nullvm_both_master = {{ cpu_client_v2_sd_nologging_nullvm_both_master| safe }}
         cpu_client_v2_sd_full_nullvm_both_master = {{ cpu_client_v2_sd_full_nullvm_both_master|safe }}
+        cpu_client_none_security_authz_ip_both_master = {{ cpu_client_none_security_authz_ip_both_master|safe }}
+        cpu_client_none_security_authz_path_both_master = {{ cpu_client_none_security_authz_path_both_master|safe }}
+        cpu_client_none_security_authz_jwt_both_master = {{ cpu_client_none_security_authz_jwt_both_master|safe }}
+        cpu_client_none_security_peer_authn_both_master = {{ cpu_client_none_security_peer_authn_both_master|safe }}
 
         cpu_server_none_mtls_base_master = {{ cpu_server_none_mtls_base_master|safe }}
         cpu_server_none_mtls_both_master = {{ cpu_server_none_mtls_both_master|safe }}
@@ -231,6 +243,10 @@
         cpu_server_v2_stats_wasm_both_master = {{ cpu_server_v2_stats_wasm_both_master|safe }}
         cpu_server_v2_sd_nologging_nullvm_both_master = {{ cpu_server_v2_sd_nologging_nullvm_both_master| safe }}
         cpu_server_v2_sd_full_nullvm_both_master = {{ cpu_server_v2_sd_full_nullvm_both_master|safe }}
+        cpu_server_none_security_authz_ip_both_master = {{ cpu_server_none_security_authz_ip_both_master|safe }}
+        cpu_server_none_security_authz_path_both_master = {{ cpu_server_none_security_authz_path_both_master|safe }}
+        cpu_server_none_security_authz_jwt_both_master = {{ cpu_server_none_security_authz_jwt_both_master|safe }}
+        cpu_server_none_security_peer_authn_both_master = {{ cpu_server_none_security_peer_authn_both_master|safe }}
 
         cpu_ingressgw_none_mtls_base_master = {{ cpu_ingressgw_none_mtls_base_master|safe }}
         cpu_ingressgw_none_mtls_both_master = {{ cpu_ingressgw_none_mtls_both_master|safe }}

--- a/perf_dashboard/benchmarks/templates/latency_vs_conn.html
+++ b/perf_dashboard/benchmarks/templates/latency_vs_conn.html
@@ -198,6 +198,10 @@
         latency_v2_stats_wasm_both_p50 = {{ latency_v2_stats_wasm_both_p50|safe }}
         latency_v2_sd_nologging_nullvm_both_p50 = {{ latency_v2_sd_nologging_nullvm_both_p50|safe }}
         latency_v2_sd_full_nullvm_both_p50 = {{ latency_v2_sd_full_nullvm_both_p50|safe }}
+        latency_none_security_authz_ip_both_p50 = {{ latency_none_security_authz_ip_both_p50|safe }}
+        latency_none_security_authz_path_both_p50 = {{ latency_none_security_authz_path_both_p50|safe }}
+        latency_none_security_authz_jwt_both_p50 = {{ latency_none_security_authz_jwt_both_p50|safe }}
+        latency_none_security_peer_authn_both_p50 = {{ latency_none_security_peer_authn_both_p50|safe }}
 
         latency_none_mtls_base_p90 = {{ latency_none_mtls_base_p90|safe }}
         latency_none_mtls_both_p90 = {{ latency_none_mtls_both_p90|safe }}
@@ -206,6 +210,10 @@
         latency_v2_stats_wasm_both_p90 = {{ latency_v2_stats_wasm_both_p90|safe }}
         latency_v2_sd_nologging_nullvm_both_p90 = {{ latency_v2_sd_nologging_nullvm_both_p90|safe }}
         latency_v2_sd_full_nullvm_both_p90 = {{ latency_v2_sd_full_nullvm_both_p90|safe }}
+        latency_none_security_authz_ip_both_p90 = {{ latency_none_security_authz_ip_both_p90|safe }}
+        latency_none_security_authz_path_both_p90 = {{ latency_none_security_authz_path_both_p90|safe }}
+        latency_none_security_authz_jwt_both_p90 = {{ latency_none_security_authz_jwt_both_p90|safe }}
+        latency_none_security_peer_authn_both_p90 = {{ latency_none_security_peer_authn_both_p90|safe }}
 
         latency_none_mtls_base_p99 = {{ latency_none_mtls_base_p99|safe }}
         latency_none_mtls_both_p99 = {{ latency_none_mtls_both_p99|safe }}
@@ -214,6 +222,10 @@
         latency_v2_stats_wasm_both_p99 = {{ latency_v2_stats_wasm_both_p99|safe }}
         latency_v2_sd_nologging_nullvm_both_p99 = {{ latency_v2_sd_nologging_nullvm_both_p99|safe }}
         latency_v2_sd_full_nullvm_both_p99 = {{ latency_v2_sd_full_nullvm_both_p99|safe }}
+        latency_none_security_authz_ip_both_p99 = {{ latency_none_security_authz_ip_both_p99|safe }}
+        latency_none_security_authz_path_both_p99 = {{ latency_none_security_authz_path_both_p99|safe }}
+        latency_none_security_authz_jwt_both_p99 = {{ latency_none_security_authz_jwt_both_p99|safe }}
+        latency_none_security_peer_authn_both_p99 = {{ latency_none_security_peer_authn_both_p99|safe }}
 
         latency_none_mtls_base_p999 = {{ latency_none_mtls_base_p999|safe }}
         latency_none_mtls_both_p999 = {{ latency_none_mtls_both_p999|safe }}
@@ -222,6 +234,10 @@
         latency_v2_stats_wasm_both_p999 = {{ latency_v2_stats_wasm_both_p999|safe }}
         latency_v2_sd_nologging_nullvm_both_p999 = {{ latency_v2_sd_nologging_nullvm_both_p999|safe }}
         latency_v2_sd_full_nullvm_both_p999 = {{ latency_v2_sd_full_nullvm_both_p999|safe }}
+        latency_none_security_authz_ip_both_p999 = {{ latency_none_security_authz_ip_both_p999|safe }}
+        latency_none_security_authz_path_both_p999 = {{ latency_none_security_authz_path_both_p999|safe }}
+        latency_none_security_authz_jwt_both_p999 = {{ latency_none_security_authz_jwt_both_p999|safe }}
+        latency_none_security_peer_authn_both_p999 = {{ latency_none_security_peer_authn_both_p999|safe }}
 
         latency_none_mtls_base_p50_master = {{ latency_none_mtls_base_p50_master|safe }}
         latency_none_mtls_both_p50_master = {{ latency_none_mtls_both_p50_master|safe }}
@@ -230,6 +246,10 @@
         latency_v2_stats_wasm_both_p50_master = {{ latency_v2_stats_wasm_both_p50_master|safe }}
         latency_v2_sd_nologging_nullvm_both_p50_master = {{ latency_v2_sd_nologging_nullvm_both_p50_master|safe }}
         latency_v2_sd_full_nullvm_both_p50_master = {{ latency_v2_sd_full_nullvm_both_p50_master|safe }}
+        latency_none_security_authz_ip_both_p50_master = {{ latency_none_security_authz_ip_both_p50_master|safe }}
+        latency_none_security_authz_path_both_p50_master = {{ latency_none_security_authz_path_both_p50_master|safe }}
+        latency_none_security_authz_jwt_both_p50_master = {{ latency_none_security_authz_jwt_both_p50_master|safe }}
+        latency_none_security_peer_authn_both_p50_master = {{ latency_none_security_peer_authn_both_p50_master|safe }}
 
         latency_none_mtls_base_p90_master = {{ latency_none_mtls_base_p90_master|safe }}
         latency_none_mtls_both_p90_master = {{ latency_none_mtls_both_p90_master|safe }}
@@ -238,6 +258,10 @@
         latency_v2_stats_wasm_both_p90_master = {{ latency_v2_stats_wasm_both_p90_master|safe }}
         latency_v2_sd_nologging_nullvm_both_p90_master = {{ latency_v2_sd_nologging_nullvm_both_p90_master|safe }}
         latency_v2_sd_full_nullvm_both_p90_master = {{ latency_v2_sd_full_nullvm_both_p90_master|safe }}
+        latency_none_security_authz_ip_both_p90_master = {{ latency_none_security_authz_ip_both_p90_master|safe }}
+        latency_none_security_authz_path_both_p90_master = {{ latency_none_security_authz_path_both_p90_master|safe }}
+        latency_none_security_authz_jwt_both_p90_master = {{ latency_none_security_authz_jwt_both_p90_master|safe }}
+        latency_none_security_peer_authn_both_p90_master = {{ latency_none_security_peer_authn_both_p90_master|safe }}
 
         latency_none_mtls_base_p99_master = {{ latency_none_mtls_base_p99_master|safe }}
         latency_none_mtls_both_p99_master = {{ latency_none_mtls_both_p99_master|safe }}
@@ -246,6 +270,10 @@
         latency_v2_stats_wasm_both_p99_master = {{ latency_v2_stats_wasm_both_p99_master|safe }}
         latency_v2_sd_nologging_nullvm_both_p99_master = {{ latency_v2_sd_nologging_nullvm_both_p99_master|safe }}
         latency_v2_sd_full_nullvm_both_p99_master = {{ latency_v2_sd_full_nullvm_both_p99_master|safe }}
+        latency_none_security_authz_ip_both_p99_master = {{ latency_none_security_authz_ip_both_p99_master|safe }}
+        latency_none_security_authz_path_both_p99_master = {{ latency_none_security_authz_path_both_p99_master|safe }}
+        latency_none_security_authz_jwt_both_p99_master = {{ latency_none_security_authz_jwt_both_p99_master|safe }}
+        latency_none_security_peer_authn_both_p99_master = {{ latency_none_security_peer_authn_both_p99_master|safe }}
 
         latency_none_mtls_base_p999_master = {{ latency_none_mtls_base_p999_master|safe }}
         latency_none_mtls_both_p999_master = {{ latency_none_mtls_both_p999_master|safe }}
@@ -254,6 +282,10 @@
         latency_v2_stats_wasm_both_p999_master = {{ latency_v2_stats_wasm_both_p999_master|safe }}
         latency_v2_sd_nologging_nullvm_both_p999_master = {{ latency_v2_sd_nologging_nullvm_both_p999_master|safe }}
         latency_v2_sd_full_nullvm_both_p999_master = {{ latency_v2_sd_full_nullvm_both_p999_master|safe }}
+        latency_none_security_authz_ip_both_p999_master = {{ latency_none_security_authz_ip_both_p999_master|safe }}
+        latency_none_security_authz_path_both_p999_master = {{ latency_none_security_authz_path_both_p999_master|safe }}
+        latency_none_security_authz_jwt_both_p999_master = {{ latency_none_security_authz_jwt_both_p999_master|safe }}
+        latency_none_security_peer_authn_both_p999_master = {{ latency_none_security_peer_authn_both_p999_master|safe }}
     </script>
 {% endblock page_data %}
 

--- a/perf_dashboard/benchmarks/templates/latency_vs_qps.html
+++ b/perf_dashboard/benchmarks/templates/latency_vs_qps.html
@@ -198,6 +198,10 @@
         latency_v2_stats_wasm_both_p50 = {{ latency_v2_stats_wasm_both_p50|safe }}
         latency_v2_sd_nologging_nullvm_both_p50 = {{ latency_v2_sd_nologging_nullvm_both_p50|safe }}
         latency_v2_sd_full_nullvm_both_p50 = {{ latency_v2_sd_full_nullvm_both_p50|safe }}
+        latency_none_security_authz_ip_both_p50 = {{ latency_none_security_authz_ip_both_p50|safe }}
+        latency_none_security_authz_path_both_p50 = {{ latency_none_security_authz_path_both_p50|safe }}
+        latency_none_security_authz_jwt_both_p50 = {{ latency_none_security_authz_jwt_both_p50|safe }}
+        latency_none_security_peer_authn_both_p50 = {{ latency_none_security_peer_authn_both_p50|safe }}
 
         latency_none_mtls_base_p90 = {{ latency_none_mtls_base_p90|safe }}
         latency_none_mtls_both_p90 = {{ latency_none_mtls_both_p90|safe }}
@@ -206,6 +210,10 @@
         latency_v2_stats_wasm_both_p90 = {{ latency_v2_stats_wasm_both_p90|safe }}
         latency_v2_sd_nologging_nullvm_both_p90 = {{ latency_v2_sd_nologging_nullvm_both_p90|safe }}
         latency_v2_sd_full_nullvm_both_p90 = {{ latency_v2_sd_full_nullvm_both_p90|safe }}
+        latency_none_security_authz_ip_both_p90 = {{ latency_none_security_authz_ip_both_p90|safe }}
+        latency_none_security_authz_path_both_p90 = {{ latency_none_security_authz_path_both_p90|safe }}
+        latency_none_security_authz_jwt_both_p90 = {{ latency_none_security_authz_jwt_both_p90|safe }}
+        latency_none_security_peer_authn_both_p90 = {{ latency_none_security_peer_authn_both_p90|safe }}
 
         latency_none_mtls_base_p99 = {{ latency_none_mtls_base_p99|safe }}
         latency_none_mtls_both_p99 = {{ latency_none_mtls_both_p99|safe }}
@@ -214,6 +222,10 @@
         latency_v2_stats_wasm_both_p99 = {{ latency_v2_stats_wasm_both_p99|safe }}
         latency_v2_sd_nologging_nullvm_both_p99 = {{ latency_v2_sd_nologging_nullvm_both_p99|safe }}
         latency_v2_sd_full_nullvm_both_p99 = {{ latency_v2_sd_full_nullvm_both_p99|safe }}
+        latency_none_security_authz_ip_both_p99 = {{ latency_none_security_authz_ip_both_p99|safe }}
+        latency_none_security_authz_path_both_p99 = {{ latency_none_security_authz_path_both_p99|safe }}
+        latency_none_security_authz_jwt_both_p99 = {{ latency_none_security_authz_jwt_both_p99|safe }}
+        latency_none_security_peer_authn_both_p99 = {{ latency_none_security_peer_authn_both_p99|safe }}
 
         latency_none_mtls_base_p999 = {{ latency_none_mtls_base_p999|safe }}
         latency_none_mtls_both_p999 = {{ latency_none_mtls_both_p999|safe }}
@@ -222,6 +234,10 @@
         latency_v2_stats_wasm_both_p999 = {{ latency_v2_stats_wasm_both_p999|safe }}
         latency_v2_sd_nologging_nullvm_both_p999 = {{ latency_v2_sd_nologging_nullvm_both_p999|safe }}
         latency_v2_sd_full_nullvm_both_p999 = {{ latency_v2_sd_full_nullvm_both_p999|safe }}
+        latency_none_security_authz_ip_both_p999 = {{ latency_none_security_authz_ip_both_p999|safe }}
+        latency_none_security_authz_path_both_p999 = {{ latency_none_security_authz_path_both_p999|safe }}
+        latency_none_security_authz_jwt_both_p999 = {{ latency_none_security_authz_jwt_both_p999|safe }}
+        latency_none_security_peer_authn_both_p999 = {{ latency_none_security_peer_authn_both_p999|safe }}
 
         latency_none_mtls_base_p50_master = {{ latency_none_mtls_base_p50_master|safe }}
         latency_none_mtls_both_p50_master = {{ latency_none_mtls_both_p50_master|safe }}
@@ -230,6 +246,10 @@
         latency_v2_stats_wasm_both_p50_master = {{ latency_v2_stats_wasm_both_p50_master|safe }}
         latency_v2_sd_nologging_nullvm_both_p50_master = {{ latency_v2_sd_nologging_nullvm_both_p50_master|safe }}
         latency_v2_sd_full_nullvm_both_p50_master = {{ latency_v2_sd_full_nullvm_both_p50_master|safe }}
+        latency_none_security_authz_ip_both_p50_master = {{ latency_none_security_authz_ip_both_p50_master|safe }}
+        latency_none_security_authz_path_both_p50_master = {{ latency_none_security_authz_path_both_p50_master|safe }}
+        latency_none_security_authz_jwt_both_p50_master = {{ latency_none_security_authz_jwt_both_p50_master|safe }}
+        latency_none_security_peer_authn_both_p50_master = {{ latency_none_security_peer_authn_both_p50_master|safe }}
 
         latency_none_mtls_base_p90_master = {{ latency_none_mtls_base_p90_master|safe }}
         latency_none_mtls_both_p90_master = {{ latency_none_mtls_both_p90_master|safe }}
@@ -238,6 +258,10 @@
         latency_v2_stats_wasm_both_p90_master = {{ latency_v2_stats_wasm_both_p90_master|safe }}
         latency_v2_sd_nologging_nullvm_both_p90_master = {{ latency_v2_sd_nologging_nullvm_both_p90_master|safe }}
         latency_v2_sd_full_nullvm_both_p90_master = {{ latency_v2_sd_full_nullvm_both_p90_master|safe }}
+        latency_none_security_authz_ip_both_p90_master = {{ latency_none_security_authz_ip_both_p90_master|safe }}
+        latency_none_security_authz_path_both_p90_master = {{ latency_none_security_authz_path_both_p90_master|safe }}
+        latency_none_security_authz_jwt_both_p90_master = {{ latency_none_security_authz_jwt_both_p90_master|safe }}
+        latency_none_security_peer_authn_both_p90_master = {{ latency_none_security_peer_authn_both_p90_master|safe }}
 
         latency_none_mtls_base_p99_master = {{ latency_none_mtls_base_p99_master|safe }}
         latency_none_mtls_both_p99_master = {{ latency_none_mtls_both_p99_master|safe }}
@@ -246,6 +270,10 @@
         latency_v2_stats_wasm_both_p99_master = {{ latency_v2_stats_wasm_both_p99_master|safe }}
         latency_v2_sd_nologging_nullvm_both_p99_master = {{ latency_v2_sd_nologging_nullvm_both_p99_master|safe }}
         latency_v2_sd_full_nullvm_both_p99_master = {{ latency_v2_sd_full_nullvm_both_p99_master|safe }}
+        latency_none_security_authz_ip_both_p99_master = {{ latency_none_security_authz_ip_both_p99_master|safe }}
+        latency_none_security_authz_path_both_p99_master = {{ latency_none_security_authz_path_both_p99_master|safe }}
+        latency_none_security_authz_jwt_both_p99_master = {{ latency_none_security_authz_jwt_both_p99_master|safe }}
+        latency_none_security_peer_authn_both_p99_master = {{ latency_none_security_peer_authn_both_p99_master|safe }}
 
         latency_none_mtls_base_p999_master = {{ latency_none_mtls_base_p999_master|safe }}
         latency_none_mtls_both_p999_master = {{ latency_none_mtls_both_p999_master|safe }}
@@ -254,6 +282,10 @@
         latency_v2_stats_wasm_both_p999_master = {{ latency_v2_stats_wasm_both_p999_master|safe }}
         latency_v2_sd_nologging_nullvm_both_p999_master = {{ latency_v2_sd_nologging_nullvm_both_p999_master|safe }}
         latency_v2_sd_full_nullvm_both_p999_master = {{ latency_v2_sd_full_nullvm_both_p999_master|safe }}
+        latency_none_security_authz_ip_both_p999_master = {{ latency_none_security_authz_ip_both_p999_master|safe }}
+        latency_none_security_authz_path_both_p999_master = {{ latency_none_security_authz_path_both_p999_master|safe }}
+        latency_none_security_authz_jwt_both_p999_master = {{ latency_none_security_authz_jwt_both_p999_master|safe }}
+        latency_none_security_peer_authn_both_p999_master = {{ latency_none_security_peer_authn_both_p999_master|safe }}
     </script>
 {% endblock page_data %}
 

--- a/perf_dashboard/benchmarks/templates/mem_vs_conn.html
+++ b/perf_dashboard/benchmarks/templates/mem_vs_conn.html
@@ -195,6 +195,10 @@
         mem_client_v2_stats_wasm_both = {{ mem_client_v2_stats_wasm_both|safe }}
         mem_client_v2_sd_nologging_nullvm_both = {{ mem_client_v2_sd_nologging_nullvm_both|safe }}
         mem_client_v2_sd_full_nullvm_both = {{ mem_client_v2_sd_full_nullvm_both|safe }}
+        mem_client_none_security_authz_ip_both = {{ mem_client_none_security_authz_ip_both|safe }}
+        mem_client_none_security_authz_jwt_both = {{ mem_client_none_security_authz_jwt_both|safe }}
+        mem_client_none_security_authz_path_both = {{ mem_client_none_security_authz_path_both|safe }}
+        mem_client_none_security_peer_authn_both = {{ mem_client_none_security_peer_authn_both|safe }}
 
         mem_server_none_mtls_base = {{ mem_server_none_mtls_base|safe }}
         mem_server_none_mtls_both = {{ mem_server_none_mtls_both|safe }}
@@ -203,6 +207,10 @@
         mem_server_v2_stats_wasm_both = {{ mem_server_v2_stats_wasm_both|safe }}
         mem_server_v2_sd_nologging_nullvm_both = {{ mem_server_v2_sd_nologging_nullvm_both|safe }}
         mem_server_v2_sd_full_nullvm_both = {{ mem_server_v2_sd_full_nullvm_both|safe }}
+        mem_server_none_security_authz_ip_both = {{ mem_server_none_security_authz_ip_both|safe }}
+        mem_server_none_security_authz_path_both = {{ mem_server_none_security_authz_path_both|safe }}
+        mem_server_none_security_authz_jwt_both = {{ mem_server_none_security_authz_jwt_both|safe }}
+        mem_server_none_security_peer_authn_both = {{ mem_server_none_security_peer_authn_both|safe }}
 
         mem_ingressgw_none_mtls_base = {{ mem_ingressgw_none_mtls_base|safe }}
         mem_ingressgw_none_mtls_both = {{ mem_ingressgw_none_mtls_both|safe }}
@@ -219,6 +227,10 @@
         mem_client_v2_stats_wasm_both_master = {{ mem_client_v2_stats_wasm_both_master|safe }}
         mem_client_v2_sd_nologging_nullvm_both_master = {{ mem_client_v2_sd_nologging_nullvm_both_master| safe }}
         mem_client_v2_sd_full_nullvm_both_master = {{ mem_client_v2_sd_full_nullvm_both_master|safe }}
+        mem_client_none_security_authz_ip_both_master = {{ mem_client_none_security_authz_ip_both_master|safe }}
+        mem_client_none_security_authz_path_both_master = {{ mem_client_none_security_authz_path_both_master|safe }}
+        mem_client_none_security_authz_jwt_both_master = {{ mem_client_none_security_authz_jwt_both_master|safe }}
+        mem_client_none_security_peer_authn_both_master = {{ mem_client_none_security_peer_authn_both_master|safe }}
 
         mem_server_none_mtls_base_master = {{ mem_server_none_mtls_base_master|safe }}
         mem_server_none_mtls_both_master = {{ mem_server_none_mtls_both_master|safe }}
@@ -227,6 +239,10 @@
         mem_server_v2_stats_wasm_both_master = {{ mem_server_v2_stats_wasm_both_master|safe }}
         mem_server_v2_sd_nologging_nullvm_both_master = {{ mem_server_v2_sd_nologging_nullvm_both_master| safe }}
         mem_server_v2_sd_full_nullvm_both_master = {{ mem_server_v2_sd_full_nullvm_both_master|safe }}
+        mem_server_none_security_authz_ip_both_master = {{ mem_server_none_security_authz_ip_both_master|safe }}
+        mem_server_none_security_authz_path_both_master = {{ mem_server_none_security_authz_path_both_master|safe }}
+        mem_server_none_security_authz_jwt_both_master = {{ mem_server_none_security_authz_jwt_both_master|safe }}
+        mem_server_none_security_peer_authn_both_master = {{ mem_server_none_security_peer_authn_both_master|safe }}
 
         mem_ingressgw_none_mtls_base_master = {{ mem_ingressgw_none_mtls_base_master|safe }}
         mem_ingressgw_none_mtls_both_master = {{ mem_ingressgw_none_mtls_both_master|safe }}

--- a/perf_dashboard/benchmarks/templates/mem_vs_qps.html
+++ b/perf_dashboard/benchmarks/templates/mem_vs_qps.html
@@ -196,6 +196,10 @@
         mem_client_v2_stats_wasm_both = {{ mem_client_v2_stats_wasm_both|safe }}
         mem_client_v2_sd_nologging_nullvm_both = {{ mem_client_v2_sd_nologging_nullvm_both|safe }}
         mem_client_v2_sd_full_nullvm_both = {{ mem_client_v2_sd_full_nullvm_both|safe }}
+        mem_client_none_security_authz_ip_both = {{ mem_client_none_security_authz_ip_both|safe }}
+        mem_client_none_security_authz_jwt_both = {{ mem_client_none_security_authz_jwt_both|safe }}
+        mem_client_none_security_authz_path_both = {{ mem_client_none_security_authz_path_both|safe }}
+        mem_client_none_security_peer_authn_both = {{ mem_client_none_security_peer_authn_both|safe }}
 
         mem_server_none_mtls_base = {{ mem_server_none_mtls_base|safe }}
         mem_server_none_mtls_both = {{ mem_server_none_mtls_both|safe }}
@@ -204,6 +208,10 @@
         mem_server_v2_stats_wasm_both = {{ mem_server_v2_stats_wasm_both|safe }}
         mem_server_v2_sd_nologging_nullvm_both = {{ mem_server_v2_sd_nologging_nullvm_both|safe }}
         mem_server_v2_sd_full_nullvm_both = {{ mem_server_v2_sd_full_nullvm_both|safe }}
+        mem_server_none_security_authz_ip_both = {{ mem_server_none_security_authz_ip_both|safe }}
+        mem_server_none_security_authz_path_both = {{ mem_server_none_security_authz_path_both|safe }}
+        mem_server_none_security_authz_jwt_both = {{ mem_server_none_security_authz_jwt_both|safe }}
+        mem_server_none_security_peer_authn_both = {{ mem_server_none_security_peer_authn_both|safe }}
 
         mem_ingressgw_none_mtls_base = {{ mem_ingressgw_none_mtls_base|safe }}
         mem_ingressgw_none_mtls_both = {{ mem_ingressgw_none_mtls_both|safe }}
@@ -220,6 +228,10 @@
         mem_client_v2_stats_wasm_both_master = {{ mem_client_v2_stats_wasm_both_master|safe }}
         mem_client_v2_sd_nologging_nullvm_both_master = {{ mem_client_v2_sd_nologging_nullvm_both_master| safe }}
         mem_client_v2_sd_full_nullvm_both_master = {{ mem_client_v2_sd_full_nullvm_both_master|safe }}
+        mem_client_none_security_authz_ip_both_master = {{ mem_client_none_security_authz_ip_both_master|safe }}
+        mem_client_none_security_authz_path_both_master = {{ mem_client_none_security_authz_path_both_master|safe }}
+        mem_client_none_security_authz_jwt_both_master = {{ mem_client_none_security_authz_jwt_both_master|safe }}
+        mem_client_none_security_peer_authn_both_master = {{ mem_client_none_security_peer_authn_both_master|safe }}
 
         mem_server_none_mtls_base_master = {{ mem_server_none_mtls_base_master|safe }}
         mem_server_none_mtls_both_master = {{ mem_server_none_mtls_both_master|safe }}
@@ -228,6 +240,10 @@
         mem_server_v2_stats_wasm_both_master = {{ mem_server_v2_stats_wasm_both_master|safe }}
         mem_server_v2_sd_nologging_nullvm_both_master = {{ mem_server_v2_sd_nologging_nullvm_both_master| safe }}
         mem_server_v2_sd_full_nullvm_both_master = {{ mem_server_v2_sd_full_nullvm_both_master|safe }}
+        mem_server_none_security_authz_ip_both_master = {{ mem_server_none_security_authz_ip_both_master|safe }}
+        mem_server_none_security_authz_path_both_master = {{ mem_server_none_security_authz_path_both_master|safe }}
+        mem_server_none_security_authz_jwt_both_master = {{ mem_server_none_security_authz_jwt_both_master|safe }}
+        mem_server_none_security_peer_authn_both_master = {{ mem_server_none_security_peer_authn_both_master|safe }}
 
         mem_ingressgw_none_mtls_base_master = {{ mem_ingressgw_none_mtls_base_master|safe }}
         mem_ingressgw_none_mtls_both_master = {{ mem_ingressgw_none_mtls_both_master|safe }}

--- a/perf_dashboard/benchmarks/views.py
+++ b/perf_dashboard/benchmarks/views.py
@@ -96,6 +96,10 @@ def latency_vs_conn(request, uploaded_csv_url=None):
                                                                                       '_v2-sd-nologging-nullvm_both',
                                                                                       'p50')
         latency_v2_sd_full_nullvm_both_p50_master = get_latency_vs_conn_y_series(df, '_v2-sd-full-nullvm_both', 'p50')
+        latency_none_security_authz_ip_both_p50_master = get_latency_vs_conn_y_series(df, '_none_security_authz_ip_both', 'p50')
+        latency_none_security_authz_path_both_p50_master = get_latency_vs_conn_y_series(df, '_none_security_authz_path_both', 'p50')
+        latency_none_security_authz_jwt_both_p50_master = get_latency_vs_conn_y_series(df, '_none_security_authz_jwt_both', 'p50')
+        latency_none_security_peer_authn_both_p50_master = get_latency_vs_conn_y_series(df, '_none_security_peer_authn_both', 'p50')
 
         latency_none_mtls_base_p90_master = get_latency_vs_conn_y_series(df, '_none_mtls_baseline', 'p90')
         latency_none_mtls_both_p90_master = get_latency_vs_conn_y_series(df, '_none_mtls_both', 'p90')
@@ -106,6 +110,10 @@ def latency_vs_conn(request, uploaded_csv_url=None):
                                                                                       '_v2-sd-nologging-nullvm_both',
                                                                                       'p90')
         latency_v2_sd_full_nullvm_both_p90_master = get_latency_vs_conn_y_series(df, '_v2-sd-full-nullvm_both', 'p90')
+        latency_none_security_authz_ip_both_p90_master = get_latency_vs_conn_y_series(df, '_none_security_authz_ip_both', 'p90')
+        latency_none_security_authz_path_both_p90_master = get_latency_vs_conn_y_series(df, '_none_security_authz_path_both', 'p90')
+        latency_none_security_authz_jwt_both_p90_master = get_latency_vs_conn_y_series(df, '_none_security_authz_jwt_both', 'p90')
+        latency_none_security_peer_authn_both_p90_master = get_latency_vs_conn_y_series(df, '_none_security_peer_authn_both', 'p90')
 
         latency_none_mtls_base_p99_master = get_latency_vs_conn_y_series(df, '_none_mtls_baseline', 'p99')
         latency_none_mtls_both_p99_master = get_latency_vs_conn_y_series(df, '_none_mtls_both', 'p99')
@@ -116,6 +124,10 @@ def latency_vs_conn(request, uploaded_csv_url=None):
                                                                                       '_v2-sd-nologging-nullvm_both',
                                                                                       'p99')
         latency_v2_sd_full_nullvm_both_p99_master = get_latency_vs_conn_y_series(df, '_v2-sd-full-nullvm_both', 'p99')
+        latency_none_security_authz_ip_both_p99_master = get_latency_vs_conn_y_series(df, '_none_security_authz_ip_both', 'p99')
+        latency_none_security_authz_path_both_p99_master = get_latency_vs_conn_y_series(df, '_none_security_authz_path_both', 'p99')
+        latency_none_security_authz_jwt_both_p99_master = get_latency_vs_conn_y_series(df, '_none_security_authz_jwt_both', 'p99')
+        latency_none_security_peer_authn_both_p99_master = get_latency_vs_conn_y_series(df, '_none_security_peer_authn_both', 'p99')
 
         latency_none_mtls_base_p999_master = get_latency_vs_conn_y_series(df, '_none_mtls_baseline', 'p999')
         latency_none_mtls_both_p999_master = get_latency_vs_conn_y_series(df, '_none_mtls_both', 'p999')
@@ -124,6 +136,10 @@ def latency_vs_conn(request, uploaded_csv_url=None):
         latency_v2_stats_wasm_both_p999_master = get_latency_vs_conn_y_series(df, '_v2-stats-wasm_both', 'p999')
         latency_v2_sd_nologging_nullvm_both_p999_master = get_latency_vs_conn_y_series(df, '_v2-sd-nologging-nullvm_both', 'p999')
         latency_v2_sd_full_nullvm_both_p999_master = get_latency_vs_conn_y_series(df, '_v2-sd-full-nullvm_both', 'p999')
+        latency_none_security_authz_ip_both_p999_master = get_latency_vs_conn_y_series(df, '_none_security_authz_ip_both', 'p999')
+        latency_none_security_authz_path_both_p999_master = get_latency_vs_conn_y_series(df, '_none_security_authz_path_both', 'p999')
+        latency_none_security_authz_jwt_both_p999_master = get_latency_vs_conn_y_series(df, '_none_security_authz_jwt_both', 'p999')
+        latency_none_security_peer_authn_both_p999_master = get_latency_vs_conn_y_series(df, '_none_security_peer_authn_both', 'p999')
 
         other_context = {'current_release': current_release,
                          'cur_selected_release': cur_selected_release,
@@ -139,6 +155,10 @@ def latency_vs_conn(request, uploaded_csv_url=None):
                           'latency_v2_stats_wasm_both_p50_master': latency_v2_stats_wasm_both_p50_master,
                           'latency_v2_sd_nologging_nullvm_both_p50_master': latency_v2_sd_nologging_nullvm_both_p50_master,
                           'latency_v2_sd_full_nullvm_both_p50_master': latency_v2_sd_full_nullvm_both_p50_master,
+                          'latency_none_security_authz_ip_both_p50_master': latency_none_security_authz_ip_both_p50_master,
+                          'latency_none_security_authz_path_both_p50_master': latency_none_security_authz_path_both_p50_master,
+                          'latency_none_security_authz_jwt_both_p50_master': latency_none_security_authz_jwt_both_p50_master,
+                          'latency_none_security_peer_authn_both_p50_master': latency_none_security_peer_authn_both_p50_master,
                           'latency_none_mtls_base_p90_master': latency_none_mtls_base_p90_master,
                           'latency_none_mtls_both_p90_master': latency_none_mtls_both_p90_master,
                           'latency_none_plaintext_both_p90_master': latency_none_plaintext_both_p90_master,
@@ -146,6 +166,10 @@ def latency_vs_conn(request, uploaded_csv_url=None):
                           'latency_v2_stats_wasm_both_p90_master': latency_v2_stats_wasm_both_p90_master,
                           'latency_v2_sd_nologging_nullvm_both_p90_master': latency_v2_sd_nologging_nullvm_both_p90_master,
                           'latency_v2_sd_full_nullvm_both_p90_master': latency_v2_sd_full_nullvm_both_p90_master,
+                          'latency_none_security_authz_ip_both_p90_master': latency_none_security_authz_ip_both_p90_master,
+                          'latency_none_security_authz_path_both_p90_master': latency_none_security_authz_path_both_p90_master,
+                          'latency_none_security_authz_jwt_both_p90_master': latency_none_security_authz_jwt_both_p90_master,
+                          'latency_none_security_peer_authn_both_p90_master': latency_none_security_peer_authn_both_p90_master,
                           'latency_none_mtls_base_p99_master': latency_none_mtls_base_p99_master,
                           'latency_none_mtls_both_p99_master': latency_none_mtls_both_p99_master,
                           'latency_none_plaintext_both_p99_master': latency_none_plaintext_both_p99_master,
@@ -153,6 +177,10 @@ def latency_vs_conn(request, uploaded_csv_url=None):
                           'latency_v2_stats_wasm_both_p99_master': latency_v2_stats_wasm_both_p99_master,
                           'latency_v2_sd_nologging_nullvm_both_p99_master': latency_v2_sd_nologging_nullvm_both_p99_master,
                           'latency_v2_sd_full_nullvm_both_p99_master': latency_v2_sd_full_nullvm_both_p99_master,
+                          'latency_none_security_authz_ip_both_p99_master': latency_none_security_authz_ip_both_p99_master,
+                          'latency_none_security_authz_path_both_p99_master': latency_none_security_authz_path_both_p99_master,
+                          'latency_none_security_authz_jwt_both_p99_master': latency_none_security_authz_jwt_both_p99_master,
+                          'latency_none_security_peer_authn_both_p99_master': latency_none_security_peer_authn_both_p99_master,
                           'latency_none_mtls_base_p999_master': latency_none_mtls_base_p999_master,
                           'latency_none_mtls_both_p999_master': latency_none_mtls_both_p999_master,
                           'latency_none_plaintext_both_p999_master': latency_none_plaintext_both_p999_master,
@@ -160,6 +188,10 @@ def latency_vs_conn(request, uploaded_csv_url=None):
                           'latency_v2_stats_wasm_both_p999_master': latency_v2_stats_wasm_both_p999_master,
                           'latency_v2_sd_nologging_nullvm_both_p999_master': latency_v2_sd_nologging_nullvm_both_p999_master,
                           'latency_v2_sd_full_nullvm_both_p999_master': latency_v2_sd_full_nullvm_both_p999_master,
+                          'latency_none_security_authz_ip_both_p999_master': latency_none_security_authz_ip_both_p999_master,
+                          'latency_none_security_authz_path_both_p999_master': latency_none_security_authz_path_both_p999_master,
+                          'latency_none_security_authz_jwt_both_p999_master': latency_none_security_authz_jwt_both_p999_master,
+                          'latency_none_security_peer_authn_both_p999_master': latency_none_security_peer_authn_both_p999_master,
                           }
 
         context = reduce(lambda x, y: dict(x, **y), (other_context, release_context, master_context))
@@ -224,6 +256,10 @@ def latency_vs_qps(request, uploaded_csv_url=None):
         latency_v2_sd_nologging_nullvm_both_p50_master = get_latency_vs_qps_y_series(df, '_v2-sd-nologging-nullvm_both',
                                                                                      'p50')
         latency_v2_sd_full_nullvm_both_p50_master = get_latency_vs_qps_y_series(df, '_v2-sd-full-nullvm_both', 'p50')
+        latency_none_security_authz_ip_both_p50_master = get_latency_vs_qps_y_series(df, '_none_security_authz_ip_both', 'p50')
+        latency_none_security_authz_path_both_p50_master = get_latency_vs_qps_y_series(df, '_none_security_authz_path_both', 'p50')
+        latency_none_security_authz_jwt_both_p50_master = get_latency_vs_qps_y_series(df, '_none_security_authz_jwt_both', 'p50')
+        latency_none_security_peer_authn_both_p50_master = get_latency_vs_qps_y_series(df, '_none_security_peer_authn_both', 'p50')
 
         latency_none_mtls_base_p90_master = get_latency_vs_qps_y_series(df, '_none_mtls_baseline', 'p90')
         latency_none_mtls_both_p90_master = get_latency_vs_qps_y_series(df, '_none_mtls_both', 'p90')
@@ -232,6 +268,10 @@ def latency_vs_qps(request, uploaded_csv_url=None):
         latency_v2_stats_wasm_both_p90_master = get_latency_vs_qps_y_series(df, '_v2-stats-wasm_both', 'p90')
         latency_v2_sd_nologging_nullvm_both_p90_master = get_latency_vs_qps_y_series(df, '_v2-sd-nologging-nullvm_both', 'p90')
         latency_v2_sd_full_nullvm_both_p90_master = get_latency_vs_qps_y_series(df, '_v2-sd-full-nullvm_both', 'p90')
+        latency_none_security_authz_ip_both_p90_master = get_latency_vs_qps_y_series(df, '_none_security_authz_ip_both', 'p90')
+        latency_none_security_authz_path_both_p90_master = get_latency_vs_qps_y_series(df, '_none_security_authz_path_both', 'p90')
+        latency_none_security_authz_jwt_both_p90_master = get_latency_vs_qps_y_series(df, '_none_security_authz_jwt_both', 'p90')
+        latency_none_security_peer_authn_both_p90_master = get_latency_vs_qps_y_series(df, '_none_security_peer_authn_both', 'p90')
 
         latency_none_mtls_base_p99_master = get_latency_vs_qps_y_series(df, '_none_mtls_baseline', 'p99')
         latency_none_mtls_both_p99_master = get_latency_vs_qps_y_series(df, '_none_mtls_both', 'p99')
@@ -240,6 +280,10 @@ def latency_vs_qps(request, uploaded_csv_url=None):
         latency_v2_stats_wasm_both_p99_master = get_latency_vs_qps_y_series(df, '_v2-stats-wasm_both', 'p99')
         latency_v2_sd_nologging_nullvm_both_p99_master = get_latency_vs_qps_y_series(df, '_v2-sd-nologging-nullvm_both', 'p99')
         latency_v2_sd_full_nullvm_both_p99_master = get_latency_vs_qps_y_series(df, '_v2-sd-full-nullvm_both', 'p99')
+        latency_none_security_authz_ip_both_p99_master = get_latency_vs_qps_y_series(df, '_none_security_authz_ip_both', 'p99')
+        latency_none_security_authz_path_both_p99_master = get_latency_vs_qps_y_series(df, '_none_security_authz_path_both', 'p99')
+        latency_none_security_authz_jwt_both_p99_master = get_latency_vs_qps_y_series(df, '_none_security_authz_jwt_both', 'p99')
+        latency_none_security_peer_authn_both_p99_master = get_latency_vs_qps_y_series(df, '_none_security_peer_authn_both', 'p99')
 
         latency_none_mtls_base_p999_master = get_latency_vs_qps_y_series(df, '_none_mtls_baseline', 'p999')
         latency_none_mtls_both_p999_master = get_latency_vs_qps_y_series(df, '_none_mtls_both', 'p999')
@@ -248,6 +292,10 @@ def latency_vs_qps(request, uploaded_csv_url=None):
         latency_v2_stats_wasm_both_p999_master = get_latency_vs_qps_y_series(df, '_v2-stats-wasm_both', 'p999')
         latency_v2_sd_nologging_nullvm_both_p999_master = get_latency_vs_qps_y_series(df, '_v2-sd-nologging-nullvm_both', 'p999')
         latency_v2_sd_full_nullvm_both_p999_master = get_latency_vs_qps_y_series(df, '_v2-sd-full-nullvm_both', 'p999')
+        latency_none_security_authz_ip_both_p999_master = get_latency_vs_qps_y_series(df, '_none_security_authz_ip_both', 'p999')
+        latency_none_security_authz_path_both_p999_master = get_latency_vs_qps_y_series(df, '_none_security_authz_path_both', 'p999')
+        latency_none_security_authz_jwt_both_p999_master = get_latency_vs_qps_y_series(df, '_none_security_authz_jwt_both', 'p999')
+        latency_none_security_peer_authn_both_p999_master = get_latency_vs_qps_y_series(df, '_none_security_peer_authn_both', 'p999')
 
         other_context = {'current_release': current_release,
                          'cur_selected_release': cur_selected_release,
@@ -263,6 +311,10 @@ def latency_vs_qps(request, uploaded_csv_url=None):
                           'latency_v2_stats_wasm_both_p50_master': latency_v2_stats_wasm_both_p50_master,
                           'latency_v2_sd_nologging_nullvm_both_p50_master': latency_v2_sd_nologging_nullvm_both_p50_master,
                           'latency_v2_sd_full_nullvm_both_p50_master': latency_v2_sd_full_nullvm_both_p50_master,
+                          'latency_none_security_authz_ip_both_p50_master': latency_none_security_authz_ip_both_p50_master,
+                          'latency_none_security_authz_path_both_p50_master': latency_none_security_authz_path_both_p50_master,
+                          'latency_none_security_authz_jwt_both_p50_master': latency_none_security_authz_jwt_both_p50_master,
+                          'latency_none_security_peer_authn_both_p50_master': latency_none_security_peer_authn_both_p50_master,
                           'latency_none_mtls_base_p90_master': latency_none_mtls_base_p90_master,
                           'latency_none_mtls_both_p90_master': latency_none_mtls_both_p90_master,
                           'latency_none_plaintext_both_p90_master': latency_none_plaintext_both_p90_master,
@@ -270,6 +322,10 @@ def latency_vs_qps(request, uploaded_csv_url=None):
                           'latency_v2_stats_wasm_both_p90_master': latency_v2_stats_wasm_both_p90_master,
                           'latency_v2_sd_nologging_nullvm_both_p90_master': latency_v2_sd_nologging_nullvm_both_p90_master,
                           'latency_v2_sd_full_nullvm_both_p90_master': latency_v2_sd_full_nullvm_both_p90_master,
+                          'latency_none_security_authz_ip_both_p90_master': latency_none_security_authz_ip_both_p90_master,
+                          'latency_none_security_authz_path_both_p90_master': latency_none_security_authz_path_both_p90_master,
+                          'latency_none_security_authz_jwt_both_p90_master': latency_none_security_authz_jwt_both_p90_master,
+                          'latency_none_security_peer_authn_both_p90_master': latency_none_security_peer_authn_both_p90_master,
                           'latency_none_mtls_base_p99_master': latency_none_mtls_base_p99_master,
                           'latency_none_mtls_both_p99_master': latency_none_mtls_both_p99_master,
                           'latency_none_plaintext_both_p99_master': latency_none_plaintext_both_p99_master,
@@ -277,6 +333,10 @@ def latency_vs_qps(request, uploaded_csv_url=None):
                           'latency_v2_stats_wasm_both_p99_master': latency_v2_stats_wasm_both_p99_master,
                           'latency_v2_sd_nologging_nullvm_both_p99_master': latency_v2_sd_nologging_nullvm_both_p99_master,
                           'latency_v2_sd_full_nullvm_both_p99_master': latency_v2_sd_full_nullvm_both_p99_master,
+                          'latency_none_security_authz_ip_both_p99_master': latency_none_security_authz_ip_both_p99_master,
+                          'latency_none_security_authz_path_both_p99_master': latency_none_security_authz_path_both_p99_master,
+                          'latency_none_security_authz_jwt_both_p99_master': latency_none_security_authz_jwt_both_p99_master,
+                          'latency_none_security_peer_authn_both_p99_master': latency_none_security_peer_authn_both_p99_master,
                           'latency_none_mtls_base_p999_master': latency_none_mtls_base_p999_master,
                           'latency_none_mtls_both_p999_master': latency_none_mtls_both_p999_master,
                           'latency_none_plaintext_both_p999_master': latency_none_plaintext_both_p999_master,
@@ -284,6 +344,10 @@ def latency_vs_qps(request, uploaded_csv_url=None):
                           'latency_v2_stats_wasm_both_p999_master': latency_v2_stats_wasm_both_p999_master,
                           'latency_v2_sd_nologging_nullvm_both_p999_master': latency_v2_sd_nologging_nullvm_both_p999_master,
                           'latency_v2_sd_full_nullvm_both_p999_master': latency_v2_sd_full_nullvm_both_p999_master,
+                          'latency_none_security_authz_ip_both_p999_master': latency_none_security_authz_ip_both_p999_master,
+                          'latency_none_security_authz_path_both_p999_master': latency_none_security_authz_path_both_p999_master,
+                          'latency_none_security_authz_jwt_both_p999_master': latency_none_security_authz_jwt_both_p999_master,
+                          'latency_none_security_peer_authn_both_p999_master': latency_none_security_peer_authn_both_p999_master,
                           }
         context = reduce(lambda x, y: dict(x, **y), (other_context, release_context, master_context))
 
@@ -339,6 +403,10 @@ def cpu_vs_qps(request, uploaded_csv_url=None):
         cpu_client_v2_stats_wasm_both_master = get_cpu_vs_qps_y_series(df, '_v2-stats-wasm_both', cpu_client_metric_name)
         cpu_client_v2_sd_nologging_nullvm_both_master = get_cpu_vs_qps_y_series(df, '_v2-sd-nologging-nullvm_both', cpu_client_metric_name)
         cpu_client_v2_sd_full_nullvm_both_master = get_cpu_vs_qps_y_series(df, '_v2-sd-full-nullvm_both', cpu_client_metric_name)
+        cpu_client_none_security_authz_ip_both_master = get_cpu_vs_qps_y_series(df, '_none_security_authz_ip_both', cpu_client_metric_name)
+        cpu_client_none_security_authz_path_both_master = get_cpu_vs_qps_y_series(df, '_none_security_authz_path_both', cpu_client_metric_name)
+        cpu_client_none_security_authz_jwt_both_master = get_cpu_vs_qps_y_series(df, '_none_security_authz_jwt_both', cpu_client_metric_name)
+        cpu_client_none_security_peer_authn_both_master = get_cpu_vs_qps_y_series(df, '_none_security_peer_authn_both', cpu_client_metric_name)
 
         cpu_server_none_mtls_base_master = get_cpu_vs_qps_y_series(df, '_none_mtls_baseline', cpu_server_metric_name)
         cpu_server_none_mtls_both_master = get_cpu_vs_qps_y_series(df, '_none_mtls_both', cpu_server_metric_name)
@@ -347,6 +415,10 @@ def cpu_vs_qps(request, uploaded_csv_url=None):
         cpu_server_v2_stats_wasm_both_master = get_cpu_vs_qps_y_series(df, '_v2-stats-wasm_both', cpu_server_metric_name)
         cpu_server_v2_sd_nologging_nullvm_both_master = get_cpu_vs_qps_y_series(df, '_v2-sd-nologging-nullvm_both', cpu_server_metric_name)
         cpu_server_v2_sd_full_nullvm_both_master = get_cpu_vs_qps_y_series(df, '_v2-sd-full-nullvm_both', cpu_server_metric_name)
+        cpu_server_none_security_authz_ip_both_master = get_cpu_vs_qps_y_series(df, '_none_security_authz_ip_both', cpu_server_metric_name)
+        cpu_server_none_security_authz_path_both_master = get_cpu_vs_qps_y_series(df, '_none_security_authz_path_both', cpu_server_metric_name)
+        cpu_server_none_security_authz_jwt_both_master = get_cpu_vs_qps_y_series(df, '_none_security_authz_jwt_both', cpu_server_metric_name)
+        cpu_server_none_security_peer_authn_both_master = get_cpu_vs_qps_y_series(df, '_none_security_peer_authn_both', cpu_server_metric_name)
 
         cpu_ingressgw_none_mtls_base_master = get_cpu_vs_qps_y_series(df, '_none_mtls_baseline', cpu_ingressgw_metric_name)
         cpu_ingressgw_none_mtls_both_master = get_cpu_vs_qps_y_series(df, '_none_mtls_both', cpu_ingressgw_metric_name)
@@ -370,6 +442,10 @@ def cpu_vs_qps(request, uploaded_csv_url=None):
                           'cpu_client_v2_stats_wasm_both_master': cpu_client_v2_stats_wasm_both_master,
                           'cpu_client_v2_sd_nologging_nullvm_both_master': cpu_client_v2_sd_nologging_nullvm_both_master,
                           'cpu_client_v2_sd_full_nullvm_both_master': cpu_client_v2_sd_full_nullvm_both_master,
+                          'cpu_client_none_security_authz_ip_both_master': cpu_client_none_security_authz_ip_both_master,
+                          'cpu_client_none_security_authz_path_both_master': cpu_client_none_security_authz_path_both_master,
+                          'cpu_client_none_security_authz_jwt_both_master': cpu_client_none_security_authz_jwt_both_master,
+                          'cpu_client_none_security_peer_authn_both_master': cpu_client_none_security_peer_authn_both_master,
                           'cpu_server_none_mtls_base_master': cpu_server_none_mtls_base_master,
                           'cpu_server_none_mtls_both_master': cpu_server_none_mtls_both_master,
                           'cpu_server_none_plaintext_both_master': cpu_server_none_plaintext_both_master,
@@ -377,6 +453,10 @@ def cpu_vs_qps(request, uploaded_csv_url=None):
                           'cpu_server_v2_stats_wasm_both_master': cpu_server_v2_stats_wasm_both_master,
                           'cpu_server_v2_sd_nologging_nullvm_both_master': cpu_server_v2_sd_nologging_nullvm_both_master,
                           'cpu_server_v2_sd_full_nullvm_both_master': cpu_server_v2_sd_full_nullvm_both_master,
+                          'cpu_server_none_security_authz_ip_both_master': cpu_server_none_security_authz_ip_both_master,
+                          'cpu_server_none_security_authz_path_both_master': cpu_server_none_security_authz_path_both_master,
+                          'cpu_server_none_security_authz_jwt_both_master': cpu_server_none_security_authz_jwt_both_master,
+                          'cpu_server_none_security_peer_authn_both_master': cpu_server_none_security_peer_authn_both_master,
                           'cpu_ingressgw_none_mtls_base_master': cpu_ingressgw_none_mtls_base_master,
                           'cpu_ingressgw_none_mtls_both_master': cpu_ingressgw_none_mtls_both_master,
                           'cpu_ingressgw_none_plaintext_both_master': cpu_ingressgw_none_plaintext_both_master,
@@ -438,6 +518,10 @@ def cpu_vs_conn(request, uploaded_csv_url=None):
         cpu_client_v2_stats_wasm_both_master = get_cpu_vs_conn_y_series(df, '_v2-wasm-nullvm_both', cpu_client_metric_name)
         cpu_client_v2_sd_nologging_nullvm_both_master = get_cpu_vs_conn_y_series(df, '_v2-sd-nologging-nullvm_both', cpu_client_metric_name)
         cpu_client_v2_sd_full_nullvm_both_master = get_cpu_vs_conn_y_series(df, '_v2-sd-full-nullvm_both', cpu_client_metric_name)
+        cpu_client_none_security_authz_ip_both_master = get_cpu_vs_conn_y_series(df, '_none_security_authz_ip_both', cpu_client_metric_name)
+        cpu_client_none_security_authz_path_both_master = get_cpu_vs_conn_y_series(df, '_none_security_authz_path_both', cpu_client_metric_name)
+        cpu_client_none_security_authz_jwt_both_master = get_cpu_vs_conn_y_series(df, '_none_security_authz_jwt_both', cpu_client_metric_name)
+        cpu_client_none_security_peer_authn_both_master = get_cpu_vs_conn_y_series(df, '_none_security_peer_authn_both', cpu_client_metric_name)
 
         cpu_server_none_mtls_base_master = get_cpu_vs_conn_y_series(df, '_none_mtls_baseline', cpu_server_metric_name)
         cpu_server_none_mtls_both_master = get_cpu_vs_conn_y_series(df, '_none_mtls_both', cpu_server_metric_name)
@@ -446,6 +530,10 @@ def cpu_vs_conn(request, uploaded_csv_url=None):
         cpu_server_v2_stats_wasm_both_master = get_cpu_vs_conn_y_series(df, '_v2-stats-wasm_both', cpu_server_metric_name)
         cpu_server_v2_sd_nologging_nullvm_both_master = get_cpu_vs_conn_y_series(df, '_v2-sd-nologging-nullvm_both', cpu_server_metric_name)
         cpu_server_v2_sd_full_nullvm_both_master = get_cpu_vs_conn_y_series(df, '_v2-sd-full-nullvm_both', cpu_server_metric_name)
+        cpu_server_none_security_authz_ip_both_master = get_cpu_vs_conn_y_series(df, '_none_security_authz_ip_both', cpu_server_metric_name)
+        cpu_server_none_security_authz_path_both_master = get_cpu_vs_conn_y_series(df, '_none_security_authz_path_both', cpu_server_metric_name)
+        cpu_server_none_security_authz_jwt_both_master = get_cpu_vs_conn_y_series(df, '_none_security_authz_jwt_both', cpu_server_metric_name)
+        cpu_server_none_security_peer_authn_both_master = get_cpu_vs_conn_y_series(df, '_none_security_peer_authn_both', cpu_server_metric_name)
 
         cpu_ingressgw_none_mtls_base_master = get_cpu_vs_conn_y_series(df, '_none_mtls_baseline', cpu_ingressgw_metric_name)
         cpu_ingressgw_none_mtls_both_master = get_cpu_vs_conn_y_series(df, '_none_mtls_both', cpu_ingressgw_metric_name)
@@ -469,6 +557,10 @@ def cpu_vs_conn(request, uploaded_csv_url=None):
                           'cpu_client_v2_stats_wasm_both_master': cpu_client_v2_stats_wasm_both_master,
                           'cpu_client_v2_sd_nologging_nullvm_both_master': cpu_client_v2_sd_nologging_nullvm_both_master,
                           'cpu_client_v2_sd_full_nullvm_both_master': cpu_client_v2_sd_full_nullvm_both_master,
+                          'cpu_client_none_security_authz_ip_both_master': cpu_client_none_security_authz_ip_both_master,
+                          'cpu_client_none_security_authz_path_both_master': cpu_client_none_security_authz_path_both_master,
+                          'cpu_client_none_security_authz_jwt_both_master': cpu_client_none_security_authz_jwt_both_master,
+                          'cpu_client_none_security_peer_authn_both_master': cpu_client_none_security_peer_authn_both_master,
                           'cpu_server_none_mtls_base_master': cpu_server_none_mtls_base_master,
                           'cpu_server_none_mtls_both_master': cpu_server_none_mtls_both_master,
                           'cpu_server_none_plaintext_both_master': cpu_server_none_plaintext_both_master,
@@ -476,6 +568,10 @@ def cpu_vs_conn(request, uploaded_csv_url=None):
                           'cpu_server_v2_stats_wasm_both_master': cpu_server_v2_stats_wasm_both_master,
                           'cpu_server_v2_sd_nologging_nullvm_both_master': cpu_server_v2_sd_nologging_nullvm_both_master,
                           'cpu_server_v2_sd_full_nullvm_both_master': cpu_server_v2_sd_full_nullvm_both_master,
+                          'cpu_server_none_security_authz_ip_both_master': cpu_server_none_security_authz_ip_both_master,
+                          'cpu_server_none_security_authz_path_both_master': cpu_server_none_security_authz_path_both_master,
+                          'cpu_server_none_security_authz_jwt_both_master': cpu_server_none_security_authz_jwt_both_master,
+                          'cpu_server_none_security_peer_authn_both_master': cpu_server_none_security_peer_authn_both_master,
                           'cpu_ingressgw_none_mtls_base_master': cpu_ingressgw_none_mtls_base_master,
                           'cpu_ingressgw_none_mtls_both_master': cpu_ingressgw_none_mtls_both_master,
                           'cpu_ingressgw_none_plaintext_both_master': cpu_ingressgw_none_plaintext_both_master,
@@ -539,6 +635,10 @@ def mem_vs_qps(request, uploaded_csv_url=None):
         mem_client_v2_stats_wasm_both_master = get_mem_vs_qps_y_series(df, '_v2-stats-wasm_both', mem_client_metric_name)
         mem_client_v2_sd_nologging_nullvm_both_master = get_mem_vs_qps_y_series(df, '_v2-sd-nologging-nullvm_both', mem_client_metric_name)
         mem_client_v2_sd_full_nullvm_both_master = get_mem_vs_qps_y_series(df, '_v2-sd-full-nullvm_both', mem_client_metric_name)
+        mem_client_none_security_authz_ip_both_master = get_mem_vs_qps_y_series(df, '_none_security_authz_ip_both', mem_client_metric_name)
+        mem_client_none_security_authz_path_both_master = get_mem_vs_qps_y_series(df, '_none_security_authz_path_both', mem_client_metric_name)
+        mem_client_none_security_authz_jwt_both_master = get_mem_vs_qps_y_series(df, '_none_security_authz_jwt_both', mem_client_metric_name)
+        mem_client_none_security_peer_authn_both_master = get_mem_vs_qps_y_series(df, '_none_security_peer_authn_both', mem_client_metric_name)
 
         mem_server_none_mtls_base_master = get_mem_vs_qps_y_series(df, '_none_mtls_baseline', mem_server_metric_name)
         mem_server_none_mtls_both_master = get_mem_vs_qps_y_series(df, '_none_mtls_both', mem_server_metric_name)
@@ -547,6 +647,10 @@ def mem_vs_qps(request, uploaded_csv_url=None):
         mem_server_v2_stats_wasm_both_master = get_mem_vs_qps_y_series(df, '_v2-stats-wasm_both', mem_server_metric_name)
         mem_server_v2_sd_nologging_nullvm_both_master = get_mem_vs_qps_y_series(df, '_v2-sd-nologging-nullvm_both', mem_server_metric_name)
         mem_server_v2_sd_full_nullvm_both_master = get_mem_vs_qps_y_series(df, '_v2-sd-full-nullvm_both', mem_server_metric_name)
+        mem_server_none_security_authz_ip_both_master = get_mem_vs_qps_y_series(df, '_none_security_authz_ip_both', mem_server_metric_name)
+        mem_server_none_security_authz_path_both_master = get_mem_vs_qps_y_series(df, '_none_security_authz_path_both', mem_server_metric_name)
+        mem_server_none_security_authz_jwt_both_master = get_mem_vs_qps_y_series(df, '_none_security_authz_jwt_both', mem_server_metric_name)
+        mem_server_none_security_peer_authn_both_master = get_mem_vs_qps_y_series(df, '_none_security_peer_authn_both', mem_server_metric_name)
 
         mem_ingressgw_none_mtls_base_master = get_mem_vs_qps_y_series(df, '_none_mtls_baseline', mem_ingressgw_metric_name)
         mem_ingressgw_none_mtls_both_master = get_mem_vs_qps_y_series(df, '_none_mtls_both', mem_ingressgw_metric_name)
@@ -570,6 +674,10 @@ def mem_vs_qps(request, uploaded_csv_url=None):
                           'mem_client_v2_stats_wasm_both_master': mem_client_v2_stats_wasm_both_master,
                           'mem_client_v2_sd_nologging_nullvm_both_master': mem_client_v2_sd_nologging_nullvm_both_master,
                           'mem_client_v2_sd_full_nullvm_both_master': mem_client_v2_sd_full_nullvm_both_master,
+                          'mem_client_none_security_authz_ip_both_master': mem_client_none_security_authz_ip_both_master,
+                          'mem_client_none_security_authz_path_both_master': mem_client_none_security_authz_path_both_master,
+                          'mem_client_none_security_authz_jwt_both_master': mem_client_none_security_authz_jwt_both_master,
+                          'mem_client_none_security_peer_authn_both_master': mem_client_none_security_peer_authn_both_master,
                           'mem_server_none_mtls_base_master': mem_server_none_mtls_base_master,
                           'mem_server_none_mtls_both_master': mem_server_none_mtls_both_master,
                           'mem_server_none_plaintext_both_master': mem_server_none_plaintext_both_master,
@@ -577,6 +685,10 @@ def mem_vs_qps(request, uploaded_csv_url=None):
                           'mem_server_v2_stats_wasm_both_master': mem_server_v2_stats_wasm_both_master,
                           'mem_server_v2_sd_nologging_nullvm_both_master': mem_server_v2_sd_nologging_nullvm_both_master,
                           'mem_server_v2_sd_full_nullvm_both_master': mem_server_v2_sd_full_nullvm_both_master,
+                          'mem_server_none_security_authz_ip_both_master': mem_server_none_security_authz_ip_both_master,
+                          'mem_server_none_security_authz_path_both_master': mem_server_none_security_authz_path_both_master,
+                          'mem_server_none_security_authz_jwt_both_master': mem_server_none_security_authz_jwt_both_master,
+                          'mem_server_none_security_peer_authn_both_master': mem_server_none_security_peer_authn_both_master,
                           'mem_ingressgw_none_mtls_base_master': mem_ingressgw_none_mtls_base_master,
                           'mem_ingressgw_none_mtls_both_master': mem_ingressgw_none_mtls_both_master,
                           'mem_ingressgw_none_plaintext_both_master': mem_ingressgw_none_plaintext_both_master,
@@ -639,6 +751,10 @@ def mem_vs_conn(request, uploaded_csv_url=None):
         mem_client_v2_stats_wasm_both_master = get_mem_vs_conn_y_series(df, '_v2-stats-wasm_both', mem_client_metric_name)
         mem_client_v2_sd_nologging_nullvm_both_master = get_mem_vs_conn_y_series(df, '_v2-sd-nologging-nullvm_both', mem_client_metric_name)
         mem_client_v2_sd_full_nullvm_both_master = get_mem_vs_conn_y_series(df, '_v2-sd-full-nullvm_both', mem_client_metric_name)
+        mem_client_none_security_authz_ip_both_master = get_mem_vs_conn_y_series(df, '_none_security_authz_ip_both', mem_client_metric_name)
+        mem_client_none_security_authz_path_both_master = get_mem_vs_conn_y_series(df, '_none_security_authz_path_both', mem_client_metric_name)
+        mem_client_none_security_authz_jwt_both_master = get_mem_vs_conn_y_series(df, '_none_security_authz_jwt_both', mem_client_metric_name)
+        mem_client_none_security_peer_authn_both_master = get_mem_vs_conn_y_series(df, '_none_security_peer_authn_both', mem_client_metric_name)
 
         mem_server_none_mtls_base_master = get_mem_vs_conn_y_series(df, '_none_mtls_baseline', mem_server_metric_name)
         mem_server_none_mtls_both_master = get_mem_vs_conn_y_series(df, '_none_mtls_both', mem_server_metric_name)
@@ -647,6 +763,10 @@ def mem_vs_conn(request, uploaded_csv_url=None):
         mem_server_v2_stats_wasm_both_master = get_mem_vs_conn_y_series(df, '_v2-stats-wasm_both', mem_server_metric_name)
         mem_server_v2_sd_nologging_nullvm_both_master = get_mem_vs_conn_y_series(df, '_v2-sd-nologging-nullvm_both', mem_server_metric_name)
         mem_server_v2_sd_full_nullvm_both_master = get_mem_vs_conn_y_series(df, '_v2-sd-full-nullvm_both', mem_server_metric_name)
+        mem_server_none_security_authz_ip_both_master = get_mem_vs_conn_y_series(df, '_none_security_authz_ip_both', mem_server_metric_name)
+        mem_server_none_security_authz_path_both_master = get_mem_vs_conn_y_series(df, '_none_security_authz_path_both', mem_server_metric_name)
+        mem_server_none_security_authz_jwt_both_master = get_mem_vs_conn_y_series(df, '_none_security_authz_jwt_both', mem_server_metric_name)
+        mem_server_none_security_peer_authn_both_master = get_mem_vs_conn_y_series(df, '_none_security_peer_authn_both', mem_server_metric_name)
 
         mem_ingressgw_none_mtls_base_master = get_mem_vs_qps_y_series(df, '_none_mtls_baseline', mem_ingressgw_metric_name)
         mem_ingressgw_none_mtls_both_master = get_mem_vs_qps_y_series(df, '_none_mtls_both', mem_ingressgw_metric_name)
@@ -670,6 +790,10 @@ def mem_vs_conn(request, uploaded_csv_url=None):
                           'mem_client_v2_stats_wasm_both_master': mem_client_v2_stats_wasm_both_master,
                           'mem_client_v2_sd_nologging_nullvm_both_master': mem_client_v2_sd_nologging_nullvm_both_master,
                           'mem_client_v2_sd_full_nullvm_both_master': mem_client_v2_sd_full_nullvm_both_master,
+                          'mem_client_none_security_authz_ip_both_master': mem_client_none_security_authz_ip_both_master,
+                          'mem_client_none_security_authz_path_both_master': mem_client_none_security_authz_path_both_master,
+                          'mem_client_none_security_authz_jwt_both_master': mem_client_none_security_authz_jwt_both_master,
+                          'mem_client_none_security_peer_authn_both_master': mem_client_none_security_peer_authn_both_master,
                           'mem_server_none_mtls_base_master': mem_server_none_mtls_base_master,
                           'mem_server_none_mtls_both_master': mem_server_none_mtls_both_master,
                           'mem_server_none_plaintext_both_master': mem_server_none_plaintext_both_master,
@@ -677,6 +801,10 @@ def mem_vs_conn(request, uploaded_csv_url=None):
                           'mem_server_v2_stats_wasm_both_master': mem_server_v2_stats_wasm_both_master,
                           'mem_server_v2_sd_nologging_nullvm_both_master': mem_server_v2_sd_nologging_nullvm_both_master,
                           'mem_server_v2_sd_full_nullvm_both_master': mem_server_v2_sd_full_nullvm_both_master,
+                          'mem_server_none_security_authz_ip_both_master': mem_server_none_security_authz_ip_both_master,
+                          'mem_server_none_security_authz_path_both_master': mem_server_none_security_authz_path_both_master,
+                          'mem_server_none_security_authz_jwt_both_master': mem_server_none_security_authz_jwt_both_master,
+                          'mem_server_none_security_peer_authn_both_master': mem_server_none_security_peer_authn_both_master,
                           'mem_ingressgw_none_mtls_base_master': mem_ingressgw_none_mtls_base_master,
                           'mem_ingressgw_none_mtls_both_master': mem_ingressgw_none_mtls_both_master,
                           'mem_ingressgw_none_plaintext_both_master': mem_ingressgw_none_plaintext_both_master,
@@ -699,6 +827,16 @@ def get_lantency_vs_conn_context(df):
     latency_v2_sd_nologging_nullvm_both_p50 = get_latency_vs_conn_y_series(df, '_v2-sd-nologging-nullvm_both', 'p50')
     latency_v2_sd_full_nullvm_both_p50 = get_latency_vs_conn_y_series(df, '_v2-sd-full-nullvm_both', 'p50')
 
+    latency_none_security_authz_ip_both_p50 = get_latency_vs_conn_y_series(df, '_none_security_authz_ip_both',
+                                                                           'p50')
+    latency_none_security_authz_path_both_p50 = get_latency_vs_conn_y_series(df,
+                                                                             '_none_security_authz_path_both',
+                                                                             'p50')
+    latency_none_security_authz_jwt_both_p50 = get_latency_vs_conn_y_series(df, '_none_security_authz_jwt_both',
+                                                                            'p50')
+    latency_none_security_peer_authn_both_p50 = get_latency_vs_conn_y_series(df,
+                                                                             '_none_security_peer_authn_both',
+                                                                             'p50')
     latency_none_mtls_base_p90 = get_latency_vs_conn_y_series(df, '_none_mtls_baseline', 'p90')
     latency_none_mtls_both_p90 = get_latency_vs_conn_y_series(df, '_none_mtls_both', 'p90')
     latency_none_plaintext_both_p90 = get_latency_vs_conn_y_series(df, '_none_plaintext_both', 'p90')
@@ -706,6 +844,16 @@ def get_lantency_vs_conn_context(df):
     latency_v2_stats_wasm_both_p90 = get_latency_vs_conn_y_series(df, '_v2-stats-wasm_both', 'p90')
     latency_v2_sd_nologging_nullvm_both_p90 = get_latency_vs_conn_y_series(df, '_v2-sd-nologging-nullvm_both', 'p90')
     latency_v2_sd_full_nullvm_both_p90 = get_latency_vs_conn_y_series(df, '_v2-sd-full-nullvm_both', 'p90')
+    latency_none_security_authz_ip_both_p90 = get_latency_vs_conn_y_series(df, '_none_security_authz_ip_both',
+                                                                           'p90')
+    latency_none_security_authz_path_both_p90 = get_latency_vs_conn_y_series(df,
+                                                                             '_none_security_authz_path_both',
+                                                                             'p90')
+    latency_none_security_authz_jwt_both_p90 = get_latency_vs_conn_y_series(df, '_none_security_authz_jwt_both',
+                                                                            'p90')
+    latency_none_security_peer_authn_both_p90 = get_latency_vs_conn_y_series(df,
+                                                                             '_none_security_peer_authn_both',
+                                                                             'p90')
 
     latency_none_mtls_base_p99 = get_latency_vs_conn_y_series(df, '_none_mtls_baseline', 'p99')
     latency_none_mtls_both_p99 = get_latency_vs_conn_y_series(df, '_none_mtls_both', 'p99')
@@ -714,6 +862,16 @@ def get_lantency_vs_conn_context(df):
     latency_v2_stats_wasm_both_p99 = get_latency_vs_conn_y_series(df, '_v2-stats-wasm_both', 'p99')
     latency_v2_sd_nologging_nullvm_both_p99 = get_latency_vs_conn_y_series(df, '_v2-sd-nologging-nullvm_both', 'p99')
     latency_v2_sd_full_nullvm_both_p99 = get_latency_vs_conn_y_series(df, '_v2-sd-full-nullvm_both', 'p99')
+    latency_none_security_authz_ip_both_p99 = get_latency_vs_conn_y_series(df, '_none_security_authz_ip_both',
+                                                                           'p99')
+    latency_none_security_authz_path_both_p99 = get_latency_vs_conn_y_series(df,
+                                                                             '_none_security_authz_path_both',
+                                                                             'p99')
+    latency_none_security_authz_jwt_both_p99 = get_latency_vs_conn_y_series(df, '_none_security_authz_jwt_both',
+                                                                            'p99')
+    latency_none_security_peer_authn_both_p99 = get_latency_vs_conn_y_series(df,
+                                                                             '_none_security_peer_authn_both',
+                                                                             'p99')
 
     latency_none_mtls_base_p999 = get_latency_vs_conn_y_series(df, '_none_mtls_baseline', 'p999')
     latency_none_mtls_both_p999 = get_latency_vs_conn_y_series(df, '_none_mtls_both', 'p999')
@@ -722,6 +880,16 @@ def get_lantency_vs_conn_context(df):
     latency_v2_stats_wasm_both_p999 = get_latency_vs_conn_y_series(df, '_v2-stats-wasm_both', 'p999')
     latency_v2_sd_nologging_nullvm_both_p999 = get_latency_vs_conn_y_series(df, '_v2-sd-nologging-nullvm_both', 'p999')
     latency_v2_sd_full_nullvm_both_p999 = get_latency_vs_conn_y_series(df, '_v2-sd-full-nullvm_both', 'p999')
+    latency_none_security_authz_ip_both_p999 = get_latency_vs_conn_y_series(df, '_none_security_authz_ip_both',
+                                                                            'p999')
+    latency_none_security_authz_path_both_p999 = get_latency_vs_conn_y_series(df,
+                                                                              '_none_security_authz_path_both',
+                                                                              'p999')
+    latency_none_security_authz_jwt_both_p999 = get_latency_vs_conn_y_series(df, '_none_security_authz_jwt_both',
+                                                                             'p999')
+    latency_none_security_peer_authn_both_p999 = get_latency_vs_conn_y_series(df,
+                                                                              '_none_security_peer_authn_both',
+                                                                              'p999')
 
     context = {'latency_none_mtls_base_p50': latency_none_mtls_base_p50,
                'latency_none_mtls_both_p50': latency_none_mtls_both_p50,
@@ -730,6 +898,10 @@ def get_lantency_vs_conn_context(df):
                'latency_v2_stats_wasm_both_p50': latency_v2_stats_wasm_both_p50,
                'latency_v2_sd_nologging_nullvm_both_p50': latency_v2_sd_nologging_nullvm_both_p50,
                'latency_v2_sd_full_nullvm_both_p50': latency_v2_sd_full_nullvm_both_p50,
+               'latency_none_security_authz_ip_both_p50': latency_none_security_authz_ip_both_p50,
+               'latency_none_security_authz_path_both_p50': latency_none_security_authz_path_both_p50,
+               'latency_none_security_authz_jwt_both_p50': latency_none_security_authz_jwt_both_p50,
+               'latency_none_security_peer_authn_both_p50': latency_none_security_peer_authn_both_p50,
                'latency_none_mtls_base_p90': latency_none_mtls_base_p90,
                'latency_none_mtls_both_p90': latency_none_mtls_both_p90,
                'latency_none_plaintext_both_p90': latency_none_plaintext_both_p90,
@@ -737,6 +909,10 @@ def get_lantency_vs_conn_context(df):
                'latency_v2_stats_wasm_both_p90': latency_v2_stats_wasm_both_p90,
                'latency_v2_sd_nologging_nullvm_both_p90': latency_v2_sd_nologging_nullvm_both_p90,
                'latency_v2_sd_full_nullvm_both_p90': latency_v2_sd_full_nullvm_both_p90,
+               'latency_none_security_authz_ip_both_p90': latency_none_security_authz_ip_both_p90,
+               'latency_none_security_authz_path_both_p90': latency_none_security_authz_path_both_p90,
+               'latency_none_security_authz_jwt_both_p90': latency_none_security_authz_jwt_both_p90,
+               'latency_none_security_peer_authn_both_p90': latency_none_security_peer_authn_both_p90,
                'latency_none_mtls_base_p99': latency_none_mtls_base_p99,
                'latency_none_mtls_both_p99': latency_none_mtls_both_p99,
                'latency_none_plaintext_both_p99': latency_none_plaintext_both_p99,
@@ -744,6 +920,10 @@ def get_lantency_vs_conn_context(df):
                'latency_v2_stats_wasm_both_p99': latency_v2_stats_wasm_both_p99,
                'latency_v2_sd_nologging_nullvm_both_p99': latency_v2_sd_nologging_nullvm_both_p99,
                'latency_v2_sd_full_nullvm_both_p99': latency_v2_sd_full_nullvm_both_p99,
+               'latency_none_security_authz_ip_both_p99': latency_none_security_authz_ip_both_p99,
+               'latency_none_security_authz_path_both_p99': latency_none_security_authz_path_both_p99,
+               'latency_none_security_authz_jwt_both_p99': latency_none_security_authz_jwt_both_p99,
+               'latency_none_security_peer_authn_both_p99': latency_none_security_peer_authn_both_p99,
                'latency_none_mtls_base_p999': latency_none_mtls_base_p999,
                'latency_none_mtls_both_p999': latency_none_mtls_both_p999,
                'latency_none_plaintext_both_p999': latency_none_plaintext_both_p999,
@@ -751,6 +931,11 @@ def get_lantency_vs_conn_context(df):
                'latency_v2_stats_wasm_both_p999': latency_v2_stats_wasm_both_p999,
                'latency_v2_sd_nologging_nullvm_both_p999': latency_v2_sd_nologging_nullvm_both_p999,
                'latency_v2_sd_full_nullvm_both_p999': latency_v2_sd_full_nullvm_both_p999,
+               'latency_none_security_authz_ip_both_p999': latency_none_security_authz_ip_both_p999,
+               'latency_none_security_authz_path_both_p999': latency_none_security_authz_path_both_p999,
+               'latency_none_security_authz_jwt_both_p999': latency_none_security_authz_jwt_both_p999,
+               'latency_none_security_peer_authn_both_p999': latency_none_security_peer_authn_both_p999,
+
                }
     return context
 
@@ -763,6 +948,14 @@ def get_lantency_vs_qps_context(df):
     latency_v2_stats_wasm_both_p50 = get_latency_vs_qps_y_series(df, '_v2-stats-wasm_both', 'p50')
     latency_v2_sd_nologging_nullvm_both_p50 = get_latency_vs_qps_y_series(df, '_v2-sd-nologging-nullvm_both', 'p50')
     latency_v2_sd_full_nullvm_both_p50 = get_latency_vs_qps_y_series(df, '_v2-sd-full-nullvm_both', 'p50')
+    latency_none_security_authz_ip_both_p50 = get_latency_vs_qps_y_series(df, '_none_security_authz_ip_both',
+                                                                          'p50')
+    latency_none_security_authz_path_both_p50 = get_latency_vs_qps_y_series(df, '_none_security_authz_path_both',
+                                                                            'p50')
+    latency_none_security_authz_jwt_both_p50 = get_latency_vs_qps_y_series(df, '_none_security_authz_jwt_both',
+                                                                           'p50')
+    latency_none_security_peer_authn_both_p50 = get_latency_vs_qps_y_series(df, '_none_security_peer_authn_both',
+                                                                            'p50')
 
     latency_none_mtls_base_p90 = get_latency_vs_qps_y_series(df, '_none_mtls_baseline', 'p90')
     latency_none_mtls_both_p90 = get_latency_vs_qps_y_series(df, '_none_mtls_both', 'p90')
@@ -771,6 +964,14 @@ def get_lantency_vs_qps_context(df):
     latency_v2_stats_wasm_both_p90 = get_latency_vs_qps_y_series(df, '_v2-stats-wasm_both', 'p90')
     latency_v2_sd_nologging_nullvm_both_p90 = get_latency_vs_qps_y_series(df, '_v2-sd-nologging-nullvm_both', 'p90')
     latency_v2_sd_full_nullvm_both_p90 = get_latency_vs_qps_y_series(df, '_v2-sd-full-nullvm_both', 'p90')
+    latency_none_security_authz_ip_both_p90 = get_latency_vs_qps_y_series(df, '_none_security_authz_ip_both',
+                                                                          'p90')
+    latency_none_security_authz_path_both_p90 = get_latency_vs_qps_y_series(df, '_none_security_authz_path_both',
+                                                                            'p90')
+    latency_none_security_authz_jwt_both_p90 = get_latency_vs_qps_y_series(df, '_none_security_authz_jwt_both',
+                                                                           'p90')
+    latency_none_security_peer_authn_both_p90 = get_latency_vs_qps_y_series(df, '_none_security_peer_authn_both',
+                                                                            'p90')
 
     latency_none_mtls_base_p99 = get_latency_vs_qps_y_series(df, '_none_mtls_baseline', 'p99')
     latency_none_mtls_both_p99 = get_latency_vs_qps_y_series(df, '_none_mtls_both', 'p99')
@@ -779,6 +980,14 @@ def get_lantency_vs_qps_context(df):
     latency_v2_stats_wasm_both_p99 = get_latency_vs_qps_y_series(df, '_v2-stats-wasm_both', 'p99')
     latency_v2_sd_nologging_nullvm_both_p99 = get_latency_vs_qps_y_series(df, '_v2-sd-nologging-nullvm_both', 'p99')
     latency_v2_sd_full_nullvm_both_p99 = get_latency_vs_qps_y_series(df, '_v2-sd-full-nullvm_both', 'p99')
+    latency_none_security_authz_ip_both_p99 = get_latency_vs_qps_y_series(df, '_none_security_authz_ip_both',
+                                                                          'p99')
+    latency_none_security_authz_path_both_p99 = get_latency_vs_qps_y_series(df, '_none_security_authz_path_both',
+                                                                            'p99')
+    latency_none_security_authz_jwt_both_p99 = get_latency_vs_qps_y_series(df, '_none_security_authz_jwt_both',
+                                                                           'p99')
+    latency_none_security_peer_authn_both_p99 = get_latency_vs_qps_y_series(df, '_none_security_peer_authn_both',
+                                                                            'p99')
 
     latency_none_mtls_base_p999 = get_latency_vs_qps_y_series(df, '_none_mtls_baseline', 'p999')
     latency_none_mtls_both_p999 = get_latency_vs_qps_y_series(df, '_none_mtls_both', 'p999')
@@ -787,6 +996,16 @@ def get_lantency_vs_qps_context(df):
     latency_v2_stats_wasm_both_p999 = get_latency_vs_qps_y_series(df, '_v2-stats-wasm_both', 'p999')
     latency_v2_sd_nologging_nullvm_both_p999 = get_latency_vs_qps_y_series(df, '_v2-sd-nologging-nullvm_both', 'p999')
     latency_v2_sd_full_nullvm_both_p999 = get_latency_vs_qps_y_series(df, '_v2-sd-full-nullvm_both', 'p999')
+    latency_none_security_authz_ip_both_p999 = get_latency_vs_qps_y_series(df, '_none_security_authz_ip_both',
+                                                                           'p999')
+    latency_none_security_authz_path_both_p999 = get_latency_vs_qps_y_series(df,
+                                                                             '_none_security_authz_path_both',
+                                                                             'p999')
+    latency_none_security_authz_jwt_both_p999 = get_latency_vs_qps_y_series(df, '_none_security_authz_jwt_both',
+                                                                            'p999')
+    latency_none_security_peer_authn_both_p999 = get_latency_vs_qps_y_series(df,
+                                                                             '_none_security_peer_authn_both',
+                                                                             'p999')
 
     context = {'latency_none_mtls_base_p50': latency_none_mtls_base_p50,
                'latency_none_mtls_both_p50': latency_none_mtls_both_p50,
@@ -795,6 +1014,10 @@ def get_lantency_vs_qps_context(df):
                'latency_v2_stats_wasm_both_p50': latency_v2_stats_wasm_both_p50,
                'latency_v2_sd_nologging_nullvm_both_p50': latency_v2_sd_nologging_nullvm_both_p50,
                'latency_v2_sd_full_nullvm_both_p50': latency_v2_sd_full_nullvm_both_p50,
+               'latency_none_security_authz_ip_both_p50': latency_none_security_authz_ip_both_p50,
+               'latency_none_security_authz_path_both_p50': latency_none_security_authz_path_both_p50,
+               'latency_none_security_authz_jwt_both_p50': latency_none_security_authz_jwt_both_p50,
+               'latency_none_security_peer_authn_both_p50': latency_none_security_peer_authn_both_p50,
                'latency_none_mtls_base_p90': latency_none_mtls_base_p90,
                'latency_none_mtls_both_p90': latency_none_mtls_both_p90,
                'latency_none_plaintext_both_p90': latency_none_plaintext_both_p90,
@@ -802,6 +1025,10 @@ def get_lantency_vs_qps_context(df):
                'latency_v2_stats_wasm_both_p90': latency_v2_stats_wasm_both_p90,
                'latency_v2_sd_nologging_nullvm_both_p90': latency_v2_sd_nologging_nullvm_both_p90,
                'latency_v2_sd_full_nullvm_both_p90': latency_v2_sd_full_nullvm_both_p90,
+               'latency_none_security_authz_ip_both_p90': latency_none_security_authz_ip_both_p90,
+               'latency_none_security_authz_path_both_p90': latency_none_security_authz_path_both_p90,
+               'latency_none_security_authz_jwt_both_p90': latency_none_security_authz_jwt_both_p90,
+               'latency_none_security_peer_authn_both_p90': latency_none_security_peer_authn_both_p90,
                'latency_none_mtls_base_p99': latency_none_mtls_base_p99,
                'latency_none_mtls_both_p99': latency_none_mtls_both_p99,
                'latency_none_plaintext_both_p99': latency_none_plaintext_both_p99,
@@ -809,6 +1036,10 @@ def get_lantency_vs_qps_context(df):
                'latency_v2_stats_wasm_both_p99': latency_v2_stats_wasm_both_p99,
                'latency_v2_sd_nologging_nullvm_both_p99': latency_v2_sd_nologging_nullvm_both_p99,
                'latency_v2_sd_full_nullvm_both_p99': latency_v2_sd_full_nullvm_both_p99,
+               'latency_none_security_authz_ip_both_p99': latency_none_security_authz_ip_both_p99,
+               'latency_none_security_authz_path_both_p99': latency_none_security_authz_path_both_p99,
+               'latency_none_security_authz_jwt_both_p99': latency_none_security_authz_jwt_both_p99,
+               'latency_none_security_peer_authn_both_p99': latency_none_security_peer_authn_both_p99,
                'latency_none_mtls_base_p999': latency_none_mtls_base_p999,
                'latency_none_mtls_both_p999': latency_none_mtls_both_p999,
                'latency_none_plaintext_both_p999': latency_none_plaintext_both_p999,
@@ -816,6 +1047,10 @@ def get_lantency_vs_qps_context(df):
                'latency_v2_stats_wasm_both_p999': latency_v2_stats_wasm_both_p999,
                'latency_v2_sd_nologging_nullvm_both_p999': latency_v2_sd_nologging_nullvm_both_p999,
                'latency_v2_sd_full_nullvm_both_p999': latency_v2_sd_full_nullvm_both_p999,
+               'latency_none_security_authz_ip_both_p999': latency_none_security_authz_ip_both_p999,
+               'latency_none_security_authz_path_both_p999': latency_none_security_authz_path_both_p999,
+               'latency_none_security_authz_jwt_both_p999': latency_none_security_authz_jwt_both_p999,
+               'latency_none_security_peer_authn_both_p999': latency_none_security_peer_authn_both_p999,
                }
     return context
 
@@ -828,6 +1063,14 @@ def get_cpu_vs_qps_context(df):
     cpu_client_v2_stats_wasm_both = get_cpu_vs_qps_y_series(df, '_v2-stats-wasm_both', cpu_client_metric_name)
     cpu_client_v2_sd_nologging_nullvm_both = get_cpu_vs_qps_y_series(df, '_v2-sd-nologging-nullvm_both', cpu_client_metric_name)
     cpu_client_v2_sd_full_nullvm_both = get_cpu_vs_qps_y_series(df, '_v2-sd-full-nullvm_both', cpu_client_metric_name)
+    cpu_client_none_security_authz_ip_both = get_cpu_vs_qps_y_series(df, '_none_security_authz_ip_both',
+                                                                     cpu_client_metric_name)
+    cpu_client_none_security_authz_path_both = get_cpu_vs_qps_y_series(df, '_none_security_authz_path_both',
+                                                                       cpu_client_metric_name)
+    cpu_client_none_security_authz_jwt_both = get_cpu_vs_qps_y_series(df, '_none_security_authz_jwt_both',
+                                                                      cpu_client_metric_name)
+    cpu_client_none_security_peer_authn_both = get_cpu_vs_qps_y_series(df, '_none_security_peer_authn_both',
+                                                                       cpu_client_metric_name)
 
     cpu_server_none_mtls_base = get_cpu_vs_qps_y_series(df, '_none_mtls_baseline', cpu_server_metric_name)
     cpu_server_none_mtls_both = get_cpu_vs_qps_y_series(df, '_none_mtls_both', cpu_server_metric_name)
@@ -836,6 +1079,14 @@ def get_cpu_vs_qps_context(df):
     cpu_server_v2_stats_wasm_both = get_cpu_vs_qps_y_series(df, '_v2-stats-wasm_both', cpu_server_metric_name)
     cpu_server_v2_sd_nologging_nullvm_both = get_cpu_vs_qps_y_series(df, '_v2-sd-nologging-nullvm_both', cpu_server_metric_name)
     cpu_server_v2_sd_full_nullvm_both = get_cpu_vs_qps_y_series(df, '_v2-sd-full-nullvm_both', cpu_server_metric_name)
+    cpu_server_none_security_authz_ip_both = get_cpu_vs_qps_y_series(df, '_none_security_authz_ip_both',
+                                                                     cpu_server_metric_name)
+    cpu_server_none_security_authz_path_both = get_cpu_vs_qps_y_series(df, '_none_security_authz_path_both',
+                                                                       cpu_server_metric_name)
+    cpu_server_none_security_authz_jwt_both = get_cpu_vs_qps_y_series(df, '_none_security_authz_jwt_both',
+                                                                      cpu_server_metric_name)
+    cpu_server_none_security_peer_authn_both = get_cpu_vs_qps_y_series(df, '_none_security_peer_authn_both',
+                                                                       cpu_server_metric_name)
 
     cpu_ingressgw_none_mtls_base = get_cpu_vs_qps_y_series(df, '_none_mtls_baseline', cpu_ingressgw_metric_name)
     cpu_ingressgw_none_mtls_both = get_cpu_vs_qps_y_series(df, '_none_mtls_both', cpu_ingressgw_metric_name)
@@ -852,6 +1103,10 @@ def get_cpu_vs_qps_context(df):
                'cpu_client_v2_stats_wasm_both': cpu_client_v2_stats_wasm_both,
                'cpu_client_v2_sd_nologging_nullvm_both': cpu_client_v2_sd_nologging_nullvm_both,
                'cpu_client_v2_sd_full_nullvm_both': cpu_client_v2_sd_full_nullvm_both,
+               'cpu_client_none_security_authz_ip_both': cpu_client_none_security_authz_ip_both,
+               'cpu_client_none_security_authz_path_both': cpu_client_none_security_authz_path_both,
+               'cpu_client_none_security_authz_jwt_both': cpu_client_none_security_authz_jwt_both,
+               'cpu_client_none_security_peer_authn_both': cpu_client_none_security_peer_authn_both,
                'cpu_server_none_mtls_base': cpu_server_none_mtls_base,
                'cpu_server_none_mtls_both': cpu_server_none_mtls_both,
                'cpu_server_none_plaintext_both': cpu_server_none_plaintext_both,
@@ -859,6 +1114,10 @@ def get_cpu_vs_qps_context(df):
                'cpu_server_v2_stats_wasm_both': cpu_server_v2_stats_wasm_both,
                'cpu_server_v2_sd_nologging_nullvm_both': cpu_server_v2_sd_nologging_nullvm_both,
                'cpu_server_v2_sd_full_nullvm_both': cpu_server_v2_sd_full_nullvm_both,
+               'cpu_server_none_security_authz_ip_both': cpu_server_none_security_authz_ip_both,
+               'cpu_server_none_security_authz_path_both': cpu_server_none_security_authz_path_both,
+               'cpu_server_none_security_authz_jwt_both': cpu_server_none_security_authz_jwt_both,
+               'cpu_server_none_security_peer_authn_both': cpu_server_none_security_peer_authn_both,
                'cpu_ingressgw_none_mtls_base': cpu_ingressgw_none_mtls_base,
                'cpu_ingressgw_none_mtls_both': cpu_ingressgw_none_mtls_both,
                'cpu_ingressgw_none_plaintext_both': cpu_ingressgw_none_plaintext_both,
@@ -878,6 +1137,14 @@ def get_cpu_vs_conn_context(df):
     cpu_client_v2_stats_wasm_both = get_cpu_vs_conn_y_series(df, '_v2-stats-wasm_both', cpu_client_metric_name)
     cpu_client_v2_sd_nologging_nullvm_both = get_cpu_vs_conn_y_series(df, '_v2-sd-nologging-nullvm_both', cpu_client_metric_name)
     cpu_client_v2_sd_full_nullvm_both = get_cpu_vs_conn_y_series(df, '_v2-sd-full-nullvm_both', cpu_client_metric_name)
+    cpu_client_none_security_authz_ip_both = get_cpu_vs_conn_y_series(df, '_none_security_authz_ip_both',
+                                                                      cpu_client_metric_name)
+    cpu_client_none_security_authz_path_both = get_cpu_vs_conn_y_series(df, '_none_security_authz_path_both',
+                                                                        cpu_client_metric_name)
+    cpu_client_none_security_authz_jwt_both = get_cpu_vs_conn_y_series(df, '_none_security_authz_jwt_both',
+                                                                       cpu_client_metric_name)
+    cpu_client_none_security_peer_authn_both = get_cpu_vs_conn_y_series(df, '_none_security_peer_authn_both',
+                                                                        cpu_client_metric_name)
 
     cpu_server_none_mtls_base = get_cpu_vs_conn_y_series(df, '_none_mtls_baseline', cpu_server_metric_name)
     cpu_server_none_mtls_both = get_cpu_vs_conn_y_series(df, '_none_mtls_both', cpu_server_metric_name)
@@ -886,6 +1153,14 @@ def get_cpu_vs_conn_context(df):
     cpu_server_v2_stats_wasm_both = get_cpu_vs_conn_y_series(df, '_v2-stats-wasm_both', cpu_server_metric_name)
     cpu_server_v2_sd_nologging_nullvm_both = get_cpu_vs_conn_y_series(df, '_v2-sd-nologging-nullvm_both', cpu_server_metric_name)
     cpu_server_v2_sd_full_nullvm_both = get_cpu_vs_conn_y_series(df, '_v2-sd-full-nullvm_both', cpu_server_metric_name)
+    cpu_server_none_security_authz_ip_both = get_cpu_vs_conn_y_series(df, '_none_security_authz_ip_both',
+                                                                      cpu_server_metric_name)
+    cpu_server_none_security_authz_path_both = get_cpu_vs_conn_y_series(df, '_none_security_authz_path_both',
+                                                                        cpu_server_metric_name)
+    cpu_server_none_security_authz_jwt_both = get_cpu_vs_conn_y_series(df, '_none_security_authz_jwt_both',
+                                                                       cpu_server_metric_name)
+    cpu_server_none_security_peer_authn_both = get_cpu_vs_conn_y_series(df, '_none_security_peer_authn_both',
+                                                                        cpu_server_metric_name)
 
     cpu_ingressgw_none_mtls_base = get_cpu_vs_conn_y_series(df, '_none_mtls_baseline', cpu_ingressgw_metric_name)
     cpu_ingressgw_none_mtls_both = get_cpu_vs_conn_y_series(df, '_none_mtls_both', cpu_ingressgw_metric_name)
@@ -902,6 +1177,10 @@ def get_cpu_vs_conn_context(df):
                'cpu_client_v2_stats_wasm_both': cpu_client_v2_stats_wasm_both,
                'cpu_client_v2_sd_nologging_nullvm_both': cpu_client_v2_sd_nologging_nullvm_both,
                'cpu_client_v2_sd_full_nullvm_both': cpu_client_v2_sd_full_nullvm_both,
+               'cpu_client_none_security_authz_ip_both': cpu_client_none_security_authz_ip_both,
+               'cpu_client_none_security_authz_path_both': cpu_client_none_security_authz_path_both,
+               'cpu_client_none_security_authz_jwt_both': cpu_client_none_security_authz_jwt_both,
+               'cpu_client_none_security_peer_authn_both': cpu_client_none_security_peer_authn_both,
                'cpu_server_none_mtls_base': cpu_server_none_mtls_base,
                'cpu_server_none_mtls_both': cpu_server_none_mtls_both,
                'cpu_server_none_plaintext_both': cpu_server_none_plaintext_both,
@@ -909,6 +1188,10 @@ def get_cpu_vs_conn_context(df):
                'cpu_server_v2_stats_wasm_both': cpu_server_v2_stats_wasm_both,
                'cpu_server_v2_sd_nologging_nullvm_both': cpu_server_v2_sd_nologging_nullvm_both,
                'cpu_server_v2_sd_full_nullvm_both': cpu_server_v2_sd_full_nullvm_both,
+               'cpu_server_none_security_authz_ip_both': cpu_server_none_security_authz_ip_both,
+               'cpu_server_none_security_authz_path_both': cpu_server_none_security_authz_path_both,
+               'cpu_server_none_security_authz_jwt_both': cpu_server_none_security_authz_jwt_both,
+               'cpu_server_none_security_peer_authn_both': cpu_server_none_security_peer_authn_both,
                'cpu_ingressgw_none_mtls_base': cpu_ingressgw_none_mtls_base,
                'cpu_ingressgw_none_mtls_both': cpu_ingressgw_none_mtls_both,
                'cpu_ingressgw_none_plaintext_both': cpu_ingressgw_none_plaintext_both,
@@ -928,6 +1211,14 @@ def get_mem_vs_qps_context(df):
     mem_client_v2_stats_wasm_both = get_mem_vs_qps_y_series(df, '_v2-stats-wasm_both', mem_client_metric_name)
     mem_client_v2_sd_nologging_nullvm_both = get_mem_vs_qps_y_series(df, '_v2-sd-nologging-nullvm_both', mem_client_metric_name)
     mem_client_v2_sd_full_nullvm_both = get_mem_vs_qps_y_series(df, '_v2-sd-full-nullvm_both', mem_client_metric_name)
+    mem_client_none_security_authz_ip_both = get_mem_vs_qps_y_series(df, '_none_security_authz_ip_both',
+                                                                     mem_client_metric_name)
+    mem_client_none_security_authz_path_both = get_mem_vs_qps_y_series(df, '_none_security_authz_path_both',
+                                                                       mem_client_metric_name)
+    mem_client_none_security_authz_jwt_both = get_mem_vs_qps_y_series(df, '_none_security_authz_jwt_both',
+                                                                      mem_client_metric_name)
+    mem_client_none_security_peer_authn_both = get_mem_vs_qps_y_series(df, '_none_security_peer_authn_both',
+                                                                       mem_client_metric_name)
 
     mem_server_none_mtls_base = get_mem_vs_qps_y_series(df, '_none_mtls_baseline', mem_server_metric_name)
     mem_server_none_mtls_both = get_mem_vs_qps_y_series(df, '_none_mtls_both', mem_server_metric_name)
@@ -936,6 +1227,14 @@ def get_mem_vs_qps_context(df):
     mem_server_v2_stats_wasm_both = get_mem_vs_qps_y_series(df, '_v2-stats-wasm_both', mem_server_metric_name)
     mem_server_v2_sd_nologging_nullvm_both = get_mem_vs_qps_y_series(df, '_v2-sd-nologging-nullvm_both', mem_server_metric_name)
     mem_server_v2_sd_full_nullvm_both = get_mem_vs_qps_y_series(df, '_v2-sd-full-nullvm_both', mem_server_metric_name)
+    mem_server_none_security_authz_ip_both = get_mem_vs_qps_y_series(df, '_none_security_authz_ip_both',
+                                                                     mem_server_metric_name)
+    mem_server_none_security_authz_path_both = get_mem_vs_qps_y_series(df, '_none_security_authz_path_both',
+                                                                       mem_server_metric_name)
+    mem_server_none_security_authz_jwt_both = get_mem_vs_qps_y_series(df, '_none_security_authz_jwt_both',
+                                                                      mem_server_metric_name)
+    mem_server_none_security_peer_authn_both = get_mem_vs_qps_y_series(df, '_none_security_peer_authn_both',
+                                                                       mem_server_metric_name)
 
     mem_ingressgw_none_mtls_base = get_mem_vs_qps_y_series(df, '_none_mtls_baseline', mem_ingressgw_metric_name)
     mem_ingressgw_none_mtls_both = get_mem_vs_qps_y_series(df, '_none_mtls_both', mem_ingressgw_metric_name)
@@ -952,6 +1251,10 @@ def get_mem_vs_qps_context(df):
                'mem_client_v2_stats_wasm_both': mem_client_v2_stats_wasm_both,
                'mem_client_v2_sd_nologging_nullvm_both': mem_client_v2_sd_nologging_nullvm_both,
                'mem_client_v2_sd_full_nullvm_both': mem_client_v2_sd_full_nullvm_both,
+               'mem_client_none_security_authz_ip_both': mem_client_none_security_authz_ip_both,
+               'mem_client_none_security_authz_path_both': mem_client_none_security_authz_path_both,
+               'mem_client_none_security_authz_jwt_both': mem_client_none_security_authz_jwt_both,
+               'mem_client_none_security_peer_authn_both': mem_client_none_security_peer_authn_both,
                'mem_server_none_mtls_base': mem_server_none_mtls_base,
                'mem_server_none_mtls_both': mem_server_none_mtls_both,
                'mem_server_none_plaintext_both': mem_server_none_plaintext_both,
@@ -959,6 +1262,10 @@ def get_mem_vs_qps_context(df):
                'mem_server_v2_stats_wasm_both': mem_server_v2_stats_wasm_both,
                'mem_server_v2_sd_nologging_nullvm_both': mem_server_v2_sd_nologging_nullvm_both,
                'mem_server_v2_sd_full_nullvm_both': mem_server_v2_sd_full_nullvm_both,
+               'mem_server_none_security_authz_ip_both': mem_server_none_security_authz_ip_both,
+               'mem_server_none_security_authz_path_both': mem_server_none_security_authz_path_both,
+               'mem_server_none_security_authz_jwt_both': mem_server_none_security_authz_jwt_both,
+               'mem_server_none_security_peer_authn_both': mem_server_none_security_peer_authn_both,
                'mem_ingressgw_none_mtls_base': mem_ingressgw_none_mtls_base,
                'mem_ingressgw_none_mtls_both': mem_ingressgw_none_mtls_both,
                'mem_ingressgw_none_plaintext_both': mem_ingressgw_none_plaintext_both,
@@ -978,6 +1285,14 @@ def get_mem_vs_conn_context(df):
     mem_client_v2_stats_wasm_both = get_mem_vs_conn_y_series(df, '_v2-stats-wasm_both', mem_client_metric_name)
     mem_client_v2_sd_nologging_nullvm_both = get_mem_vs_conn_y_series(df, '_v2-sd-nologging-nullvm_both', mem_client_metric_name)
     mem_client_v2_sd_full_nullvm_both = get_mem_vs_conn_y_series(df, '_v2-sd-full-nullvm_both', mem_client_metric_name)
+    mem_client_none_security_authz_ip_both = get_mem_vs_conn_y_series(df, '_none_security_authz_ip_both',
+                                                                      mem_client_metric_name)
+    mem_client_none_security_authz_path_both = get_mem_vs_conn_y_series(df, '_none_security_authz_path_both',
+                                                                        mem_client_metric_name)
+    mem_client_none_security_authz_jwt_both = get_mem_vs_conn_y_series(df, '_none_security_authz_jwt_both',
+                                                                       mem_client_metric_name)
+    mem_client_none_security_peer_authn_both = get_mem_vs_conn_y_series(df, '_none_security_peer_authn_both',
+                                                                        mem_client_metric_name)
 
     mem_server_none_mtls_base = get_mem_vs_conn_y_series(df, '_none_mtls_baseline', mem_server_metric_name)
     mem_server_none_mtls_both = get_mem_vs_conn_y_series(df, '_none_mtls_both', mem_server_metric_name)
@@ -986,6 +1301,14 @@ def get_mem_vs_conn_context(df):
     mem_server_v2_stats_wasm_both = get_mem_vs_conn_y_series(df, '_v2-stats-wasm_both', mem_server_metric_name)
     mem_server_v2_sd_nologging_nullvm_both = get_mem_vs_conn_y_series(df, '_v2-sd-nologging-nullvm_both', mem_server_metric_name)
     mem_server_v2_sd_full_nullvm_both = get_mem_vs_conn_y_series(df, '_v2-sd-full-nullvm_both', mem_server_metric_name)
+    mem_server_none_security_authz_ip_both = get_mem_vs_conn_y_series(df, '_none_security_authz_ip_both',
+                                                                      mem_server_metric_name)
+    mem_server_none_security_authz_path_both = get_mem_vs_conn_y_series(df, '_none_security_authz_path_both',
+                                                                        mem_server_metric_name)
+    mem_server_none_security_authz_jwt_both = get_mem_vs_conn_y_series(df, '_none_security_authz_jwt_both',
+                                                                       mem_server_metric_name)
+    mem_server_none_security_peer_authn_both = get_mem_vs_conn_y_series(df, '_none_security_peer_authn_both',
+                                                                        mem_server_metric_name)
 
     mem_ingressgw_none_mtls_base = get_mem_vs_conn_y_series(df, '_none_mtls_baseline', mem_ingressgw_metric_name)
     mem_ingressgw_none_mtls_both = get_mem_vs_conn_y_series(df, '_none_mtls_both', mem_ingressgw_metric_name)
@@ -1002,6 +1325,10 @@ def get_mem_vs_conn_context(df):
                'mem_client_v2_stats_wasm_both': mem_client_v2_stats_wasm_both,
                'mem_client_v2_sd_nologging_nullvm_both': mem_client_v2_sd_nologging_nullvm_both,
                'mem_client_v2_sd_full_nullvm_both': mem_client_v2_sd_full_nullvm_both,
+               'mem_client_none_security_authz_ip_both': mem_client_none_security_authz_ip_both,
+               'mem_client_none_security_authz_path_both': mem_client_none_security_authz_path_both,
+               'mem_client_none_security_authz_jwt_both': mem_client_none_security_authz_jwt_both,
+               'mem_client_none_security_peer_authn_both': mem_client_none_security_peer_authn_both,
                'mem_server_none_mtls_base': mem_server_none_mtls_base,
                'mem_server_none_mtls_both': mem_server_none_mtls_both,
                'mem_server_none_plaintext_both': mem_server_none_plaintext_both,
@@ -1009,6 +1336,10 @@ def get_mem_vs_conn_context(df):
                'mem_server_v2_stats_wasm_both': mem_server_v2_stats_wasm_both,
                'mem_server_v2_sd_nologging_nullvm_both': mem_server_v2_sd_nologging_nullvm_both,
                'mem_server_v2_sd_full_nullvm_both': mem_server_v2_sd_full_nullvm_both,
+               'mem_server_none_security_authz_ip_both': mem_server_none_security_authz_ip_both,
+               'mem_server_none_security_authz_path_both': mem_server_none_security_authz_path_both,
+               'mem_server_none_security_authz_jwt_both': mem_server_none_security_authz_jwt_both,
+               'mem_server_none_security_peer_authn_both': mem_server_none_security_peer_authn_both,
                'mem_ingressgw_none_mtls_base': mem_ingressgw_none_mtls_base,
                'mem_ingressgw_none_mtls_both': mem_ingressgw_none_mtls_both,
                'mem_ingressgw_none_plaintext_both': mem_ingressgw_none_plaintext_both,

--- a/perf_dashboard/regressions/templates/cur_regression.html
+++ b/perf_dashboard/regressions/templates/cur_regression.html
@@ -101,6 +101,10 @@
     latency_v2_stats_wasm_both_p90 = {{ latency_v2_stats_wasm_both_p90|safe }}
     latency_v2_sd_nologging_nullvm_both_p90 = {{ latency_v2_sd_nologging_nullvm_both_p90|safe }}
     latency_v2_sd_full_nullvm_both_p90 = {{ latency_v2_sd_full_nullvm_both_p90|safe }}
+    latency_none_security_authz_ip_both_p90 = {{ latency_none_security_authz_ip_both_p90|safe }}
+    latency_none_security_authz_path_both_p90 = {{ latency_none_security_authz_path_both_p90|safe }}
+    latency_none_security_authz_jwt_both_p90 = {{ latency_none_security_authz_jwt_both_p90|safe }}
+    latency_none_security_peer_authn_both_p90 = {{ latency_none_security_peer_authn_both_p90|safe }}
 
     latency_none_mtls_base_p99 = {{ latency_none_mtls_base_p99|safe }}
     latency_none_mtls_both_p99 = {{ latency_none_mtls_both_p99|safe }}
@@ -109,5 +113,9 @@
     latency_v2_stats_wasm_both_p99 = {{ latency_v2_stats_wasm_both_p99|safe }}
     latency_v2_sd_nologging_nullvm_both_p99 = {{ latency_v2_sd_nologging_nullvm_both_p99|safe }}
     latency_v2_sd_full_nullvm_both_p99 = {{ latency_v2_sd_full_nullvm_both_p99|safe }}
+    latency_none_security_authz_ip_both_p99 = {{ latency_none_security_authz_ip_both_p99|safe }}
+    latency_none_security_authz_path_both_p99 = {{ latency_none_security_authz_path_both_p99|safe }}
+    latency_none_security_authz_jwt_both_p99 = {{ latency_none_security_authz_jwt_both_p99|safe }}
+    latency_none_security_peer_authn_both_p99 = {{ latency_none_security_peer_authn_both_p99|safe }}
     </script>
 {% endblock page_data %}

--- a/perf_dashboard/regressions/templates/master_regression.html
+++ b/perf_dashboard/regressions/templates/master_regression.html
@@ -99,6 +99,10 @@
      latency_v2_stats_wasm_both_p90_master = {{ latency_v2_stats_wasm_both_p90_master|safe }}
      latency_v2_sd_nologging_nullvm_both_p90_master = {{ latency_v2_sd_nologging_nullvm_both_p90_master|safe }}
      latency_v2_sd_full_nullvm_both_p90_master = {{ latency_v2_sd_full_nullvm_both_p90_master|safe }}
+     latency_none_security_authz_ip_both_p90_master = {{ latency_none_security_authz_ip_both_p90_master|safe }}
+     latency_none_security_authz_path_both_p90_master = {{ latency_none_security_authz_path_both_p90_master|safe }}
+     latency_none_security_authz_jwt_both_p90_master = {{ latency_none_security_authz_jwt_both_p90_master|safe }}
+     latency_none_security_peer_authn_both_p90_master = {{ latency_none_security_peer_authn_both_p90_master|safe }}
 
      latency_none_mtls_base_p99_master = {{ latency_none_mtls_base_p99_master|safe }}
      latency_none_mtls_both_p99_master = {{ latency_none_mtls_both_p99_master|safe }}
@@ -107,5 +111,9 @@
      latency_v2_stats_wasm_both_p99_master = {{ latency_v2_stats_wasm_both_p99_master|safe }}
      latency_v2_sd_nologging_nullvm_both_p99_master = {{ latency_v2_sd_nologging_nullvm_both_p99_master|safe }}
      latency_v2_sd_full_nullvm_both_p99_master = {{ latency_v2_sd_full_nullvm_both_p99_master|safe }}
+     latency_none_security_authz_ip_both_p99_master = {{ latency_none_security_authz_ip_both_p99_master|safe }}
+     latency_none_security_authz_path_both_p99_master = {{ latency_none_security_authz_path_both_p99_master|safe }}
+     latency_none_security_authz_jwt_both_p99_master = {{ latency_none_security_authz_jwt_both_p99_master|safe }}
+     latency_none_security_peer_authn_both_p99_master = {{ latency_none_security_peer_authn_both_p99_master|safe }}
     </script>
 {% endblock page_data %}

--- a/perf_dashboard/regressions/views.py
+++ b/perf_dashboard/regressions/views.py
@@ -38,6 +38,10 @@ def cur_regression(request):
     latency_v2_stats_wasm_both_p90 = get_telemetry_mode_y_series(cur_href_links, cur_release_dates, '_v2-stats-wasm_both', 'p90')
     latency_v2_sd_nologging_nullvm_both_p90 = get_telemetry_mode_y_series(cur_href_links, cur_release_dates, '_v2-sd-nologging-nullvm_both', 'p90')
     latency_v2_sd_full_nullvm_both_p90 = get_telemetry_mode_y_series(cur_href_links, cur_release_dates, '_v2-sd-full-nullvm_both', 'p90')
+    latency_none_security_authz_ip_both_p90 = get_telemetry_mode_y_series(cur_href_links, cur_release_dates, '_none_security_authz_ip_both', 'p90')
+    latency_none_security_authz_path_both_p90 = get_telemetry_mode_y_series(cur_href_links, cur_release_dates, '_none_security_authz_path_both', 'p90')
+    latency_none_security_authz_jwt_both_p90 = get_telemetry_mode_y_series(cur_href_links, cur_release_dates, '_none_security_authz_jwt_both', 'p90')
+    latency_none_security_peer_authn_both_p90 = get_telemetry_mode_y_series(cur_href_links, cur_release_dates, '_none_security_peer_authn_both', 'p90')
 
     latency_none_mtls_base_p99 = get_telemetry_mode_y_series(cur_href_links, cur_release_dates, '_none_mtls_baseline', 'p99')
     latency_none_mtls_both_p99 = get_telemetry_mode_y_series(cur_href_links, cur_release_dates, '_none_mtls_both', 'p99')
@@ -46,6 +50,10 @@ def cur_regression(request):
     latency_v2_stats_wasm_both_p99 = get_telemetry_mode_y_series(cur_href_links, cur_release_dates, '_v2-stats-wasm_both', 'p99')
     latency_v2_sd_nologging_nullvm_both_p99 = get_telemetry_mode_y_series(cur_href_links, cur_release_dates, '_v2-sd-nologging-nullvm_both', 'p99')
     latency_v2_sd_full_nullvm_both_p99 = get_telemetry_mode_y_series(cur_href_links, cur_release_dates, '_v2-sd-full-nullvm_both', 'p99')
+    latency_none_security_authz_ip_both_p99 = get_telemetry_mode_y_series(cur_href_links, cur_release_dates, '_none_security_authz_ip_both', 'p99')
+    latency_none_security_authz_path_both_p99 = get_telemetry_mode_y_series(cur_href_links, cur_release_dates, '_none_security_authz_path_both', 'p99')
+    latency_none_security_authz_jwt_both_p99 = get_telemetry_mode_y_series(cur_href_links, cur_release_dates, '_none_security_authz_jwt_both', 'p99')
+    latency_none_security_peer_authn_both_p99 = get_telemetry_mode_y_series(cur_href_links, cur_release_dates, '_none_security_peer_authn_both', 'p99')
 
     context = {'current_release': current_release,
                'latency_none_mtls_base_p90': latency_none_mtls_base_p90,
@@ -55,6 +63,10 @@ def cur_regression(request):
                'latency_v2_stats_wasm_both_p90': latency_v2_stats_wasm_both_p90,
                'latency_v2_sd_nologging_nullvm_both_p90': latency_v2_sd_nologging_nullvm_both_p90,
                'latency_v2_sd_full_nullvm_both_p90': latency_v2_sd_full_nullvm_both_p90,
+               'latency_none_security_authz_ip_both_p90': latency_none_security_authz_ip_both_p90,
+               'latency_none_security_authz_path_both_p90': latency_none_security_authz_path_both_p90,
+               'latency_none_security_authz_jwt_both_p90': latency_none_security_authz_jwt_both_p90,
+               'latency_none_security_peer_authn_both_p90': latency_none_security_peer_authn_both_p90,
                'latency_none_mtls_base_p99': latency_none_mtls_base_p99,
                'latency_none_mtls_both_p99': latency_none_mtls_both_p99,
                'latency_none_plaintext_both_p99': latency_none_plaintext_both_p99,
@@ -62,6 +74,10 @@ def cur_regression(request):
                'latency_v2_stats_wasm_both_p99': latency_v2_stats_wasm_both_p99,
                'latency_v2_sd_nologging_nullvm_both_p99': latency_v2_sd_nologging_nullvm_both_p99,
                'latency_v2_sd_full_nullvm_both_p99': latency_v2_sd_full_nullvm_both_p99,
+               'latency_none_security_authz_ip_both_p99': latency_none_security_authz_ip_both_p99,
+               'latency_none_security_authz_path_both_p99': latency_none_security_authz_path_both_p99,
+               'latency_none_security_authz_jwt_both_p99': latency_none_security_authz_jwt_both_p99,
+               'latency_none_security_peer_authn_both_p99': latency_none_security_peer_authn_both_p99,
                }
     return render(request, "cur_regression.html", context=context)
 
@@ -77,6 +93,13 @@ def master_regression(request):
     latency_v2_stats_wasm_both_p90_master = get_telemetry_mode_y_series(master_href_links, master_release_dates, '_v2-stats-wasm_both', 'p90')
     latency_v2_sd_nologging_nullvm_both_p90_master = get_telemetry_mode_y_series(master_href_links, master_release_dates, '_v2-sd-nologging-nullvm_both', 'p90')
     latency_v2_sd_full_nullvm_both_p90_master = get_telemetry_mode_y_series(master_href_links, master_release_dates, '_v2-sd-full-nullvm_both', 'p90')
+    latency_none_security_authz_ip_both_p90_master = get_telemetry_mode_y_series(master_href_links, master_release_dates, '_none_security_authz_ip_both', 'p90')
+    latency_none_security_authz_path_both_p90_master = get_telemetry_mode_y_series(
+        master_href_links, master_release_dates, '_none_security_authz_path_both', 'p90')
+    latency_none_security_authz_jwt_both_p90_master = get_telemetry_mode_y_series(
+        master_href_links, master_release_dates, '_none_security_authz_jwt_both', 'p90')
+    latency_none_security_peer_authn_both_p90_master = get_telemetry_mode_y_series(
+        master_href_links, master_release_dates, '_none_security_peer_authn_both', 'p90')
 
     latency_none_mtls_base_p99_master = get_telemetry_mode_y_series(master_href_links, master_release_dates, '_none_mtls_baseline', 'p99')
     latency_none_mtls_both_p99_master = get_telemetry_mode_y_series(master_href_links, master_release_dates, '_none_mtls_both', 'p99')
@@ -85,6 +108,13 @@ def master_regression(request):
     latency_v2_stats_wasm_both_p99_master = get_telemetry_mode_y_series(master_href_links, master_release_dates, '_v2-stats-wasm_both', 'p99')
     latency_v2_sd_nologging_nullvm_both_p99_master = get_telemetry_mode_y_series(master_href_links, master_release_dates, '_v2-sd-nologging-nullvm_both', 'p99')
     latency_v2_sd_full_nullvm_both_p99_master = get_telemetry_mode_y_series(master_href_links, master_release_dates, '_v2-sd-full-nullvm_both', 'p99')
+    latency_none_security_authz_ip_both_p99_master = get_telemetry_mode_y_series(master_href_links, master_release_dates, '_none_security_authz_ip_both', 'p99')
+    latency_none_security_authz_path_both_p99_master = get_telemetry_mode_y_series(
+        master_href_links, master_release_dates, '_none_security_authz_path_both', 'p99')
+    latency_none_security_authz_jwt_both_p99_master = get_telemetry_mode_y_series(
+        master_href_links, master_release_dates, '_none_security_authz_jwt_both', 'p99')
+    latency_none_security_peer_authn_both_p99_master = get_telemetry_mode_y_series(
+        master_href_links, master_release_dates, '_none_security_peer_authn_both', 'p99')
 
     context = {'latency_none_mtls_base_p90_master': latency_none_mtls_base_p90_master,
                'latency_none_mtls_both_p90_master': latency_none_mtls_both_p90_master,
@@ -93,6 +123,10 @@ def master_regression(request):
                'latency_v2_stats_wasm_both_p90_master': latency_v2_stats_wasm_both_p90_master,
                'latency_v2_sd_nologging_nullvm_both_p90_master': latency_v2_sd_nologging_nullvm_both_p90_master,
                'latency_v2_sd_full_nullvm_both_p90_master': latency_v2_sd_full_nullvm_both_p90_master,
+               'latency_none_security_authz_ip_both_p90_master': latency_none_security_authz_ip_both_p90_master,
+               'latency_none_security_authz_path_both_p90_master': latency_none_security_authz_path_both_p90_master,
+               'latency_none_security_authz_jwt_both_p90_master': latency_none_security_authz_jwt_both_p90_master,
+               'latency_none_security_peer_authn_both_p90_master': latency_none_security_peer_authn_both_p90_master,
                'latency_none_mtls_base_p99_master': latency_none_mtls_base_p99_master,
                'latency_none_mtls_both_p99_master': latency_none_mtls_both_p99_master,
                'latency_none_plaintext_both_p99_master': latency_none_plaintext_both_p99_master,
@@ -100,6 +134,10 @@ def master_regression(request):
                'latency_v2_stats_wasm_both_p99_master': latency_v2_stats_wasm_both_p99_master,
                'latency_v2_sd_nologging_nullvm_both_p99_master': latency_v2_sd_nologging_nullvm_both_p99_master,
                'latency_v2_sd_full_nullvm_both_p99_master': latency_v2_sd_full_nullvm_both_p99_master,
+               'latency_none_security_authz_ip_both_p99_master': latency_none_security_authz_ip_both_p99_master,
+               'latency_none_security_authz_path_both_p99_master': latency_none_security_authz_path_both_p99_master,
+               'latency_none_security_authz_jwt_both_p99_master': latency_none_security_authz_jwt_both_p99_master,
+               'latency_none_security_peer_authn_both_p99_master': latency_none_security_peer_authn_both_p99_master,
                }
 
     return render(request, "master_regression.html", context=context)

--- a/perf_dashboard/requirements.txt
+++ b/perf_dashboard/requirements.txt
@@ -1,4 +1,4 @@
-Django==2.2.18
+Django==2.2.20
 beautifulsoup4==4.8.1
 pandas==0.25.3
 wget==3.2

--- a/perf_dashboard/static/js/cpu_conn.js
+++ b/perf_dashboard/static/js/cpu_conn.js
@@ -69,6 +69,34 @@ new Chart(document.getElementById("cpu-client-conn-release"), {
                 data: cpu_client_v2_sd_full_nullvm_both,
                 hidden: true,
                 fill: false
+            }, {
+                label: "none_security_authz_ip_both",
+                backgroundColor: "rgba(50,219,199, 0.2)",
+                borderColor: "rgb(50,219,199)",
+                data: cpu_client_none_security_authz_ip_both,
+                hidden: false,
+                fill: false
+            }, {
+                label: "none_security_authz_path_both",
+                backgroundColor: "rgba(8,171,195, 0.2)",
+                borderColor: "rgb(8,171,195)",
+                data: cpu_client_none_security_authz_path_both,
+                hidden: false,
+                fill: false
+            }, {
+                label: "none_security_authz_jwt_both",
+                backgroundColor: "rgba(5,140,212, 0.2)",
+                borderColor: "rgb(5,140,212)",
+                data: cpu_client_none_security_authz_jwt_both,
+                hidden: false,
+                fill: false
+            }, {
+                label: "none_security_peer_authn_both",
+                backgroundColor: "rgba(6,91,184, 0.2)",
+                borderColor: "rgb(6,91,184)",
+                data: cpu_client_none_security_peer_authn_both,
+                hidden: false,
+                fill: false
             }
         ]
     }),
@@ -124,6 +152,34 @@ new Chart(document.getElementById("cpu-client-conn-master"), {
                 borderColor: "rgba(168, 50, 168, 1)",
                 data: cpu_client_v2_sd_full_nullvm_both_master,
                 hidden: true,
+                fill: false
+            }, {
+                label: "none_security_authz_ip_both",
+                backgroundColor: "rgba(50,219,199, 0.2)",
+                borderColor: "rgb(50,219,199)",
+                data: cpu_client_none_security_authz_ip_both_master,
+                hidden: false,
+                fill: false
+            }, {
+                label: "none_security_authz_path_both",
+                backgroundColor: "rgba(8,171,195, 0.2)",
+                borderColor: "rgb(8,171,195)",
+                data: cpu_client_none_security_authz_path_both_master,
+                hidden: false,
+                fill: false
+            }, {
+                label: "none_security_authz_jwt_both",
+                backgroundColor: "rgba(5,140,212, 0.2)",
+                borderColor: "rgb(5,140,212)",
+                data: cpu_client_none_security_authz_jwt_both_master,
+                hidden: false,
+                fill: false
+            }, {
+                label: "none_security_peer_authn_both",
+                backgroundColor: "rgba(6,91,184, 0.2)",
+                borderColor: "rgb(6,91,184)",
+                data: cpu_client_none_security_peer_authn_both_master,
+                hidden: false,
                 fill: false
             }
         ]
@@ -181,6 +237,34 @@ new Chart(document.getElementById("cpu-server-conn-release"), {
                 data: cpu_server_v2_sd_full_nullvm_both,
                 hidden: true,
                 fill: false
+            }, {
+                label: "none_security_authz_ip_both",
+                backgroundColor: "rgba(50,219,199, 0.2)",
+                borderColor: "rgb(50,219,199)",
+                data: cpu_server_none_security_authz_ip_both,
+                hidden: false,
+                fill: false
+            }, {
+                label: "none_security_authz_path_both",
+                backgroundColor: "rgba(8,171,195, 0.2)",
+                borderColor: "rgb(8,171,195)",
+                data: cpu_server_none_security_authz_path_both,
+                hidden: false,
+                fill: false
+            }, {
+                label: "none_security_authz_jwt_both",
+                backgroundColor: "rgba(5,140,212, 0.2)",
+                borderColor: "rgb(5,140,212)",
+                data: cpu_server_none_security_authz_jwt_both,
+                hidden: false,
+                fill: false
+            }, {
+                label: "none_security_peer_authn_both",
+                backgroundColor: "rgba(6,91,184, 0.2)",
+                borderColor: "rgb(6,91,184)",
+                data: cpu_server_none_security_peer_authn_both,
+                hidden: false,
+                fill: false
             }
         ]
     }),
@@ -236,6 +320,34 @@ new Chart(document.getElementById("cpu-server-conn-master"), {
                 borderColor: "rgba(168, 50, 168, 1)",
                 data: cpu_server_v2_sd_full_nullvm_both_master,
                 hidden: true,
+                fill: false
+            }, {
+                label: "none_security_authz_ip_both",
+                backgroundColor: "rgba(50,219,199, 0.2)",
+                borderColor: "rgb(50,219,199)",
+                data: cpu_server_none_security_authz_ip_both_master,
+                hidden: false,
+                fill: false
+            }, {
+                label: "none_security_authz_path_both",
+                backgroundColor: "rgba(8,171,195, 0.2)",
+                borderColor: "rgb(8,171,195)",
+                data: cpu_server_none_security_authz_path_both_master,
+                hidden: false,
+                fill: false
+            }, {
+                label: "none_security_authz_jwt_both",
+                backgroundColor: "rgba(5,140,212, 0.2)",
+                borderColor: "rgb(5,140,212)",
+                data: cpu_server_none_security_authz_jwt_both_master,
+                hidden: false,
+                fill: false
+            }, {
+                label: "none_security_peer_authn_both",
+                backgroundColor: "rgba(6,91,184, 0.2)",
+                borderColor: "rgb(6,91,184)",
+                data: cpu_server_none_security_peer_authn_both_master,
+                hidden: false,
                 fill: false
             }
         ]

--- a/perf_dashboard/static/js/cpu_qps.js
+++ b/perf_dashboard/static/js/cpu_qps.js
@@ -69,6 +69,34 @@ new Chart(document.getElementById("cpu-client-qps-release"), {
                 data: cpu_client_v2_sd_full_nullvm_both,
                 hidden: true,
                 fill: false
+            }, {
+                label: "none_security_authz_ip_both",
+                backgroundColor: "rgba(50,219,199, 0.2)",
+                borderColor: "rgb(50,219,199)",
+                data: cpu_client_none_security_authz_ip_both,
+                hidden: false,
+                fill: false
+            }, {
+                label: "none_security_authz_path_both",
+                backgroundColor: "rgba(8,171,195, 0.2)",
+                borderColor: "rgb(8,171,195)",
+                data: cpu_client_none_security_authz_path_both,
+                hidden: false,
+                fill: false
+            }, {
+                label: "none_security_authz_jwt_both",
+                backgroundColor: "rgba(5,140,212, 0.2)",
+                borderColor: "rgb(5,140,212)",
+                data: cpu_client_none_security_authz_jwt_both,
+                hidden: false,
+                fill: false
+            }, {
+                label: "none_security_peer_authn_both",
+                backgroundColor: "rgba(6,91,184, 0.2)",
+                borderColor: "rgb(6,91,184)",
+                data: cpu_client_none_security_peer_authn_both,
+                hidden: false,
+                fill: false
             }
         ]
     }),
@@ -124,6 +152,34 @@ new Chart(document.getElementById("cpu-client-qps-master"), {
                 borderColor: "rgba(168, 50, 168, 1)",
                 data: cpu_client_v2_sd_full_nullvm_both_master,
                 hidden: true,
+                fill: false
+            }, {
+                label: "none_security_authz_ip_both",
+                backgroundColor: "rgba(50,219,199, 0.2)",
+                borderColor: "rgb(50,219,199)",
+                data: cpu_client_none_security_authz_ip_both_master,
+                hidden: false,
+                fill: false
+            }, {
+                label: "none_security_authz_path_both",
+                backgroundColor: "rgba(8,171,195, 0.2)",
+                borderColor: "rgb(8,171,195)",
+                data: cpu_client_none_security_authz_path_both_master,
+                hidden: false,
+                fill: false
+            }, {
+                label: "none_security_authz_jwt_both",
+                backgroundColor: "rgba(5,140,212, 0.2)",
+                borderColor: "rgb(5,140,212)",
+                data: cpu_client_none_security_authz_jwt_both_master,
+                hidden: false,
+                fill: false
+            }, {
+                label: "none_security_peer_authn_both",
+                backgroundColor: "rgba(6,91,184, 0.2)",
+                borderColor: "rgb(6,91,184)",
+                data: cpu_client_none_security_peer_authn_both_master,
+                hidden: false,
                 fill: false
             }
         ]
@@ -181,6 +237,34 @@ new Chart(document.getElementById("cpu-server-qps-release"), {
                 data: cpu_server_v2_sd_full_nullvm_both,
                 hidden: true,
                 fill: false
+            }, {
+                label: "none_security_authz_ip_both",
+                backgroundColor: "rgba(50,219,199, 0.2)",
+                borderColor: "rgb(50,219,199)",
+                data: cpu_server_none_security_authz_ip_both,
+                hidden: false,
+                fill: false
+            }, {
+                label: "none_security_authz_path_both",
+                backgroundColor: "rgba(8,171,195, 0.2)",
+                borderColor: "rgb(8,171,195)",
+                data: cpu_server_none_security_authz_path_both,
+                hidden: false,
+                fill: false
+            }, {
+                label: "none_security_authz_jwt_both",
+                backgroundColor: "rgba(5,140,212, 0.2)",
+                borderColor: "rgb(5,140,212)",
+                data: cpu_server_none_security_authz_jwt_both,
+                hidden: false,
+                fill: false
+            }, {
+                label: "none_security_peer_authn_both",
+                backgroundColor: "rgba(6,91,184, 0.2)",
+                borderColor: "rgb(6,91,184)",
+                data: cpu_server_none_security_peer_authn_both,
+                hidden: false,
+                fill: false
             }
         ]
     }),
@@ -236,6 +320,34 @@ new Chart(document.getElementById("cpu-server-qps-master"), {
                 borderColor: "rgba(168, 50, 168, 1)",
                 data: cpu_server_v2_sd_full_nullvm_both_master,
                 hidden: true,
+                fill: false
+            }, {
+                label: "none_security_authz_ip_both",
+                backgroundColor: "rgba(50,219,199, 0.2)",
+                borderColor: "rgb(50,219,199)",
+                data: cpu_server_none_security_authz_ip_both_master,
+                hidden: false,
+                fill: false
+            }, {
+                label: "none_security_authz_path_both",
+                backgroundColor: "rgba(8,171,195, 0.2)",
+                borderColor: "rgb(8,171,195)",
+                data: cpu_server_none_security_authz_path_both_master,
+                hidden: false,
+                fill: false
+            }, {
+                label: "none_security_authz_jwt_both",
+                backgroundColor: "rgba(5,140,212, 0.2)",
+                borderColor: "rgb(5,140,212)",
+                data: cpu_server_none_security_authz_jwt_both_master,
+                hidden: false,
+                fill: false
+            }, {
+                label: "none_security_peer_authn_both",
+                backgroundColor: "rgba(6,91,184, 0.2)",
+                borderColor: "rgb(6,91,184)",
+                data: cpu_server_none_security_peer_authn_both_master,
+                hidden: false,
                 fill: false
             }
         ]

--- a/perf_dashboard/static/js/cur_regression.js
+++ b/perf_dashboard/static/js/cur_regression.js
@@ -6,6 +6,10 @@ window.onload = function () {
   let latency_v2_stats_wasm_both_p90_trending = constructDataSeries(latency_v2_stats_wasm_both_p90, latency_none_mtls_base_p90)
   let latency_v2_sd_nologging_nullvm_both_p90_trending = constructDataSeries(latency_v2_sd_nologging_nullvm_both_p90, latency_none_mtls_base_p90)
   let latency_v2_sd_full_nullvm_both_p90_trending = constructDataSeries(latency_v2_sd_full_nullvm_both_p90, latency_none_mtls_base_p90)
+  let latency_none_security_authz_ip_both_p90_trending = constructDataSeries(latency_none_security_authz_ip_both_p90, latency_none_mtls_base_p90)
+  let latency_none_security_authz_path_both_p90_trending = constructDataSeries(latency_none_security_authz_path_both_p90, latency_none_mtls_base_p90)
+  let latency_none_security_authz_jwt_both_p90_trending = constructDataSeries(latency_none_security_authz_jwt_both_p90, latency_none_mtls_base_p90)
+  let latency_none_security_peer_authn_both_p90_trending = constructDataSeries(latency_none_security_peer_authn_both_p90, latency_none_mtls_base_p90)
 
   p90ModesData = [];
   p90ModesData.push(latency_none_mtls_both_p90_trending);
@@ -14,6 +18,10 @@ window.onload = function () {
   p90ModesData.push(latency_v2_stats_wasm_both_p90_trending);
   p90ModesData.push(latency_v2_sd_nologging_nullvm_both_p90_trending);
   p90ModesData.push(latency_v2_sd_full_nullvm_both_p90_trending);
+  p90ModesData.push(latency_none_security_authz_ip_both_p90_trending);
+  p90ModesData.push(latency_none_security_authz_path_both_p90_trending);
+  p90ModesData.push(latency_none_security_authz_jwt_both_p90_trending);
+  p90ModesData.push(latency_none_security_peer_authn_both_p90_trending);
 
   generateChart("trending_p90", p90ModesData);
 
@@ -24,6 +32,10 @@ window.onload = function () {
   let latency_v2_stats_wasm_both_p99_trending = constructDataSeries(latency_v2_stats_wasm_both_p99, latency_none_mtls_base_p99)
   let latency_v2_sd_nologging_nullvm_both_p99_trending = constructDataSeries(latency_v2_sd_nologging_nullvm_both_p99, latency_none_mtls_base_p99)
   let latency_v2_sd_full_nullvm_both_p99_trending = constructDataSeries(latency_v2_sd_full_nullvm_both_p99, latency_none_mtls_base_p99)
+  let latency_none_security_authz_ip_both_p99_trending = constructDataSeries(latency_none_security_authz_ip_both_p99, latency_none_mtls_base_p99)
+  let latency_none_security_authz_path_both_p99_trending = constructDataSeries(latency_none_security_authz_path_both_p99, latency_none_mtls_base_p99)
+  let latency_none_security_authz_jwt_both_p99_trending = constructDataSeries(latency_none_security_authz_jwt_both_p99, latency_none_mtls_base_p99)
+  let latency_none_security_peer_authn_both_p99_trending = constructDataSeries(latency_none_security_peer_authn_both_p99, latency_none_mtls_base_p99)
 
   p99ModesData = [];
   p99ModesData.push(latency_none_mtls_both_p99_trending);
@@ -32,6 +44,10 @@ window.onload = function () {
   p99ModesData.push(latency_v2_stats_wasm_both_p99_trending);
   p99ModesData.push(latency_v2_sd_nologging_nullvm_both_p99_trending);
   p99ModesData.push(latency_v2_sd_full_nullvm_both_p99_trending);
+  p99ModesData.push(latency_none_security_authz_ip_both_p99_trending);
+  p99ModesData.push(latency_none_security_authz_path_both_p99_trending);
+  p99ModesData.push(latency_none_security_authz_jwt_both_p99_trending);
+  p99ModesData.push(latency_none_security_peer_authn_both_p99_trending);
 
   generateChart("trending_p99", p99ModesData);
 };

--- a/perf_dashboard/static/js/latency_common_func.js
+++ b/perf_dashboard/static/js/latency_common_func.js
@@ -8,6 +8,10 @@ window.generateLatencyChart = function(xNum, options) {
   p50ReleaseModesData.push(latency_v2_stats_wasm_both_p50);
   p50ReleaseModesData.push(latency_v2_sd_nologging_nullvm_both_p50);
   p50ReleaseModesData.push(latency_v2_sd_full_nullvm_both_p50);
+  p50ReleaseModesData.push(latency_none_security_authz_ip_both_p50);
+  p50ReleaseModesData.push(latency_none_security_authz_path_both_p50);
+  p50ReleaseModesData.push(latency_none_security_authz_jwt_both_p50);
+  p50ReleaseModesData.push(latency_none_security_peer_authn_both_p50);
 
   generateLatencyChartByID("latency-p50-release", xNum, p50ReleaseModesData, options)
 
@@ -20,6 +24,10 @@ window.generateLatencyChart = function(xNum, options) {
   p90ReleaseModesData.push(latency_v2_stats_wasm_both_p90);
   p90ReleaseModesData.push(latency_v2_sd_nologging_nullvm_both_p90);
   p90ReleaseModesData.push(latency_v2_sd_full_nullvm_both_p90);
+  p90ReleaseModesData.push(latency_none_security_authz_ip_both_p90);
+  p90ReleaseModesData.push(latency_none_security_authz_path_both_p90);
+  p90ReleaseModesData.push(latency_none_security_authz_jwt_both_p90);
+  p90ReleaseModesData.push(latency_none_security_peer_authn_both_p90);
 
   generateLatencyChartByID("latency-p90-release", xNum, p90ReleaseModesData, options)
 
@@ -32,6 +40,10 @@ window.generateLatencyChart = function(xNum, options) {
   p99ReleaseModesData.push(latency_v2_stats_wasm_both_p99);
   p99ReleaseModesData.push(latency_v2_sd_nologging_nullvm_both_p99);
   p99ReleaseModesData.push(latency_v2_sd_full_nullvm_both_p99);
+  p99ReleaseModesData.push(latency_none_security_authz_ip_both_p99);
+  p99ReleaseModesData.push(latency_none_security_authz_path_both_p99);
+  p99ReleaseModesData.push(latency_none_security_authz_jwt_both_p99);
+  p99ReleaseModesData.push(latency_none_security_peer_authn_both_p99);
 
   generateLatencyChartByID("latency-p99-release", xNum, p99ReleaseModesData, options)
 
@@ -44,6 +56,10 @@ window.generateLatencyChart = function(xNum, options) {
   p999ReleaseModesData.push(latency_v2_stats_wasm_both_p999);
   p999ReleaseModesData.push(latency_v2_sd_nologging_nullvm_both_p999);
   p999ReleaseModesData.push(latency_v2_sd_full_nullvm_both_p999);
+  p999ReleaseModesData.push(latency_none_security_authz_ip_both_p999);
+  p999ReleaseModesData.push(latency_none_security_authz_path_both_p999);
+  p999ReleaseModesData.push(latency_none_security_authz_jwt_both_p999);
+  p999ReleaseModesData.push(latency_none_security_peer_authn_both_p999);
 
   generateLatencyChartByID("latency-p999-release", xNum, p999ReleaseModesData, options)
 
@@ -56,6 +72,10 @@ window.generateLatencyChart = function(xNum, options) {
   p50ModesData.push(latency_v2_stats_wasm_both_p50_master);
   p50ModesData.push(latency_v2_sd_nologging_nullvm_both_p50_master);
   p50ModesData.push(latency_v2_sd_full_nullvm_both_p50_master);
+  p50ModesData.push(latency_none_security_authz_ip_both_p50_master);
+  p50ModesData.push(latency_none_security_authz_path_both_p50_master);
+  p50ModesData.push(latency_none_security_authz_jwt_both_p50_master);
+  p50ModesData.push(latency_none_security_peer_authn_both_p50_master);
 
   generateLatencyChartByID("latency-p50-master", xNum, p50ModesData, options)
 
@@ -68,6 +88,10 @@ window.generateLatencyChart = function(xNum, options) {
   p90ModesData.push(latency_v2_stats_wasm_both_p90_master);
   p90ModesData.push(latency_v2_sd_nologging_nullvm_both_p90_master);
   p90ModesData.push(latency_v2_sd_full_nullvm_both_p90_master);
+  p90ModesData.push(latency_none_security_authz_ip_both_p90_master);
+  p90ModesData.push(latency_none_security_authz_path_both_p90_master);
+  p90ModesData.push(latency_none_security_authz_jwt_both_p90_master);
+  p90ModesData.push(latency_none_security_peer_authn_both_p90_master);
 
   generateLatencyChartByID("latency-p90-master", xNum, p90ModesData, options)
 
@@ -80,6 +104,10 @@ window.generateLatencyChart = function(xNum, options) {
   p99ModesData.push(latency_v2_stats_wasm_both_p99_master);
   p99ModesData.push(latency_v2_sd_nologging_nullvm_both_p99_master);
   p99ModesData.push(latency_v2_sd_full_nullvm_both_p99_master);
+  p99ModesData.push(latency_none_security_authz_ip_both_p99_master);
+  p99ModesData.push(latency_none_security_authz_path_both_p99_master);
+  p99ModesData.push(latency_none_security_authz_jwt_both_p99_master);
+  p99ModesData.push(latency_none_security_peer_authn_both_p99_master);
 
   generateLatencyChartByID("latency-p99-master", xNum, p99ModesData, options)
 
@@ -92,6 +120,10 @@ window.generateLatencyChart = function(xNum, options) {
   p999ModesData.push(latency_v2_stats_wasm_both_p999_master);
   p999ModesData.push(latency_v2_sd_nologging_nullvm_both_p999_master);
   p999ModesData.push(latency_v2_sd_full_nullvm_both_p999_master);
+  p999ModesData.push(latency_none_security_authz_ip_both_p999_master);
+  p999ModesData.push(latency_none_security_authz_path_both_p999_master);
+  p999ModesData.push(latency_none_security_authz_jwt_both_p999_master);
+  p999ModesData.push(latency_none_security_peer_authn_both_p999_master);
 
   generateLatencyChartByID("latency-p999-master", xNum, p999ModesData, options)
 };
@@ -146,6 +178,34 @@ window.generateLatencyChartByID = function(chartID, xNum, modesData, options) {
                 borderColor: "rgba(168, 50, 168, 1)",
                 data: modesData[6],
                 hidden: true,
+                fill: false
+            }, {
+                label: "none_security_authz_ip_both",
+                backgroundColor: "rgba(50,219,199, 0.2)",
+                borderColor: "rgb(50,219,199)",
+                data: modesData[7],
+                hidden: false,
+                fill: false
+            }, {
+                label: "none_security_authz_path_both",
+                backgroundColor: "rgba(8,171,195, 0.2)",
+                borderColor: "rgb(8,171,195)",
+                data: modesData[8],
+                hidden: false,
+                fill: false
+            }, {
+                label: "none_security_authz_jwt_both",
+                backgroundColor: "rgba(5,140,212, 0.2)",
+                borderColor: "rgb(5,140,212)",
+                data: modesData[9],
+                hidden: false,
+                fill: false
+            }, {
+                label: "none_security_peer_authn_both",
+                backgroundColor: "rgba(6,91,184, 0.2)",
+                borderColor: "rgb(6,91,184)",
+                data: modesData[10],
+                hidden: false,
                 fill: false
             }
         ]

--- a/perf_dashboard/static/js/master_regression.js
+++ b/perf_dashboard/static/js/master_regression.js
@@ -6,6 +6,10 @@ window.onload = function () {
   let latency_v2_stats_wasm_both_p90_master_trending = constructDataSeries(latency_v2_stats_wasm_both_p90_master, latency_none_mtls_base_p90_master)
   let latency_v2_sd_nologging_nullvm_both_p90_master_trending = constructDataSeries(latency_v2_sd_nologging_nullvm_both_p90_master, latency_none_mtls_base_p90_master)
   let latency_v2_sd_full_nullvm_both_p90_master_trending = constructDataSeries(latency_v2_sd_full_nullvm_both_p90_master, latency_none_mtls_base_p90_master)
+  let latency_none_security_authz_ip_both_p90_master_trending = constructDataSeries(latency_none_security_authz_ip_both_p90_master, latency_none_mtls_base_p90_master)
+  let latency_none_security_authz_path_both_p90_master_trending = constructDataSeries(latency_none_security_authz_path_both_p90_master, latency_none_mtls_base_p90_master)
+  let latency_none_security_authz_jwt_both_p90_master_trending = constructDataSeries(latency_none_security_authz_jwt_both_p90_master, latency_none_mtls_base_p90_master)
+  let latency_none_security_peer_authn_both_p90_master_trending = constructDataSeries(latency_none_security_peer_authn_both_p90_master, latency_none_mtls_base_p90_master)
 
   p90ModesData = [];
   p90ModesData.push(latency_none_mtls_both_p90_master_trending);
@@ -14,6 +18,10 @@ window.onload = function () {
   p90ModesData.push(latency_v2_stats_wasm_both_p90_master_trending);
   p90ModesData.push(latency_v2_sd_nologging_nullvm_both_p90_master_trending);
   p90ModesData.push(latency_v2_sd_full_nullvm_both_p90_master_trending);
+  p90ModesData.push(latency_none_security_authz_ip_both_p90_master_trending);
+  p90ModesData.push(latency_none_security_authz_path_both_p90_master_trending);
+  p90ModesData.push(latency_none_security_authz_jwt_both_p90_master_trending);
+  p90ModesData.push(latency_none_security_peer_authn_both_p90_master_trending);
 
   generateChart("trending_p90_master", p90ModesData);
 
@@ -24,6 +32,10 @@ window.onload = function () {
   let latency_v2_stats_wasm_both_p99_master_trending = constructDataSeries(latency_v2_stats_wasm_both_p99_master, latency_none_mtls_base_p99_master)
   let latency_v2_sd_nologging_nullvm_both_p99_master_trending = constructDataSeries(latency_v2_sd_nologging_nullvm_both_p99_master, latency_none_mtls_base_p99_master)
   let latency_v2_sd_full_nullvm_both_p99_master_trending = constructDataSeries(latency_v2_sd_full_nullvm_both_p99_master, latency_none_mtls_base_p99_master)
+  let latency_none_security_authz_ip_both_p99_master_trending = constructDataSeries(latency_none_security_authz_ip_both_p99_master, latency_none_mtls_base_p99_master)
+  let latency_none_security_authz_path_both_p99_master_trending = constructDataSeries(latency_none_security_authz_path_both_p99_master, latency_none_mtls_base_p99_master)
+  let latency_none_security_authz_jwt_both_p99_master_trending = constructDataSeries(latency_none_security_authz_jwt_both_p99_master, latency_none_mtls_base_p99_master)
+  let latency_none_security_peer_authn_both_p99_master_trending = constructDataSeries(latency_none_security_peer_authn_both_p99_master, latency_none_mtls_base_p99_master)
 
   p99ModesData = [];
   p99ModesData.push(latency_none_mtls_both_p99_master_trending);
@@ -32,6 +44,10 @@ window.onload = function () {
   p99ModesData.push(latency_v2_stats_wasm_both_p99_master_trending);
   p99ModesData.push(latency_v2_sd_nologging_nullvm_both_p99_master_trending);
   p99ModesData.push(latency_v2_sd_full_nullvm_both_p99_master_trending);
+  p99ModesData.push(latency_none_security_authz_ip_both_p99_master_trending);
+  p99ModesData.push(latency_none_security_authz_path_both_p99_master_trending);
+  p99ModesData.push(latency_none_security_authz_jwt_both_p99_master_trending);
+  p99ModesData.push(latency_none_security_peer_authn_both_p99_master_trending);
 
   generateChart("trending_p99_master", p99ModesData);
 };

--- a/perf_dashboard/static/js/mem_conn.js
+++ b/perf_dashboard/static/js/mem_conn.js
@@ -69,6 +69,34 @@ new Chart(document.getElementById("mem-client-conn-release"), {
                 data: mem_client_v2_sd_full_nullvm_both,
                 hidden: true,
                 fill: false
+            }, {
+                label: "none_security_authz_ip_both",
+                backgroundColor: "rgba(50,219,199, 0.2)",
+                borderColor: "rgb(50,219,199)",
+                data: mem_client_none_security_authz_ip_both,
+                hidden: false,
+                fill: false
+            }, {
+                label: "none_security_authz_path_both",
+                backgroundColor: "rgba(8,171,195, 0.2)",
+                borderColor: "rgb(8,171,195)",
+                data: mem_client_none_security_authz_path_both,
+                hidden: false,
+                fill: false
+            }, {
+                label: "none_security_authz_jwt_both",
+                backgroundColor: "rgba(5,140,212, 0.2)",
+                borderColor: "rgb(5,140,212)",
+                data: mem_client_none_security_authz_jwt_both,
+                hidden: false,
+                fill: false
+            }, {
+                label: "none_security_peer_authn_both",
+                backgroundColor: "rgba(6,91,184, 0.2)",
+                borderColor: "rgb(6,91,184)",
+                data: mem_client_none_security_peer_authn_both,
+                hidden: false,
+                fill: false
             }
         ]
     }),
@@ -124,6 +152,34 @@ new Chart(document.getElementById("mem-client-conn-master"), {
                 borderColor: "rgba(168, 50, 168, 1)",
                 data: mem_client_v2_sd_full_nullvm_both_master,
                 hidden: true,
+                fill: false
+            }, {
+                label: "none_security_authz_ip_both",
+                backgroundColor: "rgba(50,219,199, 0.2)",
+                borderColor: "rgb(50,219,199)",
+                data: mem_client_none_security_authz_ip_both_master,
+                hidden: false,
+                fill: false
+            }, {
+                label: "none_security_authz_path_both",
+                backgroundColor: "rgba(8,171,195, 0.2)",
+                borderColor: "rgb(8,171,195)",
+                data: mem_client_none_security_authz_path_both_master,
+                hidden: false,
+                fill: false
+            }, {
+                label: "none_security_authz_jwt_both",
+                backgroundColor: "rgba(5,140,212, 0.2)",
+                borderColor: "rgb(5,140,212)",
+                data: mem_client_none_security_authz_jwt_both_master,
+                hidden: false,
+                fill: false
+            }, {
+                label: "none_security_peer_authn_both",
+                backgroundColor: "rgba(6,91,184, 0.2)",
+                borderColor: "rgb(6,91,184)",
+                data: mem_client_none_security_peer_authn_both_master,
+                hidden: false,
                 fill: false
             }
         ]
@@ -181,6 +237,34 @@ new Chart(document.getElementById("mem-server-conn-release"), {
                 data: mem_server_v2_sd_full_nullvm_both,
                 hidden: true,
                 fill: false
+            }, {
+                label: "none_security_authz_ip_both",
+                backgroundColor: "rgba(50,219,199, 0.2)",
+                borderColor: "rgb(50,219,199)",
+                data: mem_server_none_security_authz_ip_both,
+                hidden: false,
+                fill: false
+            }, {
+                label: "none_security_authz_path_both",
+                backgroundColor: "rgba(8,171,195, 0.2)",
+                borderColor: "rgb(8,171,195)",
+                data: mem_server_none_security_authz_path_both,
+                hidden: false,
+                fill: false
+            }, {
+                label: "none_security_authz_jwt_both",
+                backgroundColor: "rgba(5,140,212, 0.2)",
+                borderColor: "rgb(5,140,212)",
+                data: mem_server_none_security_authz_jwt_both,
+                hidden: false,
+                fill: false
+            }, {
+                label: "none_security_peer_authn_both",
+                backgroundColor: "rgba(6,91,184, 0.2)",
+                borderColor: "rgb(6,91,184)",
+                data: mem_server_none_security_peer_authn_both,
+                hidden: false,
+                fill: false
             }
         ]
     }),
@@ -236,6 +320,34 @@ new Chart(document.getElementById("mem-server-conn-master"), {
                 borderColor: "rgba(168, 50, 168, 1)",
                 data: mem_server_v2_sd_full_nullvm_both_master,
                 hidden: true,
+                fill: false
+            }, {
+                label: "none_security_authz_ip_both",
+                backgroundColor: "rgba(50,219,199, 0.2)",
+                borderColor: "rgb(50,219,199)",
+                data: mem_server_none_security_authz_ip_both_master,
+                hidden: false,
+                fill: false
+            }, {
+                label: "none_security_authz_path_both",
+                backgroundColor: "rgba(8,171,195, 0.2)",
+                borderColor: "rgb(8,171,195)",
+                data: mem_server_none_security_authz_path_both_master,
+                hidden: false,
+                fill: false
+            }, {
+                label: "none_security_authz_jwt_both",
+                backgroundColor: "rgba(5,140,212, 0.2)",
+                borderColor: "rgb(5,140,212)",
+                data: mem_server_none_security_authz_jwt_both_master,
+                hidden: false,
+                fill: false
+            }, {
+                label: "none_security_peer_authn_both",
+                backgroundColor: "rgba(6,91,184, 0.2)",
+                borderColor: "rgb(6,91,184)",
+                data: mem_server_none_security_peer_authn_both_master,
+                hidden: false,
                 fill: false
             }
         ]

--- a/perf_dashboard/static/js/mem_qps.js
+++ b/perf_dashboard/static/js/mem_qps.js
@@ -69,6 +69,34 @@ new Chart(document.getElementById("mem-client-qps-release"), {
                 data: mem_client_v2_sd_full_nullvm_both,
                 hidden: true,
                 fill: false
+            }, {
+                label: "none_security_authz_ip_both",
+                backgroundColor: "rgba(50,219,199, 0.2)",
+                borderColor: "rgb(50,219,199)",
+                data: mem_client_none_security_authz_ip_both,
+                hidden: false,
+                fill: false
+            }, {
+                label: "none_security_authz_path_both",
+                backgroundColor: "rgba(8,171,195, 0.2)",
+                borderColor: "rgb(8,171,195)",
+                data: mem_client_none_security_authz_path_both,
+                hidden: false,
+                fill: false
+            }, {
+                label: "none_security_authz_jwt_both",
+                backgroundColor: "rgba(5,140,212, 0.2)",
+                borderColor: "rgb(5,140,212)",
+                data: mem_client_none_security_authz_jwt_both,
+                hidden: false,
+                fill: false
+            }, {
+                label: "none_security_peer_authn_both",
+                backgroundColor: "rgba(6,91,184, 0.2)",
+                borderColor: "rgb(6,91,184)",
+                data: mem_client_none_security_peer_authn_both,
+                hidden: false,
+                fill: false
             }
         ]
     }),
@@ -124,6 +152,34 @@ new Chart(document.getElementById("mem-client-qps-master"), {
                 borderColor: "rgba(168, 50, 168, 1)",
                 data: mem_client_v2_sd_full_nullvm_both_master,
                 hidden: true,
+                fill: false
+            }, {
+                label: "none_security_authz_ip_both",
+                backgroundColor: "rgba(50,219,199, 0.2)",
+                borderColor: "rgb(50,219,199)",
+                data: mem_client_none_security_authz_ip_both_master,
+                hidden: false,
+                fill: false
+            }, {
+                label: "none_security_authz_path_both",
+                backgroundColor: "rgba(8,171,195, 0.2)",
+                borderColor: "rgb(8,171,195)",
+                data: mem_client_none_security_authz_path_both_master,
+                hidden: false,
+                fill: false
+            }, {
+                label: "none_security_authz_jwt_both",
+                backgroundColor: "rgba(5,140,212, 0.2)",
+                borderColor: "rgb(5,140,212)",
+                data: mem_client_none_security_authz_jwt_both_master,
+                hidden: false,
+                fill: false
+            }, {
+                label: "none_security_peer_authn_both",
+                backgroundColor: "rgba(6,91,184, 0.2)",
+                borderColor: "rgb(6,91,184)",
+                data: mem_client_none_security_peer_authn_both_master,
+                hidden: false,
                 fill: false
             }
         ]
@@ -181,6 +237,34 @@ new Chart(document.getElementById("mem-server-qps-release"), {
                 data: mem_server_v2_sd_full_nullvm_both,
                 hidden: true,
                 fill: false
+            }, {
+                label: "none_security_authz_ip_both",
+                backgroundColor: "rgba(50,219,199, 0.2)",
+                borderColor: "rgb(50,219,199)",
+                data: mem_server_none_security_authz_ip_both,
+                hidden: false,
+                fill: false
+            }, {
+                label: "none_security_authz_path_both",
+                backgroundColor: "rgba(8,171,195, 0.2)",
+                borderColor: "rgb(8,171,195)",
+                data: mem_server_none_security_authz_path_both,
+                hidden: false,
+                fill: false
+            }, {
+                label: "none_security_authz_jwt_both",
+                backgroundColor: "rgba(5,140,212, 0.2)",
+                borderColor: "rgb(5,140,212)",
+                data: mem_server_none_security_authz_jwt_both,
+                hidden: false,
+                fill: false
+            }, {
+                label: "none_security_peer_authn_both",
+                backgroundColor: "rgba(6,91,184, 0.2)",
+                borderColor: "rgb(6,91,184)",
+                data: mem_server_none_security_peer_authn_both,
+                hidden: false,
+                fill: false
             }
         ]
     }),
@@ -236,6 +320,34 @@ new Chart(document.getElementById("mem-server-qps-master"), {
                 borderColor: "rgba(168, 50, 168, 1)",
                 data: mem_server_v2_sd_full_nullvm_both_master,
                 hidden: true,
+                fill: false
+            }, {
+                label: "none_security_authz_ip_both",
+                backgroundColor: "rgba(50,219,199, 0.2)",
+                borderColor: "rgb(50,219,199)",
+                data: mem_server_none_security_authz_ip_both_master,
+                hidden: false,
+                fill: false
+            }, {
+                label: "none_security_authz_path_both",
+                backgroundColor: "rgba(8,171,195, 0.2)",
+                borderColor: "rgb(8,171,195)",
+                data: mem_server_none_security_authz_path_both_master,
+                hidden: false,
+                fill: false
+            }, {
+                label: "none_security_authz_jwt_both",
+                backgroundColor: "rgba(5,140,212, 0.2)",
+                borderColor: "rgb(5,140,212)",
+                data: mem_server_none_security_authz_jwt_both_master,
+                hidden: false,
+                fill: false
+            }, {
+                label: "none_security_peer_authn_both",
+                backgroundColor: "rgba(6,91,184, 0.2)",
+                borderColor: "rgb(6,91,184)",
+                data: mem_server_none_security_peer_authn_both_master,
+                hidden: false,
                 fill: false
             }
         ]

--- a/perf_dashboard/static/js/regression_common_func.js
+++ b/perf_dashboard/static/js/regression_common_func.js
@@ -99,6 +99,38 @@ window.generateChart = function(chartID, modesData) {
             xValueFormatString: "DD MMM, YYYY",
             color: "rgba(168, 50, 168, 1)",
             dataPoints: modesData[5]
+            }, {
+            type: "line",
+            showInLegend: true,
+            name: "none_security_authz_ip_both - baseline",
+            markerType: "square",
+            xValueFormatString: "DD MMM, YYYY",
+            color: "rgba(50,219,199)",
+            dataPoints: modesData[6]
+            }, {
+            type: "line",
+            showInLegend: true,
+            name: "none_security_authz_path_both - baseline",
+            markerType: "square",
+            xValueFormatString: "DD MMM, YYYY",
+            color: "rgba(8,171,195)",
+            dataPoints: modesData[7]
+            }, {
+            type: "line",
+            showInLegend: true,
+            name: "none_security_authz_jwt_both - baseline",
+            markerType: "square",
+            xValueFormatString: "DD MMM, YYYY",
+            color: "rgba(5,140,212)",
+            dataPoints: modesData[8]
+            }, {
+            type: "line",
+            showInLegend: true,
+            name: "none_security_peer_authn_both - baseline",
+            markerType: "square",
+            xValueFormatString: "DD MMM, YYYY",
+            color: "rgba(6,91,184)",
+            dataPoints: modesData[9]
             }
         ]
   });


### PR DESCRIPTION
Changed file:

perf/benchmark/configs/istio/security_authz_ip/cpu_mem.yaml
perf/benchmark/configs/istio/security_authz_ip/installation.yaml
perf/benchmark/configs/istio/security_authz_ip/latency.yaml
perf/benchmark/configs/istio/security_authz_jwt/cpu_mem.yaml
perf/benchmark/configs/istio/security_authz_jwt/installation.yaml
perf/benchmark/configs/istio/security_authz_jwt/latency.yaml
perf/benchmark/configs/istio/security_authz_jwt/postrun.sh
perf/benchmark/configs/istio/security_authz_jwt/prerun.sh
perf/benchmark/configs/istio/security_authz_path/cpu_mem.yaml
perf/benchmark/configs/istio/security_authz_path/installation.yaml
perf/benchmark/configs/istio/security_authz_path/latency.yaml
perf/benchmark/configs/istio/security_peer_authn/cpu_mem.yaml
perf/benchmark/configs/istio/security_peer_authn/installation.yaml
perf/benchmark/configs/istio/security_peer_authn/latency.yaml
perf_dashboard/benchmarks/templates/cpu_vs_conn.html
perf_dashboard/benchmarks/templates/cpu_vs_qps.html
perf_dashboard/benchmarks/templates/latency_vs_conn.html
perf_dashboard/benchmarks/templates/latency_vs_qps.html
perf_dashboard/benchmarks/templates/mem_vs_conn.html
perf_dashboard/benchmarks/templates/mem_vs_qps.html
perf_dashboard/benchmarks/views.py
perf_dashboard/regressions/templates/cur_regression.html
perf_dashboard/regressions/templates/master_regression.html
perf_dashboard/regressions/views.py
perf_dashboard/requirements.txt
perf_dashboard/static/js/cpu_conn.js
perf_dashboard/static/js/cpu_qps.js
perf_dashboard/static/js/cur_regression.js
perf_dashboard/static/js/latency_common_func.js
perf_dashboard/static/js/master_regression.js
perf_dashboard/static/js/mem_conn.js
perf_dashboard/static/js/mem_qps.js
perf_dashboard/static/js/regression_common_func.js
