### PR TITLE
build-tools: cache from existing image

### DIFF
--- a/docker/build-tools/build-and-push.sh
+++ b/docker/build-tools/build-and-push.sh
@@ -67,22 +67,30 @@ fi
 # shellcheck disable=SC2086
 ${CONTAINER_CLI} ${CONTAINER_BUILDER} --target build_tools \
   ${ADDITIONAL_BUILD_ARGS} --build-arg "ISTIO_TOOLS_SHA=${SHA}" --build-arg "VERSION=${VERSION}" \
-  -t "${HUB}/build-tools:${VERSION}-${ARCH}" \
+  --build-arg BUILDKIT_INLINE_CACHE=1 \
+  --cache-from "${HUB}/build-tools:${BRANCH}-latest-${ARCH}" \
   -t "${HUB}/build-tools:${BRANCH}-latest-${ARCH}" \
+  -t "${HUB}/build-tools:${VERSION}-${ARCH}" \
   .
+
 # shellcheck disable=SC2086
 ${CONTAINER_CLI} ${CONTAINER_BUILDER} --target build_env_proxy \
   ${ADDITIONAL_BUILD_ARGS} --build-arg "ISTIO_TOOLS_SHA=${SHA}" --build-arg "VERSION=${VERSION}" \
-  -t "${HUB}/build-tools-proxy:${VERSION}-${ARCH}" \
+  --build-arg BUILDKIT_INLINE_CACHE=1 \
+  --cache-from "${HUB}/build-tools-proxy:${BRANCH}-latest-${ARCH}" \
   -t "${HUB}/build-tools-proxy:${BRANCH}-latest-${ARCH}" \
+  -t "${HUB}/build-tools-proxy:${VERSION}-${ARCH}" \
   .
+
 if [[ "$(uname -m)" == "x86_64" ]]; then
   # Multi arch is not supported for CentOS, since its legacy and multi-arch is new.
   # shellcheck disable=SC2086
   ${CONTAINER_CLI} ${CONTAINER_BUILDER} \
     ${ADDITIONAL_BUILD_ARGS} --build-arg "ISTIO_TOOLS_SHA=${SHA}" --build-arg "VERSION=${VERSION}" \
-    -t "${HUB}/build-tools-centos:${VERSION}" \
+    --build-arg BUILDKIT_INLINE_CACHE=1 \
+    --cache-from "${HUB}/build-tools-centos:${BRANCH}-latest" \
     -t "${HUB}/build-tools-centos:${BRANCH}-latest" \
+    -t "${HUB}/build-tools-centos:${VERSION}" \
     -f Dockerfile.centos \
     .
 fi


### PR DESCRIPTION
This does two things - enables inline caching, and utilizes it. Inline
caching adds a pretty small blob (1kb or so) to the manifest, it is
nothing huge. Using the cache is optional - if there is none found it
doesn't fail the build. As a result, I think this will speed things up
with minimal risk.