### PR TITLE
[release-1.15] Update to Go 1.19.6

### DIFF
--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -25,7 +25,7 @@
 ################
 # Binary tools
 ################
-ARG GOLANG_IMAGE=golang:1.19.5
+ARG GOLANG_IMAGE=golang:1.19.6
 # hadolint ignore=DL3006
 FROM ${GOLANG_IMAGE} as binary_tools_context
 # TARGETARCH is an automatic platform ARG enabled by Docker BuildKit.


### PR DESCRIPTION
Need to wait on official Docker images

go1.19.6 (released 2023-02-14) includes security fixes to the crypto/tls, mime/multipart, net/http, and path/filepath packages, as well as bug fixes to the go command, the linker, the runtime, and the crypto/x509, net/http, and time packages. See the [Go 1.19.6 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.19.6+label%3ACherryPickApproved) on our issue tracker for details.