### PR TITLE
Fix release notes generation

### DIFF
--- a/cmd/gen-release-notes/main.go
+++ b/cmd/gen-release-notes/main.go
@@ -95,7 +95,7 @@ func main() {
 		fmt.Printf("Found %d files.\n\n", len(releaseNoteFiles))
 
 		fmt.Printf("Parsing release notes\n")
-		releaseNotesEntries, err := parseReleaseNotesFiles(notesDir, releaseNoteFiles)
+		releaseNotesEntries, err := parseReleaseNotesFiles(filepath.Join(notesDir, releaseNotesDir), releaseNoteFiles)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Unable to read release notes: %s\n", err.Error())
 			os.Exit(1)


### PR DESCRIPTION
Following the README, I always got:
```
$ ./gen-release-notes --notes ../../../istio --oldBranch 1.12.0 --newBranch release-1.12
Looking for release notes in ../../../istio.
Executing: cd ../../../istio; git diff-tree -r --diff-filter=AMR --name-only --relative=releasenotes/notes '1.12.0' 'release-1.12'
Found 10 files.

Parsing release notes
Unable to read release notes: unable to open file ../../../istio/36044.yaml: open ../../../istio/36044.yaml: no such file or directory
```

With this patch it works.