### PR TITLE
Add a stability test for WasmPlugin

### DIFF
--- a/perf/stability/stability.mk
+++ b/perf/stability/stability.mk
@@ -5,7 +5,7 @@ STABILITY = $(WD)/setup_test.sh
 stable_tests = http10 graceful-shutdown gateway-bouncer mysql redis rabbitmq looper
 
 # Tests that need no special setup
-standard_tests = http10 graceful-shutdown redis rabbitmq istio-chaos-total istio-chaos-partial multicluster-vpn looper
+standard_tests = http10 graceful-shutdown redis rabbitmq istio-chaos-total istio-chaos-partial multicluster-vpn looper wasm-extensions
 
 # Tests that have a special ./setup script in their folder
 extra_setup_tests = mysql sds-certmanager gateway-bouncer allconfig

--- a/perf/stability/wasm-extensions/Chart.yaml
+++ b/perf/stability/wasm-extensions/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+name: wasm-extension
+version: '1.0'
+description: Helm chart for istio testing of Wasm Extension
+keywords:
+  - wasm extension
+  - performance
+sources:
+  - http://github.com/istio/istio
+engine: gotpl
+icon: https://istio.io/favicons/android-192x192.png

--- a/perf/stability/wasm-extensions/templates/client.yaml
+++ b/perf/stability/wasm-extensions/templates/client.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: wasm-test-client
+  namespace: {{ .Release.Namespace }}
+spec:
+  selector:
+    matchLabels:
+      app: wasm-test-client
+  template:
+    metadata:
+      labels:
+        app: wasm-test-client
+    spec:
+      containers:
+        - name: wasm-test-client
+          image: {{ .Values.curlImage }}
+          args:
+            - /bin/sh
+            - -c
+            - |-
+              while true; do
+                RESULT=$(curl -sS -o /dev/null -D - wasm-test-server:8080/echo | grep x-resp-injection)
+                if [[ "$RESULT" == "" ]]; then 
+                  echo "$(date): no injected header"
+                else
+                  echo "$(date): $RESULT"
+                fi
+                sleep .1
+              done
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi

--- a/perf/stability/wasm-extensions/templates/server.yaml
+++ b/perf/stability/wasm-extensions/templates/server.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: wasm-test-server
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: wasm-test-server
+spec:
+  ports:
+  - name: http
+    port: 8080
+  selector:
+    app: wasm-test-server
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: wasm-test-server
+  namespace: {{ .Release.Namespace }}
+spec:
+  selector:
+    matchLabels:
+      app: wasm-test-server
+  template:
+    metadata:
+      labels:
+        app: wasm-test-server
+      annotations:
+        proxy.istio.io/config: |-
+          proxyMetadata:
+            WASM_PURGE_INTERVAL: 1s
+            WASM_MODULE_EXPIRY: {{.Values.moduleExpirySeconds}}s
+    spec:
+      containers:
+      - image: {{ .Values.fortioImage }}
+        imagePullPolicy: IfNotPresent
+        name: wasm-test-server
+        ports:
+          - containerPort: 8080
+        resources:
+          requests:
+            cpu: 50m
+            memory: 128Mi

--- a/perf/stability/wasm-extensions/templates/serviceaccount.yaml
+++ b/perf/stability/wasm-extensions/templates/serviceaccount.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: wasm-extensions-service-account
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: wasm-extensions-role
+rules:
+  - apiGroups: ["extensions.istio.io"]
+    resources: ["wasmplugins"]
+    verbs: ['*']
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - '*'
+  - apiGroups:
+      - apps
+      - extensions
+    resources:
+      - deployments
+      - deployments/finalizers
+      - replicasets
+    verbs:
+      - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: wasm-extensions-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: wasm-extensions-role
+subjects:
+  - kind: ServiceAccount
+    name: wasm-extensions-service-account
+    namespace: {{ .Release.Namespace }}
+---

--- a/perf/stability/wasm-extensions/templates/wasm-configurator.yaml
+++ b/perf/stability/wasm-extensions/templates/wasm-configurator.yaml
@@ -1,0 +1,55 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: wasm-configurator
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: wasm-configurator
+spec:
+  selector:
+    matchLabels:
+      app: wasm-configurator
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+      labels:
+        app: wasm-configurator
+    spec:
+      serviceAccount: wasm-extensions-service-account
+      containers:
+      - image: {{ .Values.kubectlImage }}
+        name: wasm-configurator
+        command:
+          - bash
+          - -c
+          - |-
+            #!/bin/bash
+            while [ 1 ] ; do 
+              sed "s/%PLACEHOLDER%/$(( $v + 1 ))/" /tmpl/wasm-extension.yaml | kubectl apply -f -
+              v=$(( ( $v + 1 ) % 2 ))
+              sleep {{ .Values.wasmChangeIntervalSeconds }}
+              kubectl delete -f /tmpl/wasm-extension.yaml 
+              sleep {{ .Values.wasmChangeIntervalSeconds }}
+            done
+        resources:
+          requests:
+            cpu: 50m
+            memory: 128Mi
+        volumeMounts:
+        - name: wasm-template-volume
+          mountPath: /tmpl
+      volumes:
+        - name: wasm-template-volume
+          configMap:
+            name: wasm-template
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: wasm-template
+  namespace: {{ .Release.Namespace }}
+data:
+  wasm-extension.yaml: |-
+{{ .Files.Get "wasm-extension.yaml" | indent 4 }}
+---

--- a/perf/stability/wasm-extensions/values.yaml
+++ b/perf/stability/wasm-extensions/values.yaml
@@ -1,0 +1,5 @@
+fortioImage: fortio/fortio:latest
+curlImage: curlimages/curl:latest
+wasmChangeIntervalSeconds: 10
+moduleExpirySeconds: 5
+kubectlImage: bitnami/kubectl:latest

--- a/perf/stability/wasm-extensions/wasm-extension.yaml
+++ b/perf/stability/wasm-extensions/wasm-extension.yaml
@@ -1,0 +1,11 @@
+apiVersion: extensions.istio.io/v1alpha1
+kind: WasmPlugin
+metadata:
+  name: test-wasm-filter
+spec:
+  phase: STATS
+  selector:
+    matchLabels:
+      app: wasm-test-server
+  url: oci://gcr.io/istio-testing/wasm/header-injector:0.0.%PLACEHOLDER%
+  imagePullPolicy: Always


### PR DESCRIPTION
This PR adds a stability test for WasmPlugin:

1. A client sends requests repeatedly with 100ms delay between the requests, and the server makes echo responses.
2. WasmPlugin is also repeatedly changed for each 10 seconds.
3. If Istio can interpret the proxy metadata "WASM_PURGE_INTERVAL" and "WASM_MODULE_EXPIRY", the Wasm binaries are expired within 5 seconds. So, for each request, Wasm binaries are pulled. 

In case of 3, https://github.com/istio/istio/pull/39050 is needed.