### PR TITLE
Always run gcloud auth configure-docker in prow entrypoint

### DIFF
--- a/docker/build-tools/prow-entrypoint.sh
+++ b/docker/build-tools/prow-entrypoint.sh
@@ -67,8 +67,9 @@ trap cleanup EXIT
 if [[ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then
   # Jobs that need this will fail later and jobs that don't should fail because of this
   gcloud auth activate-service-account --key-file="${GOOGLE_APPLICATION_CREDENTIALS}" || true
-  gcloud auth configure-docker -q || true
 fi
+# Always try to authenticate to GCR.
+gcloud auth configure-docker -q || true
 
 set +x
 "$@"


### PR DESCRIPTION
For workloads that authenticate to gcloud via workload identity, `GOOGLE_APPLICATION_CREDENTIALS` won't necessarily be set, but in some cases they'll still need to authenticate to GCR.

This PR moves `gcloud auth configure-docker -q || true` command out of the if check, so it always gets run in the prow entrypoint.