### PR TITLE
Update to Golang 1.17.5

### DIFF
--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -25,7 +25,7 @@
 # Binary tools
 ################
 
-ARG GOLANG_IMAGE=golang:1.17.4
+ARG GOLANG_IMAGE=golang:1.17.5
 # hadolint ignore=DL3006
 FROM ${GOLANG_IMAGE} as binary_tools_context
 # TARGETARCH is an automatic platform ARG enabled by Docker BuildKit.


### PR DESCRIPTION
go1.17.5 (released 2021-12-09) includes security fixes to the syscall and net/http packages. See the Go 1.17.5 milestone on our issue tracker for details.