### PR TITLE
Add Hadolint support for arm64 base image build

### DIFF
--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -21,11 +21,39 @@
 # We pin versions of stuff we install. Modify the various XXX_VERSION variables within the individual build contexts
 # in order to control these versions.
 
+
+ARG GOLANG_IMAGE=golang:1.16.6
+
+FROM ubuntu:focal as hadolint_tools_builder
+
+ENV OUTDIR=/out
+ENV LANG=C.UTF-8
+ENV HADOLINT_VERSION=1.22.1
+
+RUN mkdir -p ${OUTDIR}/usr/bin
+WORKDIR /root
+
+# Update distro and install dependencies
+# hadolint ignore=DL3008
+COPY ./hadolint-build-src.sh /root
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+       wget
+
+#Build from src for arm64(aarch64), but just pull binary directly for amd64(x86_64)
+RUN if [ X"$(uname -m)" = X"aarch64" ]; then \
+        chmod +x /root/hadolint-build-src.sh && \
+        /root/hadolint-build-src.sh && \
+        mv ~/.local/bin/hadolint ${OUTDIR}/usr/bin; \
+    else \
+        wget --no-check-certificate -O ${OUTDIR}/usr/bin/hadolint \
+          https://github.com/hadolint/hadolint/releases/download/v${HADOLINT_VERSION}/hadolint-Linux-x86_64; \
+    fi
+
 ################
 # Binary tools
 ################
 
-ARG GOLANG_IMAGE=golang:1.16.6
 # hadolint ignore=DL3006
 FROM ${GOLANG_IMAGE} as binary_tools_context
 # TARGETARCH is an automatic platform ARG enabled by Docker BuildKit.
@@ -205,7 +233,7 @@ RUN tar -xJf "/tmp/shellcheck-${SHELLCHECK_VERSION}.linux.$(uname -m).tar.xz" -C
 RUN mv /tmp/shellcheck-${SHELLCHECK_VERSION}/shellcheck ${OUTDIR}/usr/bin
 
 # Hadolint linter
-ADD https://github.com/hadolint/hadolint/releases/download/${HADOLINT_VERSION}/hadolint-Linux-x86_64 ${OUTDIR}/usr/bin/hadolint
+COPY --from=hadolint_tools_builder ${OUTDIR}/usr/bin/hadolint ${OUTDIR}/usr/bin/hadolint
 RUN chmod 555 ${OUTDIR}/usr/bin/hadolint
 
 # Hugo static site generator

--- a/docker/build-tools/hadolint-build-src.sh
+++ b/docker/build-tools/hadolint-build-src.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+set -eux
+
+export DEBIAN_FRONTEND=noninteractive; \
+     ln -fs /usr/share/zoneinfo/America/New_York /etc/localtime; \
+     DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y tzdata && dpkg-reconfigure --frontend noninteractive tzdata
+
+DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y --no-install-recommends \
+    apt-transport-https \
+    build-essential \
+    ca-certificates \
+    curl \
+    gnupg2 \
+    software-properties-common \
+    unzip \
+    xz-utils \
+    numactl \
+    libnuma1 \
+    libnuma-dev \
+    libc6-dev \
+    clang-9 \
+    llvm-9 \
+    libtinfo-dev \
+    libtinfo6 \
+    libtinfo5 \
+    llvm-6.0-dev \
+    llvm \
+    wget
+
+wget -nv https://github.com/hadolint/hadolint/archive/refs/tags/v${HADOLINT_VERSION}.tar.gz
+tar xvf v${HADOLINT_VERSION}.tar.gz
+
+wget -nv https://github.com/commercialhaskell/stack/releases/download/v2.7.1/stack-2.7.1-linux-aarch64.tar.gz; \
+    tar xvf stack-2.7.1-linux-aarch64.tar.gz; \
+    cp ./stack-2.7.1-linux-aarch64/stack /usr/bin
+
+cd hadolint-${HADOLINT_VERSION}; \
+    stack init --force; \
+    stack setup; \
+    stack install


### PR DESCRIPTION
Now it still lacks the Hadolint binary for arm64 build
of the base-image, and we add a source-based building
for it when do the image building for arm64, which is
then copied to the target image.
The source building script for Hadolint is also given.

For that of x86_64, it still downloads directly from
the website which is the same as original.

Signed-off-by: trevor tao <trevor.tao@arm.com>