### PR TITLE
Update Go to 1.19.2

### DIFF
--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -25,7 +25,7 @@
 ################
 # Binary tools
 ################
-ARG GOLANG_IMAGE=golang:1.19.1
+ARG GOLANG_IMAGE=golang:1.19.2
 # hadolint ignore=DL3006
 FROM ${GOLANG_IMAGE} as binary_tools_context
 # TARGETARCH is an automatic platform ARG enabled by Docker BuildKit.


### PR DESCRIPTION
go1.19.2 (released 2022-10-04) includes security fixes to the archive/tar, net/http/httputil, and regexp packages, as well as bug fixes to the compiler, the linker, the runtime, and the go/types package. See the [Go 1.19.2 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.19.2+label%3ACherryPickApproved) on our issue tracker for details.

I do know that it will take some time for the docker image to get built and pushed which will prevent the pre-submit job from passing until complete.