### PR TITLE
Skip unsupported KPT for arm

### DIFF
--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -270,8 +270,11 @@ RUN set -eux; \
     esac; \
     \
     wget "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/${GCLOUD_TAR_FILE}"; \
-    tar -xzvf ./${GCLOUD_TAR_FILE} -C ${OUTDIR}/usr/local && rm ${GCLOUD_TAR_FILE}; \
-    ${OUTDIR}/usr/local/google-cloud-sdk/bin/gcloud components install beta kpt --quiet; \
+    tar -xzf ./${GCLOUD_TAR_FILE} -C ${OUTDIR}/usr/local && rm ${GCLOUD_TAR_FILE}; \
+    case $(uname -m) in \
+        x86_64) ${OUTDIR}/usr/local/google-cloud-sdk/bin/gcloud components install beta kpt --quiet;; \
+        *) echo "kpt is not supported";; \
+    esac; \
     rm -rf /usr/local/google-cloud-sdk/.install/.backup
 
 # Cleanup stuff we don't need in the final image


### PR DESCRIPTION
Its not really used much anyways, so we can skip for now. If needed we can find another way to fetch it in the future