### PR TITLE
Disable intra-word emphasis in protoc-gen-docs

### DIFF
--- a/cmd/protoc-gen-docs/htmlGenerator.go
+++ b/cmd/protoc-gen-docs/htmlGenerator.go
@@ -849,7 +849,7 @@ func (g *htmlGenerator) generateComment(loc protomodel.LocationDescriptor, name 
 	}
 
 	// turn the comment from markdown into HTML
-	result := blackfriday.Run([]byte(text), blackfriday.WithExtensions(blackfriday.FencedCode|blackfriday.AutoHeadingIDs))
+	result := blackfriday.Run([]byte(text), blackfriday.WithExtensions(blackfriday.FencedCode|blackfriday.AutoHeadingIDs|blackfriday.NoIntraEmphasis))
 
 	// compensate for a Blackfriday bug, where it incorrectly expands the & in HTML entities to &amp;
 	result = bytes.Replace(result, []byte("&amp;lt;"), []byte("&lt;"), -1)

--- a/cmd/protoc-gen-docs/testdata/test1.proto
+++ b/cmd/protoc-gen-docs/testdata/test1.proto
@@ -35,6 +35,8 @@ message TypeX {
 }
 
 // Test is a message that I use for testing with <some> <funny> <characters>.
+//
+// Intra-word emphasis suppression test: foo_bar_baz
 message Test {
     // field1 is a field
     int32 field1 = 1;
@@ -117,7 +119,7 @@ message Test {
     int32 hidden = 16;
 }
 
-// My sample service
+// My sample service foo_bar_baz
 service Svc {
     // My sample method
     rpc Check(Test) returns (Test2);


### PR DESCRIPTION
Hi, I noticed that your markdown parser emphasizes words if it comes across an underscore even if it's in the middle of the word, e.g:

![Screenshot from 2021-11-29 23-31-24](https://user-images.githubusercontent.com/25728391/143956333-b22b62e5-b0cf-4fee-9e42-0292514cc1fd.png)

This can easily be fixed by enabling [intra-word emphasis supression extension](https://github.com/russross/blackfriday#extensions) in blackfriday, so I went ahead and did that. I also added a test for that case.

An alternative to adding this extension would be escaping the underscores but I don't really think you ever want to emphasize part of the word.