### PR TITLE
Revert "[release-1.14] Docker not start as part of prow jobs"

### DIFF
--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -475,9 +475,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     locales-all \
     file
 
-# Fix Docker issue
-RUN update-alternatives --set iptables /usr/sbin/iptables-legacy && update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
-
 # Docker including docker-ce, docker-ce-cli, and containerd.io
 ADD https://download.docker.com/linux/ubuntu/gpg /tmp/docker-key
 RUN apt-key add /tmp/docker-key


### PR DESCRIPTION
Based on an offline discussion with @ericvn @GregHanson, due to the 1.14 release timeline and the fact that Ubuntu Jammy is only released a week ago, we plan to leaving the transition to Ubuntu Jammy for Istio 1.15. The Ubuntu Focal currently used has an EOL until April 2025. Hence this PR to revert istio/tools#1967.