### PR TITLE
Ignore deleted files when using gh pr

### DIFF
--- a/cmd/gen-release-notes/main.go
+++ b/cmd/gen-release-notes/main.go
@@ -294,7 +294,10 @@ func getFilesFromGHPRView(path string, pullRequest string, notesSubpath string) 
 	var results []string
 	for _, val := range prResults.Files {
 		if strings.Contains(val.Path, notesSubpath) {
-			results = append(results, val.Path)
+			// Only add file if it exists. May have been deleted in this PR.
+			if _, err := os.Stat(val.Path); !os.IsNotExist(err) {
+				results = append(results, val.Path)
+			}
 		}
 	}
 


### PR DESCRIPTION
If a PR removes a releasenotes file, it fails the release notes test. See https://github.com/istio/istio/pull/38826 and https://prow.istio.io/view/gs/istio-prow/pr-logs/pull/istio_istio/38826/release-notes_istio/1524008660739559424.

The reason is that the gh pr returns all files changed in a PR. The release note logic assumes that it was a file add or modify, and adds it to the list of changed files to possibly check. This change is to not add the file if doesn't exist, ie it was removed.