### PR TITLE
Use go 1.16.6 in the actual build script

### DIFF
--- a/docker/build-tools/build-and-push.sh
+++ b/docker/build-tools/build-and-push.sh
@@ -23,7 +23,7 @@ export DOCKER_CLI_EXPERIMENTAL=enabled
 CONTAINER_CLI=${CONTAINER_CLI:-docker}
 # Use buildx for CI by default, allow overriding for old clients or other tools like podman
 CONTAINER_BUILDER=${CONTAINER_BUILDER:-"buildx build"}
-GOLANG_IMAGE=${GOLANG_IMAGE:-"golang:1.16.4"}
+GOLANG_IMAGE=${GOLANG_IMAGE:-"golang:1.16.6"}
 HUB=${HUB:-gcr.io/istio-testing}
 DATE=$(date +%Y-%m-%dT%H-%M-%S)
 BRANCH=master


### PR DESCRIPTION
```
$ docker run --rm -it gcr.io/istio-testing/pilot:latest version
version.BuildInfo{Version:"1.11-alpha.e4f32d629145a99e0afc67808fee4357c37927a3", GitRevision:"e4f32d629145a99e0afc67808fee4357c37927a3", GolangVersion:"go1.16.4", BuildStatus:"Clean", GitTag:"1.11-alpha.e4f32d629145a99e0afc67808fee4357c37927a3"}
```