### PR TITLE
update the image of proxy

### DIFF
--- a/perf/benchmark/flame/README.md
+++ b/perf/benchmark/flame/README.md
@@ -18,7 +18,7 @@ Flame graphs are created from data collected using linux `perf_events` by the `p
    Since `istio-proxy` container does not allow installation of new packages, build a new docker image.
 
     ```plain
-    FROM gcr.io/istio-release/proxyv2:release-1.0-20180810-09-15
+    FROM docker.io/istio/proxyv2:1.11.4
     # Install fpm tool
     RUN  sudo apt-get update && \
         sudo apt-get -qqy install linux-tools-generic


### PR DESCRIPTION
The original image `gcr.io/istio-release/proxyv2:release-1.0-20180810-09-15` is no longer available.