### PR TITLE
Replace KUBE_DNS config with DNS_SVC and DNS_POD

### DIFF
--- a/perf/benchmark/setup_test.sh
+++ b/perf/benchmark/setup_test.sh
@@ -26,7 +26,8 @@ cd "${WD}"
 NAMESPACE="${NAMESPACE:-twopods}"
 LOAD_GEN_TYPE="${LOAD_GEN_TYPE:-fortio}"
 DNS_DOMAIN=${DNS_DOMAIN:?"DNS_DOMAIN should be like v104.qualistio.org or local"}
-KUBE_DNS="${KUBE_DNS:-kube-dns}"
+DNS_POD="${DNS_POD:-kube-dns}"
+DNS_SVC="${DNS_SVC:-kube-dns}"
 TMPDIR=${TMPDIR:-${WD}/tmp}
 RBAC_ENABLED="false"
 SERVER_REPLICA="${SERVER_REPLICA:-1}"
@@ -40,11 +41,11 @@ mkdir -p "${TMPDIR}"
 
 # Get pod ip range, there must be a better way, but this works.
 function pod_ip_range() {
-    kubectl get pods --namespace kube-system -o wide | grep "${KUBE_DNS}" | awk '{print $6}'|head -1 | awk -F '.' '{printf "%s.%s.0.0/16\n", $1, $2}'
+    kubectl get pods --namespace kube-system -o wide | grep "${DNS_POD}" | awk '{print $6}'|head -1 | awk -F '.' '{printf "%s.%s.0.0/16\n", $1, $2}'
 }
 
 function svc_ip_range() {
-    kubectl -n kube-system get svc "${KUBE_DNS}" --no-headers | awk '{print $3}' | awk -F '.' '{printf "%s.%s.0.0/16\n", $1, $2}'
+    kubectl -n kube-system get svc "${DNS_SVC}" --no-headers | awk '{print $3}' | awk -F '.' '{printf "%s.%s.0.0/16\n", $1, $2}'
 }
 
 function run_test() {


### PR DESCRIPTION
On some kubernetes clusters, dns service and dns pod are not always the same.
For example, the pod is running coredns but the service name remains kube-dns, thus the code will fail to get both pod and svc ip ranges.
To use separate pod and svc configs could help users correctly configure their pod and svc names.