### PR TITLE
Update to golang 1.18rc1

### DIFF
--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -25,7 +25,7 @@
 # Binary tools
 ################
 
-ARG GOLANG_IMAGE=golang:1.17.7
+ARG GOLANG_IMAGE=golang:1.18rc1
 # hadolint ignore=DL3006
 FROM ${GOLANG_IMAGE} as binary_tools_context
 # TARGETARCH is an automatic platform ARG enabled by Docker BuildKit.


### PR DESCRIPTION
This introduces Go 1.18 just before its .0 release. This will not be shipped in a real build until 1.14 in a few months; by then we will be on a mainline release. Early adopting allows us to ensure there is no unexpected breakage.

Go 1.18 has already been tested manually, so there is no *expected* issues, although things could happen.

We will not support changes that *require* Go 1.18 until we are ready (post release + some buffer)