### PR TITLE
fixed issues for generation of releasenotes

### DIFF
--- a/cmd/gen-release-notes/README.md
+++ b/cmd/gen-release-notes/README.md
@@ -12,7 +12,7 @@ single release notes file.
 If both Istio and tools are cloned in the same directory and you want to generate release notes for changes in the `release-1.7` branch since the `1.7.0` tag was created, you could run the following from the `tools/cmd/gen-release-notes` directory:
 
 ```bash
-pushd ../../../istio/releasenotes/notes
+pushd ../../../istio
 git checkout release-1.7
 popd
 

--- a/cmd/gen-release-notes/main.go
+++ b/cmd/gen-release-notes/main.go
@@ -95,7 +95,7 @@ func main() {
 		fmt.Printf("Found %d files.\n\n", len(releaseNoteFiles))
 
 		fmt.Printf("Parsing release notes\n")
-		releaseNotesEntries, err := parseReleaseNotesFiles(notesDir, releaseNoteFiles)
+		releaseNotesEntries, err := parseReleaseNotesFiles(filepath.Join(notesDir, releaseNotesDir), releaseNoteFiles)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Unable to read release notes: %s\n", err.Error())
 			os.Exit(1)


### PR DESCRIPTION
Besides, there is a bug for generation of release notes.  It's inconsistent for finding and using release note yaml file for flag `--notes`