### PR TITLE
docker: drop UPX

### DIFF
--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -65,7 +65,6 @@ ENV PROTOLOCK_VERSION=v0.14.0
 ENV PROTOTOOL_VERSION=v1.10.0
 ENV SHELLCHECK_VERSION=v0.8.0
 ENV SU_EXEC_VERSION=0.2
-ENV UPX_VERSION=3.96
 ENV YQ_VERSION=4.28.2
 ENV KPT_VERSION=v0.39.3
 ENV BUF_VERSION=v1.9.0
@@ -286,14 +285,6 @@ RUN set -eux; \
     apt-get -y install --no-install-recommends -f "/tmp/${TRVIY_DEB_NAME}"; \
     rm "/tmp/${TRVIY_DEB_NAME}"; \
     mv /usr/local/bin/trivy ${OUTDIR}/usr/bin/
-
-
-# Compress the Go tools and put them in their final location
-ADD https://github.com/upx/upx/releases/download/v${UPX_VERSION}/upx-${UPX_VERSION}-${TARGETARCH}_linux.tar.xz /tmp
-RUN tar -xJf /tmp/upx-${UPX_VERSION}-${TARGETARCH}_linux.tar.xz -C /tmp
-RUN mv /tmp/upx-${UPX_VERSION}-${TARGETARCH}_linux/upx /usr/bin
-RUN mv /tmp/go/bin/* ${OUTDIR}/usr/bin
-RUN find ${OUTDIR}/usr/bin/ -maxdepth 1 -type f  -writable | grep -v su-exec | xargs upx --lzma || true
 
 # Cleanup stuff we don't need in the final image
 RUN rm -fr /usr/local/go/doc


### PR DESCRIPTION
This was intended to compress binaries to reduce the (already massive) image a bit.

This comes at a cost - up to 1s per binary exec.

Docker images already have their own compression though. It turns out to be actually *smaller* to just rely on this, surprisingly.

Most importantly, upx binaries seem to have intermittent issues where they random exit with 127 (see
https://github.com/istio/istio/issues/41593, and various `kind` issues that have plagued us for years).