### PR TITLE
Revert "bump perf dashboard page to 1.10"

### DIFF
--- a/perf_dashboard/docker-compose.yml
+++ b/perf_dashboard/docker-compose.yml
@@ -8,6 +8,6 @@ services:
     volumes:
       - .:/perf_dashboard
     environment:
-      - CUR_RELEASE=release-1.10
+      - CUR_RELEASE=release-1.9
     ports:
       - "8000:8000"

--- a/perf_dashboard/dockerfile
+++ b/perf_dashboard/dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update \
 ENV PYTHONUNBUFFERED 1
 
 # Set environment variable for current release
-ENV CUR_RELEASE=release-1.10
+ENV CUR_RELEASE=release-1.9
 # Create root directory for our project in the container
 RUN mkdir /perf_dashboard
 


### PR DESCRIPTION
Reverts istio/tools#1528 

Revert and check if perf dashboard can fetch release build images. https://github.com/istio/istio/issues/33213