### PR TITLE
include DNS_CAPTURE in stability test

### DIFF
--- a/perf/istio-install/istioctl_profiles/long-running.yaml
+++ b/perf/istio-install/istioctl_profiles/long-running.yaml
@@ -1,6 +1,10 @@
 apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
 spec:
+  meshConfig:
+    defaultConfig:
+      proxyMetadata:
+        ISTIO_META_DNS_CAPTURE: "true"
   components:
     ingressGateways:
       - name: istio-ingressgateway


### PR DESCRIPTION
As part of beta promotion https://github.com/istio/enhancements/pull/111 we should include this in stability, even though we won't have it on by default. 