### PR TITLE
Docker scan shows OS has outdated packages

### DIFF
--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -93,7 +93,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     gnupg2 \
     software-properties-common \
     unzip \
-    xz-utils
+    xz-utils \
+    && apt-get upgrade -y
 
 # Install protoc
 RUN set -eux; \


### PR DESCRIPTION
I'm not sure if this is intentional, but `upgrade` and/or `full-upgrade` is not run when the image is created resulting in docker scan reporting OS vulnerabilities. There should be no security risk, but it's a good practice to upgrade OS packages.