### PR TITLE
Update kubetype to support golang/protobuf

### DIFF
--- a/cmd/kubetype-gen/generators/types.go
+++ b/cmd/kubetype-gen/generators/types.go
@@ -15,7 +15,9 @@
 package generators
 
 import (
+	"fmt"
 	"io"
+	"os"
 
 	"k8s.io/gengo/generator"
 	"k8s.io/gengo/namer"
@@ -71,7 +73,15 @@ func (g *typesGenerator) GenerateType(c *generator.Context, t *types.Type, w io.
 	return sw.Error()
 }
 
-const kubeTypeTemplate = `
+// getPointerType gets the prefix for a list type, based on whether we are generating for Gogo protobuf or golang protobuf.
+func getPointerType() string {
+	if os.Getenv("KUBETYPE_GOLANG_PROTOBUF") == "true" {
+		return "*"
+	}
+	return ""
+}
+
+var kubeTypeTemplate = fmt.Sprintf(`
 $- range .RawType.SecondClosestCommentLines $
 // $ . $
 $- end $
@@ -84,24 +94,24 @@ $ range .RawType.CommentLines $
 // $ . $
 $- end $
 type $.KubeType.Type|public$ struct {
-	$.TypeMeta|raw$ ` + "`" + `json:",inline"` + "`" + `
+	$.TypeMeta|raw$ `+"`"+`json:",inline"`+"`"+`
 	// +optional
-	$.ObjectMeta|raw$ ` + "`" + `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"` + "`" + `
+	$.ObjectMeta|raw$ `+"`"+`json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`+"`"+`
 
 	// Spec defines the implementation of this definition.
 	// +optional
-	Spec $.RawType|raw$ ` + "`" + `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"` + "`" + `
+	Spec $.RawType|raw$ `+"`"+`json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`+"`"+`
 
-	Status $.IstioStatus|raw$ ` + "`" + `json:"status"` + "`" + `
+	Status $.IstioStatus|raw$ `+"`"+`json:"status"`+"`"+`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // $.KubeType.Type|public$List is a collection of $.KubeType.Type|publicPlural$.
 type $.KubeType.Type|public$List struct {
-	$.TypeMeta|raw$ ` + "`" + `json:",inline"` + "`" + `
+	$.TypeMeta|raw$ `+"`"+`json:",inline"`+"`"+`
 	// +optional
-	$.ListMeta|raw$ ` + "`" + `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"` + "`" + `
-	Items           []$.KubeType.Type|raw$ ` + "`" + `json:"items" protobuf:"bytes,2,rep,name=items"` + "`" + `
+	$.ListMeta|raw$ `+"`"+`json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`+"`"+`
+	Items           []%s$.KubeType.Type|raw$ `+"`"+`json:"items" protobuf:"bytes,2,rep,name=items"`+"`"+`
 }
-`
+`, getPointerType())


### PR DESCRIPTION
Basically conditionally make it a list of pointers instead of a list of structs based on env var so we can easily switch between the two