### PR TITLE
Fix file exclusion if flag not set in cue-gen

### DIFF
--- a/cmd/cue-gen/genoapi.go
+++ b/cmd/cue-gen/genoapi.go
@@ -192,8 +192,17 @@ func main() {
 		}
 	}
 
-	includes := strings.Split(*include, ",")
-	excludes := strings.Split(*exclude, ",")
+	var (
+		includes []string
+		excludes []string
+	)
+
+	if *include != "" {
+		includes = strings.Split(*include, ",")
+	}
+	if *exclude != "" {
+		excludes = strings.Split(*exclude, ",")
+	}
 
 	if *configFile == "" {
 		log.Fatalf("Must specify configuration with the -f option")


### PR DESCRIPTION
If the `exclude` flag was not set, all files were excluded by mistake, as `strings.Split` will return a list with one element (`""`) that would match all files when checking for exclusions.
This fixes a bug introduced in https://github.com/istio/tools/pull/2227