### PR TITLE
Always enable ipv6 sysctl

### DIFF
--- a/docker/build-tools/prow-entrypoint.sh
+++ b/docker/build-tools/prow-entrypoint.sh
@@ -23,14 +23,10 @@ function log() {
 
 log "Starting test..."
 
-# optionally enable ipv6 docker
-export DOCKER_IN_DOCKER_IPV6_ENABLED=${DOCKER_IN_DOCKER_IPV6_ENABLED:-false}
-if [[ "${DOCKER_IN_DOCKER_IPV6_ENABLED}" == "true" ]]; then
-  # enable ipv6
-  sysctl net.ipv6.conf.all.disable_ipv6=0
-  sysctl net.ipv6.conf.all.forwarding=1
-  log "Done enabling IPv6 in Docker config."
-fi
+# Always enable IPv6; all tests should function with it enabled so no need to be selective.
+sysctl net.ipv6.conf.all.forwarding=1
+sysctl net.ipv6.conf.all.disable_ipv6=0
+log "Done enabling IPv6 in Docker config."
 
 # Enable debug logs for docker daemon
 mkdir /etc/docker


### PR DESCRIPTION
We found that on GKE 1.19, these are the default. CI runs 1.19.

In GKE 1.20, they switched the defaults, which breaks some unit tests.
These tests *should* be written in a way such that they do not break if
IPv6 isn't enabled ideally, but its also good to be able to run them
rather than skip.

This PR makes it so we explicitly declare the sysctls we need for these
tests, rather than relying on GKE 1.19 defaults. This ensures that when
we upgrade to 1.20, we will not be broken.

Internal bug for context: 205630016