### PR TITLE
build-tools/Dockerfile: install zlib1g-dev

### DIFF
--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -774,6 +774,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libssl-dev \
     libcurl4-gnutls-dev \
     libexpat1-dev \
+    zlib1g-dev \
     gettext \
     unzip && \
     wget -q https://github.com/git/git/archive/v2.25.1.zip -O git.zip && \


### PR DESCRIPTION
The zlib1g-dev packages must be installed on Ubuntu to build the version of git needed.

This remediates the following error observed during the build_env_proxy stage:

```
#0 10.02 finishing deferred symbolic links:
#0 10.02   git-2.25.1/RelNotes    -> Documentation/RelNotes/2.25.1.txt
#0 10.08 GIT_VERSION = 2.25.1
#0 10.13     * new build flags
#0 10.14     CC fuzz-commit-graph.o
#0 10.25 In file included from commit-graph.h:7:0,
#0 10.25                  from fuzz-commit-graph.c:1:
#0 10.25 cache.h:21:10: fatal error: zlib.h: No such file or directory
#0 10.25  #include <zlib.h>
#0 10.25           ^~~~~~~~
#0 10.25 compilation terminated.
#0 10.25 Makefile:2385: recipe for target 'fuzz-commit-graph.o' failed
#0 10.25 make: *** [fuzz-commit-graph.o] Error 1
------
error: failed to solve: executor failed running [/bin/sh -c apt-get update && apt-get install -y --no-install-recommends     build-essential     libssl-dev     libcurl4-gnutls-dev     libexpat1-dev     gettext     unzip &&     wget -q https://github.com/git/git/archive/v2.25.1.zip -O git.zip &&     unzip git.zip &&     cd git-* &&     make prefix=/usr/local all &&     make prefix=/usr/local install &&     cd .. && rm -r git-*]: exit code: 2
Command exited with non-zero status 1
```