### PR TITLE
add perf tests for authz dry-run

### DIFF
--- a/perf/benchmark/configs/istio/security_authz_dry_run/config.json
+++ b/perf/benchmark/configs/istio/security_authz_dry_run/config.json
@@ -1,0 +1,8 @@
+{
+    "authZ":
+    {
+        "numPolicies": 1,
+        "numPaths":1000,
+        "dryRun": true
+    }
+}

--- a/perf/benchmark/configs/istio/security_authz_dry_run/cpu_mem.yaml
+++ b/perf/benchmark/configs/istio/security_authz_dry_run/cpu_mem.yaml
@@ -1,0 +1,23 @@
+# Data: cpu/mem
+# Filter: rbac, metadata-exchange and stackdriver filters
+# VM mode: nullvm
+telemetry_mode: "v2-sd-full-nullvm"
+conn:
+    - 16
+qps:
+    - 10
+    - 100
+    - 200
+    - 400
+    - 800
+    - 1000
+duration: 240
+perf_record: true
+run_bothsidecar: true
+run_serversidecar: false
+run_clientsidecar: false
+run_baseline: false
+
+extra_labels: "security_authz_dry_run"
+
+jitter: true

--- a/perf/benchmark/configs/istio/security_authz_dry_run/installation.yaml
+++ b/perf/benchmark/configs/istio/security_authz_dry_run/installation.yaml
@@ -1,0 +1,15 @@
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+spec:
+  values:
+    telemetry:
+      enabled: true
+      v2:
+        enabled: true
+        prometheus:
+          enabled: false
+        stackdriver:
+          enabled: true
+          topology: true
+          inboundAccessLogging: "FULL"
+          outboundAccessLogging: "ERRORS_ONLY"

--- a/perf/benchmark/configs/istio/security_authz_dry_run/latency.yaml
+++ b/perf/benchmark/configs/istio/security_authz_dry_run/latency.yaml
@@ -1,0 +1,23 @@
+# Data: latency
+# Filter: rbac, metadata-exchange and stackdriver filters
+# VM mode: nullvm
+telemetry_mode: "v2-sd-full-nullvm"
+conn:
+    - 2
+    - 4
+    - 8
+    - 16
+    - 32
+    - 64
+qps:
+    - 1000
+duration: 240
+perf_record: true
+run_bothsidecar: true
+run_serversidecar: false
+run_clientsidecar: false
+run_baseline: false
+
+extra_labels: "security_authz_dry_run"
+
+jitter: true

--- a/perf/benchmark/configs/istio/security_authz_dry_run/postrun.sh
+++ b/perf/benchmark/configs/istio/security_authz_dry_run/postrun.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Copyright Istio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+echo "Delete the dry-run Security Policies related config..."
+kubectl delete -f "${LOCAL_OUTPUT_DIR}/largeSecurityAuthzPolicyDryRun.yaml"
+
+rm "${LOCAL_OUTPUT_DIR}/generator"
+rm "${LOCAL_OUTPUT_DIR}/largeSecurityAuthzPolicyDryRun.yaml"

--- a/perf/benchmark/configs/istio/security_authz_dry_run/prerun.sh
+++ b/perf/benchmark/configs/istio/security_authz_dry_run/prerun.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Copyright Istio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+echo "Configure dry-run Security Policies..."
+POLICY_PATH="${WD}/security/generate_policies"
+
+echo "Build Security Policy Generator..."
+go build -o "${LOCAL_OUTPUT_DIR}/generator" "${POLICY_PATH}/generate_policies.go" "${POLICY_PATH}/generate.go" "${POLICY_PATH}/jwt.go"
+
+echo "Apply dry-run Security Policy to Cluster..."
+"${LOCAL_OUTPUT_DIR}/generator" -configFile="${CONFIG_DIR}/security_authz_dry_run/config.json" > "${LOCAL_OUTPUT_DIR}/largeSecurityAuthzPolicyDryRun.yaml"
+
+kubectl apply -f "${LOCAL_OUTPUT_DIR}/largeSecurityAuthzPolicyDryRun.yaml"

--- a/perf/benchmark/configs/run_perf_test.conf
+++ b/perf/benchmark/configs/run_perf_test.conf
@@ -8,5 +8,6 @@ telemetryv2_stats=true
 telemetryv2_statswasm=true
 security_authz_ip=true
 security_authz_path=true
+security_authz_dry_run=true
 security_peer_authn=true
 security_authz_jwt=true


### PR DESCRIPTION
Note the dry-run perf test enables the telemetry stackdriver to better simulate the use case in real environment. 

cc @xulingqing @richardwxn 