### PR TITLE
Add override for Golang image used in build-tools

### DIFF
--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -25,7 +25,7 @@
 # Binary tools
 ################
 
-ARG GOLANG_IMAGE=golang:1.16.4
+ARG GOLANG_IMAGE
 # hadolint ignore=DL3006
 FROM ${GOLANG_IMAGE} as binary_tools_context
 

--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -25,7 +25,7 @@
 # Binary tools
 ################
 
-ARG GOLANG_IMAGE
+ARG GOLANG_IMAGE=golang:1.16.4
 # hadolint ignore=DL3006
 FROM ${GOLANG_IMAGE} as binary_tools_context
 

--- a/docker/build-tools/build-and-push.sh
+++ b/docker/build-tools/build-and-push.sh
@@ -23,6 +23,7 @@ export DOCKER_CLI_EXPERIMENTAL=enabled
 CONTAINER_CLI=${CONTAINER_CLI:-docker}
 # Use buildx for CI by default, allow overriding for old clients or other tools like podman
 CONTAINER_BUILDER=${CONTAINER_BUILDER:-"buildx build"}
+GOLANG_IMAGE=${GOLANG_IMAGE:-"golang:1.16.4"}
 HUB=${HUB:-gcr.io/istio-testing}
 DATE=$(date +%Y-%m-%dT%H-%M-%S)
 BRANCH=master
@@ -37,7 +38,7 @@ if [[ "${JOB_TYPE:-}" == "postsubmit" ]]; then
 fi
 
 # shellcheck disable=SC2086
-${CONTAINER_CLI} ${CONTAINER_BUILDER}  --target build_tools --build-arg "ISTIO_TOOLS_SHA=${SHA}" --build-arg "VERSION=${VERSION}" -t "${HUB}/build-tools:${VERSION}" -t "${HUB}/build-tools:${BRANCH}-latest" .
+${CONTAINER_CLI} ${CONTAINER_BUILDER}  --target build_tools --build-arg "GOLANG_IMAGE=${GOLANG_IMAGE}" --build-arg "ISTIO_TOOLS_SHA=${SHA}" --build-arg "VERSION=${VERSION}" -t "${HUB}/build-tools:${VERSION}" -t "${HUB}/build-tools:${BRANCH}-latest" .
 # shellcheck disable=SC2086
 ${CONTAINER_CLI} ${CONTAINER_BUILDER}  --build-arg "ISTIO_TOOLS_SHA=${SHA}" --build-arg "VERSION=${VERSION}" -t "${HUB}/build-tools-proxy:${VERSION}" -t "${HUB}/build-tools-proxy:${BRANCH}-latest" .
 # shellcheck disable=SC2086

--- a/docker/build-tools/build-and-push.sh
+++ b/docker/build-tools/build-and-push.sh
@@ -42,7 +42,7 @@ ${CONTAINER_CLI} ${CONTAINER_BUILDER}  --target build_tools --build-arg "GOLANG_
 # shellcheck disable=SC2086
 ${CONTAINER_CLI} ${CONTAINER_BUILDER}  --build-arg "GOLANG_IMAGE=${GOLANG_IMAGE}" --build-arg "ISTIO_TOOLS_SHA=${SHA}" --build-arg "VERSION=${VERSION}" -t "${HUB}/build-tools-proxy:${VERSION}" -t "${HUB}/build-tools-proxy:${BRANCH}-latest" .
 # shellcheck disable=SC2086
-${CONTAINER_CLI} ${CONTAINER_BUILDER}  --build-arg "GOLANG_IMAGE=${GOLANG_IMAGE}" --build-arg "ISTIO_TOOLS_SHA=${SHA}" --build-arg "VERSION=${VERSION}" -t "${HUB}/build-tools-centos:${VERSION}" -t "${HUB}/build-tools-centos:${BRANCH}-latest" -f Dockerfile.centos .
+${CONTAINER_CLI} ${CONTAINER_BUILDER}  --build-arg "ISTIO_TOOLS_SHA=${SHA}" --build-arg "VERSION=${VERSION}" -t "${HUB}/build-tools-centos:${VERSION}" -t "${HUB}/build-tools-centos:${BRANCH}-latest" -f Dockerfile.centos .
 
 if [[ -z "${DRY_RUN:-}" ]]; then
   ${CONTAINER_CLI} push "${HUB}/build-tools:${VERSION}"

--- a/docker/build-tools/build-and-push.sh
+++ b/docker/build-tools/build-and-push.sh
@@ -23,7 +23,7 @@ export DOCKER_CLI_EXPERIMENTAL=enabled
 CONTAINER_CLI=${CONTAINER_CLI:-docker}
 # Use buildx for CI by default, allow overriding for old clients or other tools like podman
 CONTAINER_BUILDER=${CONTAINER_BUILDER:-"buildx build"}
-GOLANG_IMAGE=${GOLANG_IMAGE:-"golang:1.16.4"}
+GOLANG_IMAGE=${GOLANG_IMAGE}
 HUB=${HUB:-gcr.io/istio-testing}
 DATE=$(date +%Y-%m-%dT%H-%M-%S)
 BRANCH=master
@@ -40,9 +40,9 @@ fi
 # shellcheck disable=SC2086
 ${CONTAINER_CLI} ${CONTAINER_BUILDER}  --target build_tools --build-arg "GOLANG_IMAGE=${GOLANG_IMAGE}" --build-arg "ISTIO_TOOLS_SHA=${SHA}" --build-arg "VERSION=${VERSION}" -t "${HUB}/build-tools:${VERSION}" -t "${HUB}/build-tools:${BRANCH}-latest" .
 # shellcheck disable=SC2086
-${CONTAINER_CLI} ${CONTAINER_BUILDER}  --build-arg "ISTIO_TOOLS_SHA=${SHA}" --build-arg "VERSION=${VERSION}" -t "${HUB}/build-tools-proxy:${VERSION}" -t "${HUB}/build-tools-proxy:${BRANCH}-latest" .
+${CONTAINER_CLI} ${CONTAINER_BUILDER}  --build-arg "GOLANG_IMAGE=${GOLANG_IMAGE}" --build-arg "ISTIO_TOOLS_SHA=${SHA}" --build-arg "VERSION=${VERSION}" -t "${HUB}/build-tools-proxy:${VERSION}" -t "${HUB}/build-tools-proxy:${BRANCH}-latest" .
 # shellcheck disable=SC2086
-${CONTAINER_CLI} ${CONTAINER_BUILDER}  --build-arg "ISTIO_TOOLS_SHA=${SHA}" --build-arg "VERSION=${VERSION}" -t "${HUB}/build-tools-centos:${VERSION}" -t "${HUB}/build-tools-centos:${BRANCH}-latest" -f Dockerfile.centos .
+${CONTAINER_CLI} ${CONTAINER_BUILDER}  --build-arg "GOLANG_IMAGE=${GOLANG_IMAGE}" --build-arg "ISTIO_TOOLS_SHA=${SHA}" --build-arg "VERSION=${VERSION}" -t "${HUB}/build-tools-centos:${VERSION}" -t "${HUB}/build-tools-centos:${BRANCH}-latest" -f Dockerfile.centos .
 
 if [[ -z "${DRY_RUN:-}" ]]; then
   ${CONTAINER_CLI} push "${HUB}/build-tools:${VERSION}"

--- a/docker/build-tools/build-and-push.sh
+++ b/docker/build-tools/build-and-push.sh
@@ -23,7 +23,7 @@ export DOCKER_CLI_EXPERIMENTAL=enabled
 CONTAINER_CLI=${CONTAINER_CLI:-docker}
 # Use buildx for CI by default, allow overriding for old clients or other tools like podman
 CONTAINER_BUILDER=${CONTAINER_BUILDER:-"buildx build"}
-GOLANG_IMAGE=${GOLANG_IMAGE}
+GOLANG_IMAGE=${GOLANG_IMAGE:-"golang:1.16.4"}
 HUB=${HUB:-gcr.io/istio-testing}
 DATE=$(date +%Y-%m-%dT%H-%M-%S)
 BRANCH=master


### PR DESCRIPTION
The Dockerfile provides an arg GOLANG_IMAGE, which can be used to specify a custom Golang image, but in practice you cannot override it through the integration points(docker/build-tools/build-and-push.sh), which is used by make containers-test. This adds the ability to override the image of Golang used.