### PR TITLE
build: install python3.8 in proxy build image

### DIFF
--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -691,6 +691,9 @@ RUN ldconfig
 COPY proxy-tsan-instrumented-libcxx.sh proxy-tsan-instrumented-libcxx.sh
 RUN ./proxy-tsan-instrumented-libcxx.sh
 
+COPY install-python-3.8.sh install-python-3.8.sh
+RUN ./install-python-3.8.sh
+
 # su-exec is used in place of complex sudo setup operations
 RUN chmod u+sx /usr/bin/su-exec
 

--- a/docker/build-tools/install-python-3.8.sh
+++ b/docker/build-tools/install-python-3.8.sh
@@ -21,5 +21,5 @@ apt-get install -y make build-essential libssl-dev zlib1g-dev \
         libncurses5-dev libncursesw5-dev xz-utils tk-dev
 wget https://www.python.org/ftp/python/3.8.10/Python-3.8.10.tgz
 tar zxvf Python-3.8.10.tgz
-cd Python-3.8.10 && ./configure --with-ensurepip=install && make -j 16 && make install && ln -s  /usr/local/bin/python3 /usr/bin/python
+cd Python-3.8.10 && ./configure --with-ensurepip=install && make -j 16 && make install
 cd .. && rm -rf ./Python-3.8.10 && rm -rf ./Python-3.8.10.tgz

--- a/docker/build-tools/install-python-3.8.sh
+++ b/docker/build-tools/install-python-3.8.sh
@@ -1,4 +1,20 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+# Copyright Istio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eux
 
 apt-get install -y make build-essential libssl-dev zlib1g-dev \
         libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm \

--- a/docker/build-tools/install-python-3.8.sh
+++ b/docker/build-tools/install-python-3.8.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+apt-get install -y make build-essential libssl-dev zlib1g-dev \
+        libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm \
+        libncurses5-dev libncursesw5-dev xz-utils tk-dev
+wget https://www.python.org/ftp/python/3.8.10/Python-3.8.10.tgz
+tar zxvf Python-3.8.10.tgz
+cd Python-3.8.10 && ./configure --with-ensurepip=install && make -j 16 && make install && ln -s  /usr/local/bin/python3 /usr/bin/python
+cd .. && rm -rf ./Python-3.8.10 && rm -rf ./Python-3.8.10.tgz


### PR DESCRIPTION
Python 3.8+ is required to build proxy envoy.

The latest python3 in the base proxy build image ubuntu:xenial is python3.5 so we need to build python3.8 from source code.

Fix https://github.com/istio/test-infra/issues/3366
Signed-off-by: Yuchen Dai <lambdai@google.com>