### PR TITLE
isotope: trace errors via request body

### DIFF
--- a/isotope/service/Dockerfile
+++ b/isotope/service/Dockerfile
@@ -9,7 +9,9 @@ COPY . /build/
 
 WORKDIR /build
 
-RUN GOARCH=amd64 CGO_ENABLED=0 GOOS=linux go build -o isotope_service ./service
+RUN  --mount=type=cache,target=/go/pkg/mod \
+     --mount=type=cache,target=/root/.cache/go-build \
+      GOARCH=amd64 CGO_ENABLED=0 GOOS=linux go build -o isotope_service ./service
 
 FROM alpine:3.12
 

--- a/isotope/service/main.go
+++ b/isotope/service/main.go
@@ -42,10 +42,28 @@ var (
 	maxIdleConnectionsPerHostFlag = flag.Int(
 		"max-idle-connections-per-host", 0,
 		"maximum number of TCP connections to keep open per host")
+
+	// Set log levels
+	logLevel = flag.String(
+		"log-level", "info",
+		"log level")
 )
+
+var stringToLevel = map[string]log.Level{
+	"debug": log.DebugLevel,
+	"info":  log.InfoLevel,
+	"warn":  log.WarnLevel,
+	"error": log.ErrorLevel,
+	"fatal": log.FatalLevel,
+	"none":  log.NoneLevel,
+}
+
 
 func main() {
 	flag.Parse()
+	for _, s := range log.Scopes() {
+		s.SetOutputLevel(stringToLevel[*logLevel])
+	}
 
 	setMaxProcs()
 	setMaxIdleConnectionsPerHost(*maxIdleConnectionsPerHostFlag)

--- a/isotope/service/pkg/srv/handler.go
+++ b/isotope/service/pkg/srv/handler.go
@@ -37,10 +37,16 @@ func (h Handler) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
 
 	prometheus.RecordRequestReceived()
 
-	respond := func(status int) {
+	respond := func(status int, body string) {
 		writer.WriteHeader(status)
-		if _, err := writer.Write(h.responsePayload); err != nil {
-			log.Errorf("%s", err)
+		if body != "" {
+			if _, err := writer.Write([]byte(body)); err != nil {
+				log.Errorf("%s", err)
+			}
+		} else {
+			if _, err := writer.Write(h.responsePayload); err != nil {
+				log.Errorf("%s", err)
+			}
 		}
 
 		stopTime := time.Now()
@@ -53,10 +59,10 @@ func (h Handler) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
 		err := execute(step, forwardableHeader, h.ServiceTypes)
 		if err != nil {
 			log.Errorf("%s", err)
-			respond(http.StatusInternalServerError)
+			respond(http.StatusInternalServerError, err.Error() + "\n")
 			return
 		}
 	}
 
-	respond(http.StatusOK)
+	respond(http.StatusOK, "")
 }

--- a/perf/load/values.yaml
+++ b/perf/load/values.yaml
@@ -1,4 +1,4 @@
-serviceGraphImage: gcr.io/istio-testing/isotope:0.0.2
+serviceGraphImage: gcr.io/istio-testing/isotope:0.0.3
 serviceNamePrefix: svc-
 requestSize: 128B
 responseSize: 1KiB


### PR DESCRIPTION
Now an error will look like:
```
1 errors occurred: service svc00-0-0 responded with 500 Internal Server Error (body: 1 errors occurred: service svc00-0-0-0 responded with 503 Service Unavailable (body: upstream connect error or disconnect/reset before headers. reset reason: connection failure))
```

Compared to:
```
error   1 error occurred:
      * service svc00-0-0-0 responded with 503 Service Unavailable
```

Also added the ability to set debug logging and made dockerfile use go module cache