### PR TITLE
build centos clang+llvm in cloud build

### DIFF
--- a/clang-toolchain/Dockerfile
+++ b/clang-toolchain/Dockerfile
@@ -1,0 +1,21 @@
+# Copyright 2019 Tetrate
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM centos:7 AS builder
+
+COPY ./install_build_deps.sh /root
+RUN /root/install_build_deps.sh
+
+COPY ./build_clang_llvm.sh /home/build
+CMD ["/home/build/build_clang_llvm.sh"]

--- a/clang-toolchain/README.md
+++ b/clang-toolchain/README.md
@@ -7,10 +7,10 @@ we need to build them ourselves. Previously these artifacts were published by [g
 To run this build in your own cloudbuild environment:
 
 1. Fork this repository, you'll need to be the repo owner to set up cloud build triggers.
-2. Create a [GCP project](https://cloud.google.com/) if you don't already have one. You'll also need to enable
+1. Create a [GCP project](https://cloud.google.com/) if you don't already have one. You'll also need to enable
    [Cloud Build](https://cloud.google.com/build) and [Cloud Storage](https://cloud.google.com/storage)
-3. Create a Cloud Storage bucket to store the resulting artifacts.
-4. Modify `cloudbuild.yaml` in your fork to point to your bucket.
-5. Create a Cloud Build trigger pointing to your fork. The path to the configuration file is
+1. Create a Cloud Storage bucket to store the resulting artifacts.
+1. Modify `cloudbuild.yaml` in your fork to point to your bucket.
+1. Create a Cloud Build trigger pointing to your fork. The path to the configuration file is
    `clang-toolchain/cloudbuild.yaml`. The trigger type can be "Manual Trigger".
-6. Trigger a build and after about 2 hours, you should have the artifacts pushed to your GCS bucket.
+1. Trigger a build and after about 2 hours, you should have the artifacts pushed to your GCS bucket.

--- a/clang-toolchain/README.md
+++ b/clang-toolchain/README.md
@@ -1,0 +1,16 @@
+# clang-toolchain
+
+Because [llvm+clang](https://github.com/llvm/llvm-project/releases) doesn't ship binaries for CentOS 7,
+we need to build them ourselves. Previously these artifacts were published by [getenvoy-package](https://github.com/tetratelabs-attic/getenvoy-package/)
+(which is where these scripts are from).
+
+To run this build in your own cloudbuild environment:
+
+1. Fork this repository, you'll need to be the repo owner to set up cloud build triggers.
+2. Create a [GCP project](https://cloud.google.com/) if you don't already have one. You'll also need to enable
+   [Cloud Build](https://cloud.google.com/build) and [Cloud Storage](https://cloud.google.com/storage)
+3. Create a Cloud Storage bucket to store the resulting artifacts.
+4. Modify `cloudbuild.yaml` in your fork to point to your bucket.
+5. Create a Cloud Build trigger pointing to your fork. The path to the configuration file is
+   `clang-toolchain/cloudbuild.yaml`. The trigger type can be "Manual Trigger".
+6. Trigger a build and after about 2 hours, you should have the artifacts pushed to your GCS bucket.

--- a/clang-toolchain/build_clang_llvm.sh
+++ b/clang-toolchain/build_clang_llvm.sh
@@ -21,8 +21,8 @@ VERSION="12.0.1"
 curl -sSL "https://raw.githubusercontent.com/llvm/llvm-project/llvmorg-${VERSION}/llvm/utils/release/test-release.sh" | sed 's,http://llvm.org,https://llvm.org,' > /home/build/test-release.sh
 chmod +x /home/build/test-release.sh
 
-mkdir -p ${BUILD_DIR}
-chown build:build ${BUILD_DIR}
+mkdir -p "${BUILD_DIR}"
+chown build:build "${BUILD_DIR}"
 
 sudo -u build scl enable devtoolset-9 \
   "/home/build/test-release.sh -release ${VERSION} -final -triple x86_64-linux-centos7 -configure-flags '-DCOMPILER_RT_BUILD_LIBFUZZER=off' -build-dir ${BUILD_DIR}"

--- a/clang-toolchain/build_clang_llvm.sh
+++ b/clang-toolchain/build_clang_llvm.sh
@@ -24,5 +24,9 @@ chmod +x /home/build/test-release.sh
 mkdir -p "${BUILD_DIR}"
 chown build:build "${BUILD_DIR}"
 
+# for 1.12+ we must use python3. Their scripts don't seem to make this happen automatically.
+VIRTUALENV_PYTHON=$(which python3)
+export VIRTUALENV_PYTHON
+
 sudo -u build scl enable devtoolset-9 \
   "/home/build/test-release.sh -release ${VERSION} -final -triple x86_64-linux-centos7 -configure-flags '-DCOMPILER_RT_BUILD_LIBFUZZER=off' -build-dir ${BUILD_DIR}"

--- a/clang-toolchain/build_clang_llvm.sh
+++ b/clang-toolchain/build_clang_llvm.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Copyright 2019 Tetrate
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+VERSION="12.0.1"
+
+curl -sSL "https://raw.githubusercontent.com/llvm/llvm-project/llvmorg-${VERSION}/llvm/utils/release/test-release.sh" | sed 's,http://llvm.org,https://llvm.org,' > /home/build/test-release.sh
+chmod +x /home/build/test-release.sh
+
+mkdir -p ${BUILD_DIR}
+chown build:build ${BUILD_DIR}
+
+sudo -u build scl enable devtoolset-9 \
+  "/home/build/test-release.sh -release ${VERSION} -final -triple x86_64-linux-centos7 -configure-flags '-DCOMPILER_RT_BUILD_LIBFUZZER=off' -build-dir ${BUILD_DIR}"

--- a/clang-toolchain/build_clang_llvm.sh
+++ b/clang-toolchain/build_clang_llvm.sh
@@ -24,7 +24,7 @@ chmod +x /home/build/test-release.sh
 mkdir -p "${BUILD_DIR}"
 chown build:build "${BUILD_DIR}"
 
-# for 1.12+ we must use python3. Their scripts don't seem to make this happen automatically.
+# for 12.0+ we must use python3. Their scripts don't seem to make this happen automatically.
 VIRTUALENV_PYTHON=$(which python3)
 export VIRTUALENV_PYTHON
 

--- a/clang-toolchain/cloudbuild.yaml
+++ b/clang-toolchain/cloudbuild.yaml
@@ -1,0 +1,36 @@
+# Copyright 2019 Tetrate
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+steps:
+- id: deps
+  name: gcr.io/cloud-builders/docker
+  dir: clang-toolchain
+  args: ['build', '-t', 'centos-llvm-build', '.']
+
+- id: clang-toolchain
+  name: centos-llvm-build
+  env:
+  - "BUILD_DIR=/workspace/llvm-build"
+
+artifacts:
+  objects:
+    # TODO make this a well-supported istio path.
+    location: "gs://landow-istio-testing/clang-toolchain/$COMMIT_SHA/"
+    paths:
+    - "/workspace/llvm-build/final/logs/*"
+    - "/workspace/llvm-build/final/clang+llvm-*.tar.xz"
+options:
+  machineType: N1_HIGHCPU_32
+  logging: GCS_ONLY
+timeout: 6h

--- a/clang-toolchain/install_build_deps.sh
+++ b/clang-toolchain/install_build_deps.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Copyright 2019 Tetrate
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+yum install -y centos-release-scl epel-release
+yum update -y
+yum install -y devtoolset-9-gcc devtoolset-9-gcc-c++ devtoolset-9-libatomic-devel wget unzip which make cmake3 patch subversion ncurses-devel zlib-devel \
+  python-virtualenv chrpath file perl-Data-Dumper tcl python2-psutil sudo rsync
+
+# For LLVM to pick right libstdc++
+mkdir -p /usr/lib/gcc/x86_64-redhat-linux
+ln -s /opt/rh/devtoolset-9/root/usr/lib/gcc/x86_64-redhat-linux/9 /usr/lib/gcc/x86_64-redhat-linux
+
+ln -s /usr/bin/cmake3 /usr/bin/cmake
+
+useradd build


### PR DESCRIPTION
Using scripts from https://github.com/tetratelabs-attic/getenvoy-package, we can build the centos build deps for https://github.com/istio/istio/issues/36811. 

I had issues trying to just run them outside of cloud build (build takes >1 hr, even on cloud build, docker No Space Left On Device), so cloud build it is. 

I have this running on my personal project now and it should be done in about an hour. After that I will move the artifact to an Istio-owned bucket. 