### PR TITLE
Update git

### DIFF
--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -797,7 +797,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     zlib1g-dev \
     gettext \
     unzip && \
-    wget -q https://github.com/git/git/archive/v2.25.1.zip -O git.zip && \
+    wget -q https://github.com/git/git/archive/v2.39.1.zip -O git.zip && \
     unzip git.zip && \
     cd git-* && \
     make prefix=/usr/local all && \


### PR DESCRIPTION
Update git with the CVE issues.

I'm not sure if we need to force the apt-get version explicitly to update the version in the tools image (2.34.1 today). I think we would basically copy the changed code up into the base os context.