### PR TITLE
remove deprecated pipenv command from benchmark readme

### DIFF
--- a/perf/benchmark/README.md
+++ b/perf/benchmark/README.md
@@ -45,7 +45,6 @@ packages needed to run the benchmarking scripts and [graph_plotter](./graph_plot
 
 ```bash
 cd perf/benchmark
-pipenv --three
 pipenv shell
 pipenv install
 ```


### PR DESCRIPTION
`pipenv --three` either gives a deprecation warning or an option not found error. It can be removed since python3 is the default now.