### PR TITLE
trim build-tools image a bit

### DIFF
--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -267,7 +267,8 @@ RUN set -eux; \
     tar -xzvf ."/${GCLOUD_TAR_FILE}" -C "${OUTDIR}/usr/local" && rm "${GCLOUD_TAR_FILE}"; \
     ${OUTDIR}/usr/local/google-cloud-sdk/bin/gcloud components install beta --quiet; \
     ${OUTDIR}/usr/local/google-cloud-sdk/bin/gcloud components install alpha --quiet; \
-    rm -rf /usr/local/google-cloud-sdk/.install/.backup
+    rm -rf ${OUTDIR}/usr/local/google-cloud-sdk/.install/.backup \
+    rm -rf ${OUTDIR}/usr/local/google-cloud-sdk/bin/anthoscli
 
 # Install cosign (for signing build artifacts) and verify signature
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]


### PR DESCRIPTION
We had a cleanup of .backup but its the wrong dir. Also remove a 120mb
binary we dont need. In total this saves about 800mb