### PR TITLE
Fix an issue when using gen-release-notes manually

### DIFF
--- a/cmd/gen-release-notes/main.go
+++ b/cmd/gen-release-notes/main.go
@@ -315,5 +315,12 @@ func getNewFilesInBranch(oldBranch string, newBranch string, pullRequest string,
 	}
 	outFiles := strings.Split(string(out), "\n")
 
-	return outFiles[:len(outFiles)-1], nil
+	// the getFilesFromGHPRView(path, pullRequest, notesSubpath) method returns file names which are relative to the repo path.
+	// the git diff-tree is relative to the notesSupbpath, so we need to add the subpath back to the filenames.
+	outFileswithPath := []string{}
+	for _, f := range outFiles[:len(outFiles)-1] { // skip the last file which is empty
+		outFileswithPath = append(outFileswithPath, notesSubpath+"/"+f)
+	}
+
+	return outFileswithPath, nil
 }

--- a/cmd/gen-release-notes/main.go
+++ b/cmd/gen-release-notes/main.go
@@ -319,7 +319,7 @@ func getNewFilesInBranch(oldBranch string, newBranch string, pullRequest string,
 	// the git diff-tree is relative to the notesSupbpath, so we need to add the subpath back to the filenames.
 	outFileswithPath := []string{}
 	for _, f := range outFiles[:len(outFiles)-1] { // skip the last file which is empty
-		outFileswithPath = append(outFileswithPath, notesSubpath+"/"+f)
+		outFileswithPath = append(outFileswithPath, filepath.Join(notesSubpath, f))
 	}
 
 	return outFileswithPath, nil


### PR DESCRIPTION
Looking at #1782, it was noted that change was tried earlier and caused the CI code to fail. Investigating the failure some more, the pipeline specifies a PR when calling the code so uses earlier code in `getNewFilesInBranch`, namely calling `getFilesFromGHPRView` which returns the release note files relative to the path. When running the code manually, a PR is not specified, so the code uses `git diff-tree --relative{notesSubpath}` so the list of files was relative to the subpath. This causes the error seen in #1782.

This change adds the subpath back to the list of files in the case where `git diff-tree` was used.