### PR TITLE
Update Go to 1.18.7

### DIFF
--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -24,7 +24,7 @@
 ################
 # Binary tools
 ################
-ARG GOLANG_IMAGE=golang:1.18.6
+ARG GOLANG_IMAGE=golang:1.18.7
 # hadolint ignore=DL3006
 FROM ${GOLANG_IMAGE} as binary_tools_context
 # TARGETARCH is an automatic platform ARG enabled by Docker BuildKit.


### PR DESCRIPTION
go1.18.7 (released 2022-10-04) includes security fixes to the archive/tar, net/http/httputil, and regexp packages, as well as bug fixes to the compiler, the linker, and the go/types package. See the [Go 1.18.7 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.18.7+label%3ACherryPickApproved) on our issue tracker for details.

I do know that it will take some time for the docker image to get built and pushed which will prevent the pre-submit job from passing until complete.