### PR TITLE
Use istio-injection=enabled as default for stability test

### DIFF
--- a/perf/load/common.sh
+++ b/perf/load/common.sh
@@ -68,7 +68,7 @@ function run_test() {
 function start_servicegraphs() {
   local nn=${1:?"number of namespaces"}
   local min=${2:-"0"}
-  local injection_label=${3:?"injection label"}
+  local injection_label=${3:-"istio-injection=enabled"}
   local PERF_NAMESPACE_DELAY=${4:-30}
 
    # shellcheck disable=SC2004


### PR DESCRIPTION
Triggering long running tests fails on this step on master right now, this chooses the default injection label for the long running test as the default.