### PR TITLE
Update to Go 1.19.1

### DIFF
--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -25,7 +25,7 @@
 ################
 # Binary tools
 ################
-ARG GOLANG_IMAGE=golang:1.19.0
+ARG GOLANG_IMAGE=golang:1.19.1
 # hadolint ignore=DL3006
 FROM ${GOLANG_IMAGE} as binary_tools_context
 # TARGETARCH is an automatic platform ARG enabled by Docker BuildKit.


### PR DESCRIPTION
It will take a while for some of the images to appear.

These minor releases include 2 security fixes following the [security policy](https://urldefense.proofpoint.com/v2/url?u=https-3A__go.dev_security&d=DwMFaQ&c=jf_iaSHvJObTbx-siA1ZOg&r=Ntx1o1kPu8e6E_CyZHzUyixOnKA3KnWwy6JoT-1xctQ&m=_ikePy3cqN5_pizsGIvSL9gL4kTY_CZIkHTc81Tl3EqzfEyaDCvDiF_RRrj4G9xY&s=GsdzLlpuxQmv9VIX_FGReJxPkwvR1LM_QHWvVdBmR1A&e=):

net/http: handle server errors after sending GOAWAY

A closing HTTP/2 server connection could hang forever waiting for a clean shutdown that was preempted by a subsequent fatal error. This failure mode could be exploited to cause a denial of service.

Thanks to Bahruz Jabiyev, Tommaso Innocenti, Anthony Gavazzi, Steven Sprecher, and Kaan Onarlioglu for reporting this.

This is CVE-2022-27664 and Go issue [https://go.dev/issue/54658](https://urldefense.proofpoint.com/v2/url?u=https-3A__go.dev_issue_54658&d=DwMFaQ&c=jf_iaSHvJObTbx-siA1ZOg&r=Ntx1o1kPu8e6E_CyZHzUyixOnKA3KnWwy6JoT-1xctQ&m=_ikePy3cqN5_pizsGIvSL9gL4kTY_CZIkHTc81Tl3EqzfEyaDCvDiF_RRrj4G9xY&s=6dVtpxw0WpO9fbq0KwoqucPgd8uG5-FBekv7Rur7oS4&e=).

net/url: JoinPath does not strip relative path components in all circumstances

JoinPath and URL.JoinPath would not remove ../ path components appended to a relative path. For example, JoinPath("[https://go.dev"](https://urldefense.proofpoint.com/v2/url?u=https-3A__go.dev-2522&d=DwQFaQ&c=jf_iaSHvJObTbx-siA1ZOg&r=Ntx1o1kPu8e6E_CyZHzUyixOnKA3KnWwy6JoT-1xctQ&m=_ikePy3cqN5_pizsGIvSL9gL4kTY_CZIkHTc81Tl3EqzfEyaDCvDiF_RRrj4G9xY&s=nZMjJZYwhsjBX3KnnI3jiL6uIh5GQj1Ct5dm422ORyI&e=), "../go") returned the URL [https://go.dev/../go](https://urldefense.proofpoint.com/v2/url?u=https-3A__go.dev_.._go&d=DwMFaQ&c=jf_iaSHvJObTbx-siA1ZOg&r=Ntx1o1kPu8e6E_CyZHzUyixOnKA3KnWwy6JoT-1xctQ&m=_ikePy3cqN5_pizsGIvSL9gL4kTY_CZIkHTc81Tl3EqzfEyaDCvDiF_RRrj4G9xY&s=s8mtHtALVm6JLxdZCaVN6VPLYK8HJGdcMBxgonYFPuQ&e=), despite the JoinPath documentation stating that ../ path elements are cleaned from the result.

Thanks to @q0jt for reporting this issue.

This is CVE-2022-32190 and Go issue [https://go.dev/issue/54385](https://urldefense.proofpoint.com/v2/url?u=https-3A__go.dev_issue_54385&d=DwMFaQ&c=jf_iaSHvJObTbx-siA1ZOg&r=Ntx1o1kPu8e6E_CyZHzUyixOnKA3KnWwy6JoT-1xctQ&m=_ikePy3cqN5_pizsGIvSL9gL4kTY_CZIkHTc81Tl3EqzfEyaDCvDiF_RRrj4G9xY&s=iCHFXnm3uJECSKV83nvxKoe5-SdemTGSewC4w47QFDI&e=).

View the release notes for more information:
[https://go.dev/doc/devel/release#go1.19.1](https://urldefense.proofpoint.com/v2/url?u=https-3A__go.dev_doc_devel_release-23go1.19.1&d=DwMFaQ&c=jf_iaSHvJObTbx-siA1ZOg&r=Ntx1o1kPu8e6E_CyZHzUyixOnKA3KnWwy6JoT-1xctQ&m=_ikePy3cqN5_pizsGIvSL9gL4kTY_CZIkHTc81Tl3EqzfEyaDCvDiF_RRrj4G9xY&s=QyqB70b6jmyD4NwY0ImJIZIFeFqc_UKfR_0X9bGFhQk&e=)
These minor releases include 2 security fixes following the [security policy](https://urldefense.proofpoint.com/v2/url?u=https-3A__go.dev_security&d=DwMFaQ&c=jf_iaSHvJObTbx-siA1ZOg&r=Ntx1o1kPu8e6E_CyZHzUyixOnKA3KnWwy6JoT-1xctQ&m=_ikePy3cqN5_pizsGIvSL9gL4kTY_CZIkHTc81Tl3EqzfEyaDCvDiF_RRrj4G9xY&s=GsdzLlpuxQmv9VIX_FGReJxPkwvR1LM_QHWvVdBmR1A&e=):

net/http: handle server errors after sending GOAWAY

A closing HTTP/2 server connection could hang forever waiting for a clean shutdown that was preempted by a subsequent fatal error. This failure mode could be exploited to cause a denial of service.

Thanks to Bahruz Jabiyev, Tommaso Innocenti, Anthony Gavazzi, Steven Sprecher, and Kaan Onarlioglu for reporting this.

This is CVE-2022-27664 and Go issue [https://go.dev/issue/54658](https://urldefense.proofpoint.com/v2/url?u=https-3A__go.dev_issue_54658&d=DwMFaQ&c=jf_iaSHvJObTbx-siA1ZOg&r=Ntx1o1kPu8e6E_CyZHzUyixOnKA3KnWwy6JoT-1xctQ&m=_ikePy3cqN5_pizsGIvSL9gL4kTY_CZIkHTc81Tl3EqzfEyaDCvDiF_RRrj4G9xY&s=6dVtpxw0WpO9fbq0KwoqucPgd8uG5-FBekv7Rur7oS4&e=).

net/url: JoinPath does not strip relative path components in all circumstances

JoinPath and URL.JoinPath would not remove ../ path components appended to a relative path. For example, JoinPath("[https://go.dev"](https://urldefense.proofpoint.com/v2/url?u=https-3A__go.dev-2522&d=DwQFaQ&c=jf_iaSHvJObTbx-siA1ZOg&r=Ntx1o1kPu8e6E_CyZHzUyixOnKA3KnWwy6JoT-1xctQ&m=_ikePy3cqN5_pizsGIvSL9gL4kTY_CZIkHTc81Tl3EqzfEyaDCvDiF_RRrj4G9xY&s=nZMjJZYwhsjBX3KnnI3jiL6uIh5GQj1Ct5dm422ORyI&e=), "../go") returned the URL [https://go.dev/../go](https://urldefense.proofpoint.com/v2/url?u=https-3A__go.dev_.._go&d=DwMFaQ&c=jf_iaSHvJObTbx-siA1ZOg&r=Ntx1o1kPu8e6E_CyZHzUyixOnKA3KnWwy6JoT-1xctQ&m=_ikePy3cqN5_pizsGIvSL9gL4kTY_CZIkHTc81Tl3EqzfEyaDCvDiF_RRrj4G9xY&s=s8mtHtALVm6JLxdZCaVN6VPLYK8HJGdcMBxgonYFPuQ&e=), despite the JoinPath documentation stating that ../ path elements are cleaned from the result.

Thanks to @q0jt for reporting this issue.

This is CVE-2022-32190 and Go issue [https://go.dev/issue/54385](https://urldefense.proofpoint.com/v2/url?u=https-3A__go.dev_issue_54385&d=DwMFaQ&c=jf_iaSHvJObTbx-siA1ZOg&r=Ntx1o1kPu8e6E_CyZHzUyixOnKA3KnWwy6JoT-1xctQ&m=_ikePy3cqN5_pizsGIvSL9gL4kTY_CZIkHTc81Tl3EqzfEyaDCvDiF_RRrj4G9xY&s=iCHFXnm3uJECSKV83nvxKoe5-SdemTGSewC4w47QFDI&e=).

View the release notes for more information:
[https://go.dev/doc/devel/release#go1.19.1](https://urldefense.proofpoint.com/v2/url?u=https-3A__go.dev_doc_devel_release-23go1.19.1&d=DwMFaQ&c=jf_iaSHvJObTbx-siA1ZOg&r=Ntx1o1kPu8e6E_CyZHzUyixOnKA3KnWwy6JoT-1xctQ&m=_ikePy3cqN5_pizsGIvSL9gL4kTY_CZIkHTc81Tl3EqzfEyaDCvDiF_RRrj4G9xY&s=QyqB70b6jmyD4NwY0ImJIZIFeFqc_UKfR_0X9bGFhQk&e=)
