### PR TITLE
Bump golang to 1.17

### DIFF
--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -25,7 +25,7 @@
 # Binary tools
 ################
 
-ARG GOLANG_IMAGE=golang:1.16.7
+ARG GOLANG_IMAGE=golang:1.17
 # hadolint ignore=DL3006
 FROM ${GOLANG_IMAGE} as binary_tools_context
 # TARGETARCH is an automatic platform ARG enabled by Docker BuildKit.


### PR DESCRIPTION
Ref: https://blog.golang.org/go1.17

There are few changes in go module side, if we consider Istio master to be on 1.17.
https://golang.org/doc/go1.17#go-command