### PR TITLE
separate stdout/stderr and use subprocess.run in benchmark runner script

### DIFF
--- a/perf/benchmark/README.md
+++ b/perf/benchmark/README.md
@@ -8,7 +8,7 @@ For instructions on how to run these scripts with Linkerd, see the [linkerd/](li
 
 ## Prerequisites
 
-1. [Python3](https://docs.python-guide.org/starting/installation/#installation-guides)
+1. [Python3](https://docs.python-guide.org/starting/installation/#installation-guides) >= 3.5
 1. [`pipenv`](https://docs.python-guide.org/dev/virtualenvs/#virtualenvironments-ref)
 1. [helm](https://helm.sh/docs/using_helm/#install-helm)
 


### PR DESCRIPTION
This PR solves an issue where the `pod_info` function may fail since the kubectl stderr output will interfere with the json decoding. For example, in some environments kubectl may give stderr `E0126 14:24:32.369217    6338 memcache.go:255] couldn't get resource list for external.metrics.k8s.io/v1beta1: Got empty response for: external.metrics.k8s.io/v1beta1` which can currently get combined with the json pod info.

Other changes:
* migrate to subprocess.run in a couple spots where it's okay to wait for the process to complete
  * Note: this has a requirement on python >=3.5 which I've added to the readme
* minor formatting updates