### PR TITLE
add build dependencies for ebpf

### DIFF
--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -469,6 +469,7 @@ ENV OUTDIR=/out
 # required for general build: make, wget, curl, ssh, rpm
 # required for ruby: libcurl4-openssl-dev
 # required for python: python3, pkg-config
+# required for ebpf build: clang,llvm,libbpf-dev
 # hadolint ignore=DL3008
 RUN apt-get update && apt-get install -y --no-install-recommends \
     apt-transport-https \
@@ -501,7 +502,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libclang-dev \
     iproute2 \
     ipset \
-    rsync
+    rsync \
+    clang \
+    llvm \
+    libbpf-dev
 
 # Fix Docker issue
 RUN update-alternatives --set iptables /usr/sbin/iptables-legacy && update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy


### PR DESCRIPTION
below dependencies are added:
 clang 
 llvm 
libbpf-dev

Image side 
gcr.io/istio-testing/build-tools            master-051322f0945741253e6fb17ebd65e0f8d81341ad          15d9cf7025ca       4.95GB


gcr.io/istio-testing/build-tools            master-2023-02-17T14-56-30-amd64                         0fec7cd75115       5.23GB

less than 300MB increase
