### PR TITLE
Debian `cmake` package missing standard targets/templates (enables`fips`-less builds of ztunnel)

### DIFF
--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -840,6 +840,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     autoconf \
     automake \
     cmake \
+    cmake-data \
     libtool \
     ninja-build \
     python \


### PR DESCRIPTION
1. We install `cmake` with `apt-get`'s `--no-install-recommends` in an effort to keep images slim.
2. When 
 - building `ztunnel` using this dev image
 - if `fips` is disabled (required ATM for non-x86-64 builds, probably always optional)
 - the Rust `boringcrypto` library's `cmake` targets fail because they cannot find the standard library of targets and templates in `/usr/share`, which they depend on.
3. This is because Debian puts those in `cmake-data` which would normally be installed, absent `--no-install-recommends`, leaving a functionally incomplete `cmake` install.
4. Add `cmake-data` to the tools image so I don't have to install it manually every time I want to build on a modern Mac.