### PR TITLE
[release-1.14] Update Go to 1.18.4

### DIFF
--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -24,7 +24,7 @@
 ################
 # Binary tools
 ################
-ARG GOLANG_IMAGE=golang:1.18.3
+ARG GOLANG_IMAGE=golang:1.18.4
 # hadolint ignore=DL3006
 FROM ${GOLANG_IMAGE} as binary_tools_context
 # TARGETARCH is an automatic platform ARG enabled by Docker BuildKit.


### PR DESCRIPTION
Manual cherry-pick of https://github.com/istio/tools/pull/2053

I did only update Go, and left out the gh update.