### PR TITLE
[release-1.13] Update Golang to 1.17.9

### DIFF
--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -25,7 +25,7 @@
 # Binary tools
 ################
 
-ARG GOLANG_IMAGE=golang:1.17.8
+ARG GOLANG_IMAGE=golang:1.17.9
 # hadolint ignore=DL3006
 FROM ${GOLANG_IMAGE} as binary_tools_context
 # TARGETARCH is an automatic platform ARG enabled by Docker BuildKit.


### PR DESCRIPTION
Manual update as the main branch is already on 1.18 (PR there for similar upgrade to 1.18.1).