### PR TITLE
chore: fix root run dev container

### DIFF
--- a/docker/build-tools/docker-entrypoint.sh
+++ b/docker/build-tools/docker-entrypoint.sh
@@ -48,8 +48,11 @@ if [[ -f /config-copy/.docker/plaintext-passwords.json ]]; then
 fi
 
 # Add user based upon passed UID. this means Istio need no longer host mount /etc/passwd
-# nor /etc/group
-su-exec 0:0 useradd --uid "${uid}" --system user
+# nor /etc/group.
+# Skip adding if run as root.
+if [[ "${uid}" -ne 0 ]]; then
+  su-exec 0:0 useradd --uid "${uid}" --system user
+fi
 
 # Set ownership of /home to UID:GID
 su-exec 0:0 chown "${uid}":"${gid}" /home


### PR DESCRIPTION
When run as root, `useradd` raise an error:

```
root:[ztunnel]$ make help
useradd: UID 0 is not unique  <===
help                 Show this help
```


Signed-off-by: Loong <loong.dai@intel.com>