### PR TITLE
Add back upx and do not compress helm

### DIFF
--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -65,6 +65,7 @@ ENV PROTOLOCK_VERSION=v0.14.0
 ENV PROTOTOOL_VERSION=v1.10.0
 ENV SHELLCHECK_VERSION=v0.8.0
 ENV SU_EXEC_VERSION=0.2
+ENV UPX_VERSION=4.0.0
 ENV YQ_VERSION=4.28.2
 ENV KPT_VERSION=v0.39.3
 ENV BUF_VERSION=v1.9.0
@@ -289,8 +290,13 @@ RUN set -eux; \
     rm "/tmp/${TRVIY_DEB_NAME}"; \
     mv /usr/local/bin/trivy ${OUTDIR}/usr/bin/
 
-# Move go tools to usr/bin
+# Compress the Go tools and put them in their final location
+# Don't run upx against helm - Add a grep -v
+ADD https://github.com/upx/upx/releases/download/v${UPX_VERSION}/upx-${UPX_VERSION}-${TARGETARCH}_linux.tar.xz /tmp
+RUN tar -xJf /tmp/upx-${UPX_VERSION}-${TARGETARCH}_linux.tar.xz -C /tmp
+RUN mv /tmp/upx-${UPX_VERSION}-${TARGETARCH}_linux/upx /usr/bin
 RUN mv /tmp/go/bin/* ${OUTDIR}/usr/bin
+RUN find ${OUTDIR}/usr/bin/ -maxdepth 1 -type f -writable | grep -v su-exec | grep -v helm | xargs upx --lzma || true
 
 # Cleanup stuff we don't need in the final image
 RUN rm -fr /usr/local/go/doc

--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -289,6 +289,9 @@ RUN set -eux; \
     rm "/tmp/${TRVIY_DEB_NAME}"; \
     mv /usr/local/bin/trivy ${OUTDIR}/usr/bin/
 
+# Move go tools to usr/bin
+RUN mv /tmp/go/bin/* ${OUTDIR}/usr/bin
+
 # Cleanup stuff we don't need in the final image
 RUN rm -fr /usr/local/go/doc
 RUN rm -fr /usr/local/go/test
@@ -400,7 +403,7 @@ RUN gem install --no-wrappers --no-document licensee -v ${LICENSEE_VERSION}
 # hadolint ignore=DL3003,DL3028
 RUN mkdir fpm && \
     cd fpm && \
-    git init && \ 
+    git init && \
     git remote add origin https://github.com/jordansissel/fpm && \
     git fetch --depth 1 origin ${FPM_VERSION} && \
     git checkout FETCH_HEAD && \


### PR DESCRIPTION
Prior change inadvertently removed upx and the moving of the Go binaries to the PATH.

This resulted in a smaller sized image so it was assumed that upx was causing image to be bigger. The smaller size was due to missing binaries.

Add upx back in (it does shrink the binaries) and remove the compression of helm which was the start of the process.