### PR TITLE
Drop UPX properly this time

### DIFF
--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -65,7 +65,6 @@ ENV PROTOLOCK_VERSION=v0.14.0
 ENV PROTOTOOL_VERSION=v1.10.0
 ENV SHELLCHECK_VERSION=v0.8.0
 ENV SU_EXEC_VERSION=0.2
-ENV UPX_VERSION=4.0.0
 ENV YQ_VERSION=4.29.2
 ENV KPT_VERSION=v0.39.3
 ENV BUF_VERSION=v1.9.0
@@ -290,13 +289,8 @@ RUN set -eux; \
     rm "/tmp/${TRVIY_DEB_NAME}"; \
     mv /usr/local/bin/trivy ${OUTDIR}/usr/bin/
 
-# Compress the Go tools and put them in their final location
-# Don't run upx against helm - Add a grep -v
-ADD https://github.com/upx/upx/releases/download/v${UPX_VERSION}/upx-${UPX_VERSION}-${TARGETARCH}_linux.tar.xz /tmp
-RUN tar -xJf /tmp/upx-${UPX_VERSION}-${TARGETARCH}_linux.tar.xz -C /tmp
-RUN mv /tmp/upx-${UPX_VERSION}-${TARGETARCH}_linux/upx /usr/bin
+# Move Go tools to their final location
 RUN mv /tmp/go/bin/* ${OUTDIR}/usr/bin
-RUN find ${OUTDIR}/usr/bin/ -maxdepth 1 -type f -writable | grep -v su-exec | grep -v helm | xargs upx --lzma || true
 
 # Cleanup stuff we don't need in the final image
 RUN rm -fr /usr/local/go/doc


### PR DESCRIPTION
compressed: 1.4gb vs 1.4gb
uncompressed: 4.68gb vs 4.47gb

See https://github.com/istio/tools/pull/2216 for motivation