### PR TITLE
Update to not copy docker sockets in docker entry-point

### DIFF
--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -496,7 +496,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     file \
     libclang-dev \
     iproute2 \
-    ipset
+    ipset \
+    rsync
 
 # Fix Docker issue
 RUN update-alternatives --set iptables /usr/sbin/iptables-legacy && update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy

--- a/docker/build-tools/docker-entrypoint.sh
+++ b/docker/build-tools/docker-entrypoint.sh
@@ -21,7 +21,8 @@ gid=$(id -g)
 shopt -s dotglob
 
 # Make a copy of the hosts's config secrets
-su-exec 0:0 cp -R /config/* /config-copy/
+# Do not copy the Docker sockets
+su-exec 0:0 rsync -a --exclude=docker*.sock /config/ /config-copy/
 
 # Set the ownershp of the host's config secrets to that of the container
 su-exec 0:0 chown -R "${uid}":"${gid}" /config-copy


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/42240

Replace `cp` with `rsync` to allow specifying files not to copy in the entry-point script.

Testing with these changes on my Mac removes the warning messages. `docker ps` still works in the `make shell`