### PR TITLE
Followup fix for #2344

### DIFF
--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -475,6 +475,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     gnupg-agent \
     software-properties-common \
     ca-certificates \
+    cmake \
+    cmake-data \
     gcc \
     git \
     ssh \
@@ -840,7 +842,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     autoconf \
     automake \
     cmake \
-    cmake-data \
     libtool \
     ninja-build \
     python \


### PR DESCRIPTION
1. In https://github.com/istio/tools/pull/2344 I added `cmake-data` to what I thought was the output Docker build stage, as it was the last stage defined in the Dockerfile: `build_env_proxy`

2. I missed that `build_env_proxy` is the target used for the `build-tools-proxy` image, not the `build-tools` image - the latter is what we actually use for `ztunnel` and what I need `cmake` in.

3. Given how `base_os_context` is used/copied into later stages (we need `/usr/bin/cmake` and `/usr/share/cmake-xx` to end up in the final image), putting `cmake` && `cmake-data` in the `base_os_context` stage seems to be the cleanest way to get a non-compromised `cmake` install in the final `build-tools` image.