### PR TITLE
Update LLVM/clang to 10.0 for centos

### DIFF
--- a/docker/build-tools/Dockerfile.centos
+++ b/docker/build-tools/Dockerfile.centos
@@ -29,9 +29,9 @@ RUN echo "/opt/rh/httpd24/root/usr/lib64" > /etc/ld.so.conf.d/httpd24.conf && \
 ADD https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-265.0.0-linux-x86_64.tar.gz /tmp
 RUN tar -xzvf "/tmp/google-cloud-sdk-265.0.0-linux-x86_64.tar.gz" -C /usr/local
 
-ENV LLVM_RELEASE=clang+llvm-9.0.0-x86_64-linux-centos7
+ENV LLVM_RELEASE=clang+llvm-10.0.0-x86_64-linux-centos7
 # hadolint ignore=DL4006
-RUN curl -fsSL --output ${LLVM_RELEASE}.tar.xz http://storage.googleapis.com/getenvoy-package/clang-toolchain/0e9d364b7199f3aaecbaf914cea3d9df4e97b850/${LLVM_RELEASE}.tar.xz && \
+RUN curl -fsSL --output ${LLVM_RELEASE}.tar.xz http://storage.googleapis.com/getenvoy-package/clang-toolchain/a79bbfea57c05b5cd2708ab432192be0e187e074/${LLVM_RELEASE}.tar.xz && \
     tar Jxf ${LLVM_RELEASE}.tar.xz && \
     mv ./${LLVM_RELEASE} /opt/llvm && \
     chown -R root:root /opt/llvm && \


### PR DESCRIPTION
Try to see if compiler update could unblock envoy sha update https://github.com/istio/proxy/pull/3387