### PR TITLE
Detect host MTU and use that as the docker MTU

### DIFF
--- a/docker/build-tools/prow-entrypoint.sh
+++ b/docker/build-tools/prow-entrypoint.sh
@@ -34,9 +34,13 @@ sysctl net.ipv6.conf.all.forwarding=1
 sysctl net.ipv6.conf.all.disable_ipv6=0
 log "Done enabling IPv6 in Docker config."
 
-# Enable debug logs for docker daemon
+# Enable debug logs for docker daemon, and set the MTU to the external NIC MTU
+# Docker will always use 1500 as the MTU; in environments where the host has <1500 as the MTU
+# this may cause connectivity issues.
 mkdir /etc/docker
-echo '{"debug":true}' > /etc/docker/daemon.json
+primaryInterface="$(awk '$2 == 00000000 { print $1 }' /proc/net/route)"
+hostMTU="$(cat /sys/class/net/$primaryInterface/mtu)"
+echo "{\"debug\":true, \"mtu\":\"${hostMTU:-1500}\"}" > /etc/docker/daemon.json
 
 # Start docker daemon and wait for dockerd to start
 service docker start

--- a/docker/build-tools/prow-entrypoint.sh
+++ b/docker/build-tools/prow-entrypoint.sh
@@ -39,7 +39,7 @@ log "Done enabling IPv6 in Docker config."
 # this may cause connectivity issues.
 mkdir /etc/docker
 primaryInterface="$(awk '$2 == 00000000 { print $1 }' /proc/net/route)"
-hostMTU="$(cat /sys/class/net/$primaryInterface/mtu)"
+hostMTU="$(cat "/sys/class/net/${primaryInterface}/mtu")"
 echo "{\"debug\":true, \"mtu\":\"${hostMTU:-1500}\"}" > /etc/docker/daemon.json
 
 # Start docker daemon and wait for dockerd to start


### PR DESCRIPTION
On certain environments using the default MTU completely blocks egress traffic.

See https://sylwit.medium.com/how-we-spent-a-full-day-figuring-out-a-mtu-issue-with-docker-4d81fdfe2caf, https://mlohr.com/docker-mtu/, etc for more info