### PR TITLE
Changes to allow build-and-push.sh to create images on a Mac

### DIFF
--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -695,7 +695,7 @@ ENV UBUNTU_RELEASE_CODE_NAME=xenial
 FROM ubuntu:bionic AS build_env_proxy_arm64
 ENV UBUNTU_RELEASE_CODE_NAME=bionic
 # hadolint ignore=DL3006
-FROM build_env_proxy_${TARGETARCH}
+FROM build_env_proxy_${TARGETARCH} AS build_env_proxy
 
 # Version from build arguments
 ARG VERSION

--- a/docker/build-tools/build-and-push.sh
+++ b/docker/build-tools/build-and-push.sh
@@ -36,6 +36,8 @@ if [[ "${JOB_TYPE:-}" == "postsubmit" ]]; then
   SHA=$(git rev-parse ${BRANCH})
 fi
 
+# To generate Docker images on a Mac, setting ADDITIONAL_BUILD_ARGS=--load will result
+# in them showing up in `docker images` after running the script.
 ADDITIONAL_BUILD_ARGS=${ADDITIONAL_BUILD_ARGS:-}
 # Allow overriding of the GOLANG_IMAGE by having it set in the environment
 if [[ -n "${GOLANG_IMAGE:-}" ]]; then
@@ -43,12 +45,12 @@ if [[ -n "${GOLANG_IMAGE:-}" ]]; then
 fi
 
 # shellcheck disable=SC2086
-${CONTAINER_CLI} ${CONTAINER_BUILDER}  --target build_tools ${ADDITIONAL_BUILD_ARGS} --build-arg "ISTIO_TOOLS_SHA=${SHA}" --build-arg "VERSION=${VERSION}" -t "${HUB}/build-tools:${VERSION}" -t "${HUB}/build-tools:${BRANCH}-latest" .
+${CONTAINER_CLI} ${CONTAINER_BUILDER} --target build_tools ${ADDITIONAL_BUILD_ARGS} --build-arg "ISTIO_TOOLS_SHA=${SHA}" --build-arg "VERSION=${VERSION}" -t "${HUB}/build-tools:${VERSION}" -t "${HUB}/build-tools:${BRANCH}-latest" .
 # shellcheck disable=SC2086
-${CONTAINER_CLI} ${CONTAINER_BUILDER} ${ADDITIONAL_BUILD_ARGS} --build-arg "ISTIO_TOOLS_SHA=${SHA}" --build-arg "VERSION=${VERSION}" -t "${HUB}/build-tools-proxy:${VERSION}" -t "${HUB}/build-tools-proxy:${BRANCH}-latest" .
+${CONTAINER_CLI} ${CONTAINER_BUILDER} --target build_env_proxy ${ADDITIONAL_BUILD_ARGS} --build-arg "ISTIO_TOOLS_SHA=${SHA}" --build-arg "VERSION=${VERSION}" -t "${HUB}/build-tools-proxy:${VERSION}" -t "${HUB}/build-tools-proxy:${BRANCH}-latest" .
 if [[ "$(uname -m)" == "x86_64" ]]; then
 # shellcheck disable=SC2086
-${CONTAINER_CLI} ${CONTAINER_BUILDER}  --build-arg "ISTIO_TOOLS_SHA=${SHA}" --build-arg "VERSION=${VERSION}" -t "${HUB}/build-tools-centos:${VERSION}" -t "${HUB}/build-tools-centos:${BRANCH}-latest" -f Dockerfile.centos .
+${CONTAINER_CLI} ${CONTAINER_BUILDER} ${ADDITIONAL_BUILD_ARGS} --build-arg "ISTIO_TOOLS_SHA=${SHA}" --build-arg "VERSION=${VERSION}" -t "${HUB}/build-tools-centos:${VERSION}" -t "${HUB}/build-tools-centos:${BRANCH}-latest" -f Dockerfile.centos .
 fi
 
 if [[ -z "${DRY_RUN:-}" ]]; then


### PR DESCRIPTION
Final changes from testing build-and-push.sh on a Mac so that all images are in `docker images` after running the script.

Changes include:

- Naming the final Dockerfile target as `build_envoy_proxy` similar to how it's done for prior targets allowing it to be added to the script.
- Specifying the above target on the build-tools-proxy build instruction
- Add the missing ADDITIONAL_BUILD_ARGS to the build instruction for build-tools-centos so its image is created .

Confirmed by running `make containers-test`. Before the additions, one would see:
```
WARN[0000] No output specified for docker-container driver. Build result will only remain in the build cache. To push result image into registry use --push or to load image into docker use --load
```

With this PR and `export ADDITIONAL_BUILD_ARGS=--load` (the export is only needed on a Mac (or if the WARN is shown)), the images are now shown and `make containers` will push the images.
