### PR TITLE
Initial support for multi-architecture build-tools builds

### DIFF
--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -24,7 +24,6 @@
 ################
 # Binary tools
 ################
-
 ARG GOLANG_IMAGE=golang:1.18.3
 # hadolint ignore=DL3006
 FROM ${GOLANG_IMAGE} as binary_tools_context


### PR DESCRIPTION
See comments for details on why we do it this way vs other ways.

Once this is merged, I think we will get a manifest with a single arch.
No changes to prow job config needed.

To get ARM (once we have nodes), we can create a new job for ARM with

```
MANIFEST_ARCH=""
```

And change the amd64 job to

```
MANIFEST_ARCH="amd64 arm64"
```

I believe that is sufficient to make things work.

Common-files should not need to be changed (I hope).


For https://github.com/istio/istio/issues/26652#issuecomment-1155682106