### PR TITLE
downgrade ubuntu to bionic for arm64 build-tools-proxy to bump glibc version

### DIFF
--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -597,7 +597,7 @@ ENTRYPOINT ["/usr/local/bin/docker-entrypoint"]
 ##############
 
 FROM ubuntu:xenial AS clang_context_amd64
-FROM ubuntu:focal AS clang_context_arm64
+FROM ubuntu:bionic AS clang_context_arm64
 # hadolint ignore=DL3006
 FROM clang_context_${TARGETARCH} AS clang_context
 
@@ -663,7 +663,7 @@ RUN set -eux; \
 ###########
 
 FROM ubuntu:xenial AS bazel_context_amd64
-FROM ubuntu:focal AS bazel_context_arm64
+FROM ubuntu:bionic AS bazel_context_arm64
 # hadolint ignore=DL3006
 FROM bazel_context_${TARGETARCH} AS bazel_context
 
@@ -691,8 +691,8 @@ RUN mv ${BAZELISK_BIN} /usr/local/bin/bazel
 
 FROM ubuntu:xenial AS build_env_proxy_amd64
 ENV UBUNTU_RELEASE_CODE_NAME=xenial
-FROM ubuntu:focal AS build_env_proxy_arm64
-ENV UBUNTU_RELEASE_CODE_NAME=focal
+FROM ubuntu:bionic AS build_env_proxy_arm64
+ENV UBUNTU_RELEASE_CODE_NAME=bionic
 # hadolint ignore=DL3006
 FROM build_env_proxy_${TARGETARCH}
 
@@ -773,8 +773,16 @@ RUN chmod +x /usr/local/bin/entrypoint
 
 # CMake
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN curl -fsSL https://apt.kitware.com/keys/kitware-archive-latest.asc | apt-key add -
-RUN apt-add-repository "deb https://apt.kitware.com/ubuntu/ ${UBUNTU_RELEASE_CODE_NAME} main"
+# ubuntu 18.04 without arm64 version see https://apt.kitware.com/
+RUN set -eux; \
+    \
+    case $(uname -m) in \
+        x86_64) \
+            curl -fsSL https://apt.kitware.com/keys/kitware-archive-latest.asc | apt-key add - ; \
+            apt-add-repository "deb https://apt.kitware.com/ubuntu/ ${UBUNTU_RELEASE_CODE_NAME} main"; \
+            ;; \
+        *) echo "skip" ;; \
+    esac;
 
 # binary dependencies to build envoy at v1.12.0
 # https://github.com/envoyproxy/envoy/blob/v1.12.0/bazel/README.md


### PR DESCRIPTION
Signed-off-by: Morlay <morlay.null@gmail.com>

Compiled envoy on `ubuntu:focal`, required glibc version is too high for `distroless`.

* `2.28` on `istio-release/iptables`, https://github.com/istio/distroless/blob/iptables/package_bundle_arm64_debian10.versions#L10
* `2.31` on `ubuntu:focal` https://packages.ubuntu.com/focal/libc6-dev
* `2.27` on `ubuntu:bionic` https://packages.ubuntu.com/bionic/libc6-dev

```
$ docker run --entrypoint /usr/local/bin/envoy --platform=linux/arm64 docker.io/querycapistio/proxyv2:master-distroless --version 
/usr/local/bin/envoy: /lib/aarch64-linux-gnu/libm.so.6: version `GLIBC_2.29' not found (required by /usr/local/bin/envoy)
/usr/local/bin/envoy: /lib/aarch64-linux-gnu/libpthread.so.0: version `GLIBC_2.30' not found (required by /usr/local/bin/envoy)
```

```
$ docker run --entrypoint /usr/local/bin/envoy --platform=linux/arm64 docker.io/querycapistio/proxyv2:master --version  

/usr/local/bin/envoy  version: bf543dbf89b88b695f5b928672a32349b4fdaf58/1.19.0-dev/Clean/RELEASE/BoringSSL
```

`default` works well.

<del> **Don't merge this until i finished testings** </del>

**Updates**:

compiled `envoy`  on `ubuntu:bionic`  works well for both

```shell
$ docker run --entrypoint /usr/local/bin/envoy --platform=linux/arm64 docker.io/querycapistio/proxyv2:master-distroless --version 

/usr/local/bin/envoy  version: bf543dbf89b88b695f5b928672a32349b4fdaf58/1.19.0-dev/Clean/RELEASE/BoringSSL

$ docker run --entrypoint /usr/local/bin/envoy --platform=linux/arm64 docker.io/querycapistio/proxyv2:master --version  

/usr/local/bin/envoy  version: bf543dbf89b88b695f5b928672a32349b4fdaf58/1.19.0-dev/Clean/RELEASE/BoringSSL
```

https://github.com/querycap/istio/actions/runs/1030432279

We could build multi-arch images next release (if PROW for aarch64 ready)
Now could be easy to custom build with same source codes 🥳 https://github.com/querycap/istio/blob/build-origin/Makefile
