### PR TITLE
Prevent injection vulnerabilities

### DIFF
--- a/cmd/annotations_prep/main.go
+++ b/cmd/annotations_prep/main.go
@@ -28,7 +28,8 @@ import (
 	"regexp"
 	"sort"
 	"strings"
-	"text/template"
+
+	template "github.com/google/safetext/yamltemplate"
 
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/yaml"

--- a/cmd/goc/template.go
+++ b/cmd/goc/template.go
@@ -16,7 +16,8 @@ package main
 
 import (
 	"bytes"
-	"text/template"
+
+	template "github.com/google/safetext/yamltemplate"
 )
 
 var (

--- a/isotope/convert/pkg/graphviz/graphviz.go
+++ b/isotope/convert/pkg/graphviz/graphviz.go
@@ -18,7 +18,8 @@ package graphviz
 import (
 	"bytes"
 	"fmt"
-	"text/template"
+
+	template "github.com/google/safetext/yamltemplate"
 
 	"istio.io/tools/isotope/convert/pkg/graph"
 	"istio.io/tools/isotope/convert/pkg/graph/script"


### PR DESCRIPTION
To prevent injection vulnerabilities, replace “text/template” with “[github.com/google/safetext](https://github.com/google/safetext)”.