### PR TITLE
Allow specifying additional docker buildx arguments

### DIFF
--- a/docker/build-tools/build-and-push.sh
+++ b/docker/build-tools/build-and-push.sh
@@ -36,10 +36,10 @@ if [[ "${JOB_TYPE:-}" == "postsubmit" ]]; then
   SHA=$(git rev-parse ${BRANCH})
 fi
 
-ADDITIONAL_BUILD_ARGS=
+ADDITIONAL_BUILD_ARGS=${ADDITIONAL_BUILD_ARGS:-}
 # Allow overriding of the GOLANG_IMAGE by having it set in the environment
 if [[ -n "${GOLANG_IMAGE:-}" ]]; then
-  ADDITIONAL_BUILD_ARGS="--build-arg GOLANG_IMAGE=${GOLANG_IMAGE}"
+  ADDITIONAL_BUILD_ARGS+=" --build-arg GOLANG_IMAGE=${GOLANG_IMAGE}"
 fi
 
 # shellcheck disable=SC2086


### PR DESCRIPTION
When run locally, I receive a message:
```
level=warning msg="No output specified for docker-container driver. Build result will only remain in the build cache. To push result image into registry use --push or to load image into docker use --load"
```
which later fails when trying to push an image with:
```
An image does not exist locally
```

I do not see these same initial message in the prow output, so possibly something in the `docker buildx` on a Mac.

With this change I can set `ADDITIONAL_BUILD_ARGS=-o type=docker` and run the script and images are created. It will also add 