### PR TITLE
set container of kubectl to 'uncaptured'

### DIFF
--- a/perf/benchmark/runner/runner.py
+++ b/perf/benchmark/runner/runner.py
@@ -201,7 +201,7 @@ class Fortio:
         print('-------------- Running in {sidecar_mode} mode --------------'.format(sidecar_mode=sidecar_mode))
         if load_gen_type == "fortio":
             p = multiprocessing.Process(target=kubectl_exec,
-                                        args=[self.client.name, sidecar_mode_func(load_gen_cmd, sidecar_mode)])
+                                        args=[self.client.name, sidecar_mode_func(load_gen_cmd, sidecar_mode), run_command, "uncaptured"])
             p.start()
             processes.append(p)
         elif load_gen_type == "nighthawk":


### PR DESCRIPTION
When trying the perf/benchmark, I met a problem below.
The pods `fortioclient-54894c5758-htdgl` default container is `captured`, so the kubectl command will try to run fortio in `captured` container.
Here is the log.

```
(benchmark) root@bbf4b2393670:~/tools-master/perf/benchmark# python runner/runner.py --conn 10  --qps 100,500,1000,2000,4000 --duration 240 --load_gen_type=fortio --telemetry_mode=v2-nullvm --perf=true

-------------- Running in both mode --------------
ed78b58c_qps_100_c_10_1024_v2-nullvmbothsidecars_perf.data
kubectl --namespace twopods-istio exec fortioclient-54894c5758-htdgl  -- fortio load  -jitter=False -c 10 -qps 100 -t 240s -a -r 0.001   -httpbufferkb=128 -labels ed78b58c_qps_100_c_10_1024_v2-nullvm_both http://fortioserver:8080/echo?size=1024
Defaulting container name to captured.
Use 'kubectl describe pod/fortioclient-54894c5758-htdgl -n twopods-istio' to see all of the containers in this pod.
OCI runtime exec failed: exec failed: container_linux.go:348: starting container process caused "exec: \"fortio\": executable file not found in $PATH": unknown
command terminated with exit code 126
```

Maybe it is better to specify the container to run by kubectl, thus we won't exec fortio in wrong container.

