### PR TITLE
Add ingressgateway_tls config and changes to the benchmark runner

### DIFF
--- a/perf/benchmark/configs/istio/ingressgateway_tls/cpu_mem.yaml
+++ b/perf/benchmark/configs/istio/ingressgateway_tls/cpu_mem.yaml
@@ -1,0 +1,29 @@
+# Data: cpu/mem
+# Config: Ingress gateway TLS
+telemetry_mode: "ingressgateway-tls-listener-stats"
+conn:
+    - 16
+qps:
+    - 10
+    - 100
+    - 200
+    - 400
+    - 800
+    - 1000
+
+duration: 240
+perf_record: false
+run_bothsidecar: false
+run_serversidecar: false
+run_clientsidecar: false
+run_baseline: false
+
+jitter: false
+
+run_ingress: "https://istio-ingressgateway.istio-system.svc.cluster.local"
+headers: "Host:fortioserver.fake-dns.org"
+cacert: "/tmp/gateway-secret/tls.crt"
+
+uniform: true
+nocatchup: true
+connection_reuse: '10:10'

--- a/perf/benchmark/configs/istio/ingressgateway_tls/installation.yaml
+++ b/perf/benchmark/configs/istio/ingressgateway_tls/installation.yaml
@@ -1,0 +1,9 @@
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+spec:
+  meshConfig:
+    # This enables viewing e.g. TLS handshake statistics
+    defaultConfig:
+      proxyStatsMatcher:
+        inclusionPrefixes:
+          - "listener"

--- a/perf/benchmark/configs/istio/ingressgateway_tls/latency.yaml
+++ b/perf/benchmark/configs/istio/ingressgateway_tls/latency.yaml
@@ -1,0 +1,29 @@
+# Data: latency
+# Config: Ingress gateway TLS
+telemetry_mode: "ingressgateway-tls-listener-stats"
+conn:
+    - 2
+    - 4
+    - 8
+    - 16
+    - 32
+    - 64
+qps:
+    - 1000
+
+duration: 240
+perf_record: false
+run_bothsidecar: false
+run_serversidecar: false
+run_clientsidecar: false
+run_baseline: false
+
+jitter: false
+
+run_ingress: "https://istio-ingressgateway.istio-system.svc.cluster.local"
+headers: "Host:fortioserver.fake-dns.org"
+cacert: "/tmp/gateway-secret/tls.crt"
+
+uniform: true
+nocatchup: true
+connection_reuse: '10:10'

--- a/perf/benchmark/configs/istio/none/cpu_mem.yaml
+++ b/perf/benchmark/configs/istio/none/cpu_mem.yaml
@@ -11,7 +11,7 @@ qps:
     - 800
     - 1000
 duration: 240
-perf_record: true
+perf_record: false
 run_bothsidecar: true
 run_serversidecar: false
 run_clientsidecar: false

--- a/perf/benchmark/configs/istio/none/latency.yaml
+++ b/perf/benchmark/configs/istio/none/latency.yaml
@@ -12,7 +12,7 @@ qps:
     - 1000
 duration: 240
 size: 1024
-perf_record: true
+perf_record: false
 run_bothsidecar: true
 run_serversidecar: false
 run_clientsidecar: false

--- a/perf/benchmark/configs/istio/none_tcp/cpu_mem.yaml
+++ b/perf/benchmark/configs/istio/none_tcp/cpu_mem.yaml
@@ -11,7 +11,7 @@ qps:
     - 800
     - 1000
 duration: 240
-perf_record: true
+perf_record: false
 run_bothsidecar: true
 run_serversidecar: false
 run_clientsidecar: false

--- a/perf/benchmark/configs/istio/none_tcp/latency.yaml
+++ b/perf/benchmark/configs/istio/none_tcp/latency.yaml
@@ -12,7 +12,7 @@ qps:
     - 1000
 duration: 240
 size: 1024
-perf_record: true
+perf_record: false
 run_bothsidecar: true
 run_serversidecar: false
 run_clientsidecar: false

--- a/perf/benchmark/configs/istio/plaintext/cpu_mem.yaml
+++ b/perf/benchmark/configs/istio/plaintext/cpu_mem.yaml
@@ -12,7 +12,7 @@ qps:
     - 1000
 duration: 240
 size: 1024
-perf_record: true
+perf_record: false
 run_bothsidecar: true
 run_serversidecar: false
 run_clientsidecar: false

--- a/perf/benchmark/configs/istio/plaintext/latency.yaml
+++ b/perf/benchmark/configs/istio/plaintext/latency.yaml
@@ -11,7 +11,7 @@ conn:
 qps:
     - 1000
 duration: 240
-perf_record: true
+perf_record: false
 # we only care about both sidecar mode, which is the base line for mTLs overhead comparison.
 run_bothsidecar: true
 run_serversidecar: false

--- a/perf/benchmark/configs/istio/security_authz_dry_run/cpu_mem.yaml
+++ b/perf/benchmark/configs/istio/security_authz_dry_run/cpu_mem.yaml
@@ -12,7 +12,7 @@ qps:
     - 800
     - 1000
 duration: 240
-perf_record: true
+perf_record: false
 run_bothsidecar: true
 run_serversidecar: false
 run_clientsidecar: false

--- a/perf/benchmark/configs/istio/security_authz_dry_run/latency.yaml
+++ b/perf/benchmark/configs/istio/security_authz_dry_run/latency.yaml
@@ -12,7 +12,7 @@ conn:
 qps:
     - 1000
 duration: 240
-perf_record: true
+perf_record: false
 run_bothsidecar: true
 run_serversidecar: false
 run_clientsidecar: false

--- a/perf/benchmark/configs/istio/security_authz_ip/cpu_mem.yaml
+++ b/perf/benchmark/configs/istio/security_authz_ip/cpu_mem.yaml
@@ -12,7 +12,7 @@ qps:
     - 800
     - 1000
 duration: 240
-perf_record: true
+perf_record: false
 run_bothsidecar: true
 run_serversidecar: false
 run_clientsidecar: false

--- a/perf/benchmark/configs/istio/security_authz_ip/latency.yaml
+++ b/perf/benchmark/configs/istio/security_authz_ip/latency.yaml
@@ -12,7 +12,7 @@ conn:
 qps:
     - 1000
 duration: 240
-perf_record: true
+perf_record: false
 run_bothsidecar: true
 run_serversidecar: false
 run_clientsidecar: false

--- a/perf/benchmark/configs/istio/security_authz_jwt/cpu_mem.yaml
+++ b/perf/benchmark/configs/istio/security_authz_jwt/cpu_mem.yaml
@@ -12,7 +12,7 @@ qps:
     - 800
     - 1000
 duration: 240
-perf_record: true
+perf_record: false
 run_bothsidecar: true
 run_serversidecar: false
 run_clientsidecar: false

--- a/perf/benchmark/configs/istio/security_authz_jwt/latency.yaml
+++ b/perf/benchmark/configs/istio/security_authz_jwt/latency.yaml
@@ -12,7 +12,7 @@ conn:
 qps:
     - 1000
 duration: 240
-perf_record: true
+perf_record: false
 run_bothsidecar: true
 run_serversidecar: false
 run_clientsidecar: false

--- a/perf/benchmark/configs/istio/security_authz_path/cpu_mem.yaml
+++ b/perf/benchmark/configs/istio/security_authz_path/cpu_mem.yaml
@@ -12,7 +12,7 @@ qps:
     - 800
     - 1000
 duration: 240
-perf_record: true
+perf_record: false
 run_bothsidecar: true
 run_serversidecar: false
 run_clientsidecar: false

--- a/perf/benchmark/configs/istio/security_authz_path/latency.yaml
+++ b/perf/benchmark/configs/istio/security_authz_path/latency.yaml
@@ -12,7 +12,7 @@ conn:
 qps:
     - 1000
 duration: 240
-perf_record: true
+perf_record: false
 run_bothsidecar: true
 run_serversidecar: false
 run_clientsidecar: false

--- a/perf/benchmark/configs/istio/security_peer_authn/cpu_mem.yaml
+++ b/perf/benchmark/configs/istio/security_peer_authn/cpu_mem.yaml
@@ -12,7 +12,7 @@ qps:
     - 800
     - 1000
 duration: 240
-perf_record: true
+perf_record: false
 run_bothsidecar: true
 run_serversidecar: false
 run_clientsidecar: false

--- a/perf/benchmark/configs/istio/security_peer_authn/latency.yaml
+++ b/perf/benchmark/configs/istio/security_peer_authn/latency.yaml
@@ -12,7 +12,7 @@ conn:
 qps:
     - 1000
 duration: 240
-perf_record: true
+perf_record: false
 run_bothsidecar: true
 run_serversidecar: false
 run_clientsidecar: false

--- a/perf/benchmark/configs/istio/telemetryv2_sd_full/cpu_mem.yaml
+++ b/perf/benchmark/configs/istio/telemetryv2_sd_full/cpu_mem.yaml
@@ -12,7 +12,7 @@ qps:
     - 800
     - 1000
 duration: 240
-perf_record: true
+perf_record: false
 run_bothsidecar: true
 run_serversidecar: false
 run_clientsidecar: false

--- a/perf/benchmark/configs/istio/telemetryv2_sd_full/latency.yaml
+++ b/perf/benchmark/configs/istio/telemetryv2_sd_full/latency.yaml
@@ -12,7 +12,7 @@ conn:
 qps:
     - 1000
 duration: 240
-perf_record: true
+perf_record: false
 run_bothsidecar: true
 run_serversidecar: false
 run_clientsidecar: false

--- a/perf/benchmark/configs/istio/telemetryv2_sd_full_accesslogpolicy/cpu_mem.yaml
+++ b/perf/benchmark/configs/istio/telemetryv2_sd_full_accesslogpolicy/cpu_mem.yaml
@@ -12,7 +12,7 @@ qps:
     - 800
     - 1000
 duration: 240
-perf_record: true
+perf_record: false
 run_bothsidecar: true
 run_serversidecar: false
 run_clientsidecar: false

--- a/perf/benchmark/configs/istio/telemetryv2_sd_full_accesslogpolicy/latency.yaml
+++ b/perf/benchmark/configs/istio/telemetryv2_sd_full_accesslogpolicy/latency.yaml
@@ -13,7 +13,7 @@ qps:
     - 1000
 duration: 240
 size: 1024
-perf_record: true
+perf_record: false
 run_bothsidecar: true
 run_serversidecar: false
 run_clientsidecar: false

--- a/perf/benchmark/configs/istio/telemetryv2_sd_nologging/cpu_mem.yaml
+++ b/perf/benchmark/configs/istio/telemetryv2_sd_nologging/cpu_mem.yaml
@@ -12,7 +12,7 @@ qps:
     - 800
     - 1000
 duration: 240
-perf_record: true
+perf_record: false
 run_bothsidecar: true
 run_serversidecar: false
 run_clientsidecar: false

--- a/perf/benchmark/configs/istio/telemetryv2_sd_nologging/latency.yaml
+++ b/perf/benchmark/configs/istio/telemetryv2_sd_nologging/latency.yaml
@@ -12,7 +12,7 @@ conn:
 qps:
     - 1000
 duration: 240
-perf_record: true
+perf_record: false
 run_bothsidecar: true
 run_serversidecar: false
 run_clientsidecar: false

--- a/perf/benchmark/configs/istio/telemetryv2_stats/latency.yaml
+++ b/perf/benchmark/configs/istio/telemetryv2_stats/latency.yaml
@@ -12,7 +12,7 @@ conn:
 qps:
     - 1000
 duration: 240
-perf_record: true
+perf_record: false
 run_bothsidecar: true
 run_serversidecar: false
 run_clientsidecar: false

--- a/perf/benchmark/configs/istio/telemetryv2_statswasm/cpu_mem.yaml
+++ b/perf/benchmark/configs/istio/telemetryv2_statswasm/cpu_mem.yaml
@@ -12,7 +12,7 @@ qps:
     - 800
     - 1000
 duration: 240
-perf_record: true
+perf_record: false
 run_bothsidecar: true
 run_serversidecar: false
 run_clientsidecar: false

--- a/perf/benchmark/configs/istio/telemetryv2_statswasm/latency.yaml
+++ b/perf/benchmark/configs/istio/telemetryv2_statswasm/latency.yaml
@@ -12,7 +12,7 @@ conn:
 qps:
     - 1000
 duration: 240
-perf_record: true
+perf_record: false
 run_bothsidecar: true
 run_serversidecar: false
 run_clientsidecar: false

--- a/perf/benchmark/configs/run_perf_test.conf
+++ b/perf/benchmark/configs/run_perf_test.conf
@@ -11,3 +11,4 @@ security_authz_path=true
 security_authz_dry_run=true
 security_peer_authn=true
 security_authz_jwt=true
+ingressgateway_tls=false

--- a/perf/benchmark/runner/runner.py
+++ b/perf/benchmark/runner/runner.py
@@ -39,7 +39,7 @@ processes = []
 
 
 def pod_info(filterstr="", namespace=NAMESPACE, multi_ok=True):
-    cmd = "kubectl -n {namespace} get pod {filterstr}  -o json".format(
+    cmd = "kubectl -n {namespace} get pod {filterstr} -o json".format(
         namespace=namespace, filterstr=filterstr)
     op = getoutput(cmd)
     o = json.loads(op)
@@ -122,7 +122,11 @@ class Fortio:
             mesh="istio",
             cacert=None,
             jitter=False,
-            load_gen_type="fortio"):
+            uniform=False,
+            nocatchup=False,
+            load_gen_type="fortio",
+            keepalive=True,
+            connection_reuse=None):
         self.run_id = str(uuid.uuid4()).partition('-')[0]
         self.headers = headers
         self.conn = conn
@@ -148,7 +152,11 @@ class Fortio:
         self.run_ingress = ingress
         self.cacert = cacert
         self.jitter = jitter
+        self.uniform = uniform
+        self.nocatchup = nocatchup
         self.load_gen_type = load_gen_type
+        self.keepalive = keepalive
+        self.connection_reuse = connection_reuse
 
         if mesh == "linkerd":
             self.mesh = "linkerd"
@@ -247,13 +255,11 @@ class Fortio:
                 headers_cmd += "-H=" + header_val + " "
 
         return headers_cmd
-
-    def generate_fortio_cmd(self, headers_cmd, conn, qps, duration, grpc, cacert_arg, jitter, labels):
+    def generate_fortio_cmd(self, headers_cmd, conn, qps, duration, grpc, cacert_arg, jitter, uniform, nocatchup, keepalive, connection_reuse_arg, labels):
         if duration is None:
             duration = self.duration
-
         fortio_cmd = (
-            "fortio load {headers} -jitter={jitter} -c {conn} -qps {qps} -t {duration}s -a -r {r} {cacert_arg} {grpc} "
+            "fortio load {headers} -jitter={jitter} -uniform={uniform} -nocatchup={nocatchup} -keepalive={keepalive} {connection_reuse_arg} -c {conn} -qps {qps} -t {duration}s -a -r {r} {cacert_arg} {grpc} "
             "-httpbufferkb=128 -labels {labels}").format(
             headers=headers_cmd,
             conn=conn,
@@ -262,8 +268,12 @@ class Fortio:
             r=self.r,
             grpc=grpc,
             jitter=jitter,
+            uniform=uniform,
+            nocatchup=nocatchup,
             cacert_arg=cacert_arg,
-            labels=labels)
+            labels=labels,
+            keepalive=keepalive,
+            connection_reuse_arg=connection_reuse_arg)
 
         return fortio_cmd
 
@@ -326,11 +336,15 @@ class Fortio:
         if self.cacert is not None:
             cacert_arg = "-cacert {cacert_path}".format(cacert_path=self.cacert)
 
+        connection_reuse_arg = ""
+        if self.connection_reuse is not None:
+            connection_reuse_arg = "-connection-reuse={connection_reuse}".format(connection_reuse=self.connection_reuse)
+
         headers_cmd = self.generate_headers_cmd(headers)
 
         load_gen_cmd = ""
         if self.load_gen_type == "fortio":
-            load_gen_cmd = self.generate_fortio_cmd(headers_cmd, conn, qps, duration, grpc, cacert_arg, self.jitter, labels)
+            load_gen_cmd = self.generate_fortio_cmd(headers_cmd, conn, qps, duration, grpc, cacert_arg, self.jitter, self.uniform, self.nocatchup, self.keepalive, connection_reuse_arg, labels)
         elif self.load_gen_type == "nighthawk":
             # TODO(oschaaf): Figure out how to best determine the right concurrency for Nighthawk.
             # Results seem to get very noisy as the number of workers increases, are the clients
@@ -454,6 +468,11 @@ def fortio_from_config_file(args):
         fortio.protocol_mode = job_config.get('protocol_mode', 'http')
         fortio.extra_labels = job_config.get('extra_labels')
         fortio.jitter = job_config.get("jitter", False)
+        fortio.cacert = job_config.get("cacert", None)
+        fortio.uniform = job_config.get("uniform", False)
+        fortio.nocatchup = job_config.get("nocatchup", False)
+        fortio.keepalive = job_config.get("keepalive", True)
+        fortio.connection_reuse = job_config.get("connection_reuse", None)
 
         return fortio
 
@@ -490,7 +509,11 @@ def run_perf_test(args):
             telemetry_mode=args.telemetry_mode,
             cacert=args.cacert,
             jitter=args.jitter,
-            load_gen_type=args.load_gen_type)
+            uniform=args.uniform,
+            nocatchup=args.nocatchup,
+            load_gen_type=args.load_gen_type,
+            keepalive=args.keepalive,
+            connection_reuse=args.connection_reuse)
 
     if fortio.duration <= min_duration:
         print("Duration must be greater than {min_duration}".format(
@@ -650,9 +673,25 @@ def get_parser():
         help="to enable or disable jitter for load generator",
         default=False)
     parser.add_argument(
+        "--uniform",
+        help="to enable or disable uniform mode for the fortio load generator",
+        default=False)
+    parser.add_argument(
+        "--nocatchup",
+        help="to enable or disable nocatchup mode for the fortio load generator",
+        default=False)
+    parser.add_argument(
         "--load_gen_type",
         help="fortio or nighthawk",
-        default="fortio",
+        default="fortio")
+    parser.add_argument(
+        "--keepalive",
+        help="Connection keepalive",
+        default=True)
+    parser.add_argument(
+        "--connection_reuse",
+        help="Range min:max for the max number of connections to reuse for each thread, default to unlimited.",
+        default=None
     )
 
     define_bool(parser, "baseline", "run baseline for all", False)

--- a/perf/benchmark/runner/runner.py
+++ b/perf/benchmark/runner/runner.py
@@ -255,6 +255,7 @@ class Fortio:
                 headers_cmd += "-H=" + header_val + " "
 
         return headers_cmd
+
     def generate_fortio_cmd(self, headers_cmd, conn, qps, duration, grpc, cacert_arg, jitter, uniform, nocatchup, keepalive, connection_reuse_arg, labels):
         if duration is None:
             duration = self.duration
@@ -344,7 +345,8 @@ class Fortio:
 
         load_gen_cmd = ""
         if self.load_gen_type == "fortio":
-            load_gen_cmd = self.generate_fortio_cmd(headers_cmd, conn, qps, duration, grpc, cacert_arg, self.jitter, self.uniform, self.nocatchup, self.keepalive, connection_reuse_arg, labels)
+            load_gen_cmd = self.generate_fortio_cmd(headers_cmd, conn, qps, duration, grpc, cacert_arg, self.jitter,
+                                                    self.uniform, self.nocatchup, self.keepalive, connection_reuse_arg, labels)
         elif self.load_gen_type == "nighthawk":
             # TODO(oschaaf): Figure out how to best determine the right concurrency for Nighthawk.
             # Results seem to get very noisy as the number of workers increases, are the clients

--- a/perf/benchmark/templates/fortio.yaml
+++ b/perf/benchmark/templates/fortio.yaml
@@ -394,6 +394,11 @@ spec:
       volumes:
       - name: shared-data
         emptyDir: {}
+      {{- if and (eq $.name "fortioclient") ($.Values.cert.server) }}
+      - name: gateway-secret
+        secret:
+          secretName: fortio-server-ingress-cert
+      {{- end }}
       {{- if eq $.Values.loadGenType "nighthawk" }}
       - name: nighthawk-test-server-config
         configMap:
@@ -406,6 +411,10 @@ spec:
         volumeMounts:
         - name: shared-data
           mountPath: /var/lib/fortio
+        {{- if and (eq $.name "fortioclient") ($.Values.cert.server) }}
+        - name: gateway-secret
+          mountPath: /tmp/gateway-secret
+        {{- end }}
         {{- if eq $.Values.loadGenType "nighthawk" }}
         - name: nighthawk-test-server-config
           mountPath: /var/lib/nighthawk 
@@ -453,6 +462,11 @@ spec:
         volumeMounts:
         - name: shared-data
           mountPath: /var/lib/fortio
+        {{/* This enables the secret to be tested in the shell container. */}}
+        {{- if and (eq $.name "fortioclient") ($.Values.cert.server) }}
+        - name: gateway-secret
+          mountPath: /tmp/gateway-secret
+        {{- end }}
         {{- if eq $.Values.loadGenType "nighthawk" }}
         - name: nighthawk-test-server-config
           mountPath: /var/lib/nighthawk
@@ -572,6 +586,8 @@ spec:
       name: http
       number: 80
       protocol: HTTP
+{{- if $.Values.cert.client }}
+{{/* This has not been tested and has been left here if someone is interested in fixing/using it. */}}
   - hosts:
     - '*'
     port:
@@ -582,9 +598,22 @@ spec:
       mode: SIMPLE
       privateKey: /etc/istio/ingressgateway-certs/tls.key
       serverCertificate: /etc/istio/ingressgateway-certs/tls.crt
+{{- end }}
+{{- if $.Values.cert.server }}
+  - hosts:
+    - '*'
+    port:
+      name: https-fortioserver
+      number: 443
+      protocol: HTTPS
+    tls:
+      mode: SIMPLE
+      credentialName: fortio-server-ingress-cert
+{{- end }}
 ---
 {{- end }}
-{{- if $.Values.cert }}
+{{- if $.Values.cert.client }}
+{{/* This has not been tested and has been left here if someone is interested in fixing/using it. */}}
 apiVersion: certmanager.k8s.io/v1alpha1
 kind: Certificate
 metadata:

--- a/perf/benchmark/values.yaml
+++ b/perf/benchmark/values.yaml
@@ -42,7 +42,10 @@ client: # client overrides
   injectL: "disabled" # "enabled" or "disabled"
   replica: 1    # default value
 
-cert: false
+cert: 
+  client: false
+  server: false
+
 interceptionMode: REDIRECT
 
 namespace: ""


### PR DESCRIPTION
This pull request adds the possibility to use the Fortio client in the benchmark runner with https to connect to the ingress gateway. Changes to the benchmark runner have been added  to support this change. The changes also allow for changing the directory where the benchmark runner finds configurations for custom benchmark configurations. Also an example ingressgateway_tls benchmark config has been created.

Changes include:
 - Adding Fortio flags to the benchmark runner
	- add uniform flag
	- add nocatchup flag
	- add keepalive flag
	- add connection-reuse flag
 - Enabling custom benchmark config directory
 - Enabling setting specific Istio version
 - Changes to the helm template for using https
 - Creating self signed certificate and using it with https
 - Set perf_record to false until flame graphs are confirmed to work


Contributes to: https://github.com/istio/istio/issues/41609