### PR TITLE
mitigate log4j vuln in adservice

### DIFF
--- a/upgrade_downgrade/templates/boutique/k8s-adservice.yaml
+++ b/upgrade_downgrade/templates/boutique/k8s-adservice.yaml
@@ -35,7 +35,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: server
-        image: gcr.io/google-samples/microservices-demo/adservice:v0.2.1
+        image: gcr.io/google-samples/microservices-demo/adservice:v0.3.4
         ports:
         - containerPort: 9555
         env:


### PR DESCRIPTION
see https://github.com/GoogleCloudPlatform/microservices-demo/pull/671 for details.  tests currently failing due to removed container versions.