### PR TITLE
Update gh to latest 2.0.0. Also add less as a dependency.

### DIFF
--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -42,7 +42,7 @@ ENV GOCOVMERGE_VERSION=b5bfa59ec0adc420475f97f89b58045c721d761c
 ENV GOGO_PROTOBUF_VERSION=v1.3.2
 ENV GOIMPORTS_VERSION=v0.1.0
 ENV BENCHSTAT_VERSION=9c9101da8316
-ENV GH_VERSION=1.12.1
+ENV GH_VERSION=2.0.0
 ENV GOLANG_PROTOBUF_VERSION=v1.3.5
 # When updating the golangci version, you may want to update the common-files config/.golangci* files as well.
 ENV GOLANGCI_LINT_VERSION=v1.38.0
@@ -432,7 +432,7 @@ ENV TRIVY_VERSION=0.18.3
 
 ENV OUTDIR=/out
 
-# required for binary tools: ca-certificates, gcc, libc-dev, git, iptables, libltdl7
+# required for binary tools: ca-certificates, gcc, libc-dev, git, iptables, libltdl7, less
 # required for general build: make, wget, curl, ssh, rpm
 # required for ruby: libcurl4-openssl-dev
 # required for python: python3, pkg-config
@@ -451,6 +451,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libltdl7 \
     libc-dev \
     libcurl4-openssl-dev \
+    less \
     make \
     pkg-config \
     python3 \


### PR DESCRIPTION
The release notes test is failing in the 1.10 branch, see https://github.com/istio/istio/pull/34962.

Testing shows that gh 1.9.2 (run the 1.10 branch) does not return any files:
```
 ./gh pr view https://github.com/istio/istio/pull/34969 --json files
{
  "files": null
}


A new release of gh is available: 1.9.2 → v2.0.0
```
gh 1.12.1 (later releases):
```
 ./gh pr view https://github.com/istio/istio/pull/34969 --json files                                                                       ✔  12:13:13
{
  "files": [
    {
      "path": "manifests/charts/gateways/istio-egress/templates/serviceaccount.yaml",
      "additions": 4,
      "deletions": 0
    },
    {
      "path": "manifests/charts/gateways/istio-egress/values.yaml",
      "additions": 5,
      "deletions": 0
    },
    {
      "path": "manifests/charts/gateways/istio-ingress/templates/serviceaccount.yaml",
      "additions": 4,
      "deletions": 0
    },
    {
      "path": "manifests/charts/gateways/istio-ingress/values.yaml",
      "additions": 4,
      "deletions": 0
    },
    {
      "path": "operator/pkg/apis/istio/v1alpha1/values_types.pb.go",
      "additions": 398,
      "deletions": 340
    },
    {
      "path": "operator/pkg/apis/istio/v1alpha1/values_types.proto",
      "additions": 11,
      "deletions": 2
    },
    {
      "path": "releasenotes/notes/34969.yaml",
      "additions": 16,
      "deletions": 0
    }
  ]
}
```
I also noted that trying to run the `gh` command in a `make shell` fails:
```
build-tools:/work$ gh pr view https://github.com/istio/istio/pull/34969 --json files
exec: "less": executable file not found in $PATH
```
