### PR TITLE
Update Go to 1.18.5

### DIFF
--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -25,7 +25,7 @@
 ################
 # Binary tools
 ################
-ARG GOLANG_IMAGE=golang:1.18.4
+ARG GOLANG_IMAGE=golang:1.18.5
 # hadolint ignore=DL3006
 FROM ${GOLANG_IMAGE} as binary_tools_context
 # TARGETARCH is an automatic platform ARG enabled by Docker BuildKit.


### PR DESCRIPTION
Still need to wait for the new Docker images.

go1.18.5 (released 2022-08-01) includes security fixes to the encoding/gob and math/big packages, as well as bug fixes to the compiler, the go command, the runtime, and the testing package. See the [Go 1.18.5 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.18.5+label%3ACherryPickApproved) on our issue tracker for details.