### PR TITLE
[release-1.12] Update Go to 1.17.11. Remove some tools.

### DIFF
--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -25,7 +25,7 @@
 # Binary tools
 ################
 
-ARG GOLANG_IMAGE=golang:1.17.10
+ARG GOLANG_IMAGE=golang:1.17.11
 # hadolint ignore=DL3006
 FROM ${GOLANG_IMAGE} as binary_tools_context
 # TARGETARCH is an automatic platform ARG enabled by Docker BuildKit.
@@ -70,7 +70,6 @@ ENV KPT_VERSION=v0.39.3
 ENV BUF_VERSION=v0.43.2
 ENV GCLOUD_VERSION=377.0.0
 ENV KUBETEST2_VERSION=92c12f91d13cbe9f17b62c7b0803d31e4c40431c
-ENV BOSKOSCTL_VERSION=c6d730e323f06da1b56dfa14bdab6d7d5dc22e2a
 ENV COSIGN_VERSION=v1.2.1
 
 ENV GO111MODULE=on
@@ -175,17 +174,6 @@ RUN git clone https://github.com/kubernetes/test-infra --branch master --single-
   go install ./prow/cmd/peribolos && \
   go install ./pkg/benchmarkjunit && \
   cd .. && rm -rf test-infra
-# hadolint ignore=DL3003
-RUN git clone --depth 1 https://github.com/istio/test-infra --branch master --single-branch && \
-  cd test-infra && \
-  go install ./toolbox/githubctl && \
-  go install ./boskos/cmd/mason_client && \
-  cd .. && rm -rf test-infra
-# hadolint ignore=DL3003
-RUN git clone --depth 1 https://github.com/kubernetes-sigs/boskos --branch master --single-branch && \
-  cd boskos && \
-  go install ./cmd/boskosctl && \
-  cd .. && rm -rf boskos
 
 # Compress the Go tools and put them in their final location
 ADD https://github.com/upx/upx/releases/download/v${UPX_VERSION}/upx-${UPX_VERSION}-${TARGETARCH}_linux.tar.xz /tmp
@@ -221,7 +209,6 @@ RUN set -eux; \
     \
     wget -O /tmp/${HUGO_TAR} https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/${HUGO_TAR}; \
     tar -xzvf /tmp/${HUGO_TAR} -C /tmp; \
-
     mv /tmp/hugo ${OUTDIR}/usr/bin
 
 # Helm version 3


### PR DESCRIPTION
Includes manual cherry-pick removing Go installs removed in (https://github.com/istio/tools/pull/2028)