### PR TITLE
Support zero remotes

### DIFF
--- a/cmd/gen-release-notes/main.go
+++ b/cmd/gen-release-notes/main.go
@@ -58,6 +58,17 @@ func main() {
 	flag.StringVar(&newRelease, "newRelease", "x.y.z", "new release")
 	flag.Parse()
 
+	// Prow, at the time of writing this, does not use Git clone, meaning that there is no remote for the pull request. Generate a URL instead if we're using Prow.
+	RepoOwner := os.Getenv("REPO_OWNER")
+	RepoName := os.Getenv("REPO_NAME")
+	if RepoOwner != "" && RepoName != "" {
+		pullRequest = fmt.Sprintf("https://github.com/%s/%s/pull/%s", RepoOwner, RepoName, pullRequest)
+	}
+
+	if len(notesDirs) == 0 {
+		notesDirs = []string{"."}
+	}
+
 	var releaseNotes []Note
 	for _, notesDir := range notesDirs {
 		var releaseNoteFiles []string


### PR DESCRIPTION
Prow doesn't create remotes as can be seen here -- https://storage.googleapis.com/istio-prow/pr-logs/pull/istio_istio/34417/release-notes_istio/1420854593889243136/clone-records.json

This causes issues with GH as it expects to have a remote to read from. Instead, generate a url if an owner and repo are provided.


```
 REPO_OWNER=istio REPO_NAME=istio /istio/tools/cmd/gen-release-notes/gen-release-notes --templates  /istio/tools/cmd/gen-release-notes/templates --pullRequest 33023
Looking for release notes in ..
Executing: cd .; gh pr view https://github.com/istio/istio/pull/33023 --json files
{"files":[{"path":"galley/pkg/config/analysis/analyzers/all.go","additions":2,"deletions":0},{"path":"galley/pkg/config/analysis/analyzers/analyzers_test.go","additions":23,"deletions":0},{"path":"galley/pkg/config/analysis/analyzers/namespaceconflict/namespaceselector.go","additions":237,"deletions":0},{"path":"galley/pkg/config/analysis/analyzers/testdata/namespaceconflict-peerauth-conflicts.yaml","additions":70,"deletions":0},{"path":"galley/pkg/config/analysis/analyzers/testdata/namespaceconflict-reqauth-conflicts.yaml","additions":62,"deletions":0},{"path":"galley/pkg/config/analysis/msg/messages.gen.go","additions":17,"deletions":0},{"path":"galley/pkg/config/analysis/msg/messages.yaml","additions":16,"deletions":0},{"path":"pkg/config/schema/metadata.gen.go","additions":2,"deletions":0},{"path":"pkg/config/schema/metadata.yaml","additions":2,"deletions":0},{"path":"releasenotes/notes/30626.yaml","additions":8,"deletions":0},{"path":"tests/integration/README.md","additions":2,"deletions":1}]}

Found 1 files.

Parsing release notes
found 0 upgrade notes, 1 release notes, and 0 security notes in releasenotes/notes/30626.yaml

Looking for markdown templates in /istio/tools/cmd/gen-release-notes/templates.
Found 3 files.

Processing /istio/tools/cmd/gen-release-notes/templates/releaseNotes.md
Processed template <!-- upgradeNotes -->. Kind:  Area: action: type:upgradeNotes
Wrote markdown to upgradeNotes.md
Wrote markdown to upgradeNotes.md.html

/var/folders/pm/78xbx3j91b1gjdbp4jqx5gyw0000gp/T/tmp.IovJM0u8/istio namespace-analyzer-30626*
❯ /istio/tools/cmd/gen-release-notes/gen-release-notes --templates /istio/tools/cmd/gen-release-notes/templates --pullRequest 33023
Looking for release notes in ..
Executing: cd .; gh pr view 33023 --json files
could not determine base repo: no git remotes found

failed to list files: received error running GH: exit status 1

```

```
/istio/tools/cmd/gen-release-notes/gen-release-notes --templates /istio/tools/cmd/gen-release-notes/templates --pullRequest 33023
Looking for release notes in ..
Executing: cd .; gh pr view 33023 --json files
could not determine base repo: no git remotes found

failed to list files: received error running GH: exit status 1
```