### PR TITLE
Make golangci-lint static

### DIFF
--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -135,7 +135,8 @@ RUN go install -ldflags="-s -w" google.golang.org/protobuf/cmd/protoc-gen-go@${G
 RUN go install -ldflags="-s -w" google.golang.org/grpc/cmd/protoc-gen-go-grpc@${GOLANG_GRPC_PROTOBUF_VERSION}
 RUN go install -ldflags="-s -w" github.com/nilslice/protolock/cmd/protolock@${PROTOLOCK_VERSION}
 RUN go install -ldflags="-s -w" golang.org/x/tools/cmd/goimports@${GOIMPORTS_VERSION}
-RUN go install -ldflags="-s -w" github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANGCI_LINT_VERSION}
+# Use static as we also use in build-tools-proxy image
+RUN go install -ldflags="-s -w -extldflags '-static'" github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANGCI_LINT_VERSION}
 RUN go install -ldflags="-s -w" github.com/go-bindata/go-bindata/go-bindata@${GO_BINDATA_VERSION}
 RUN go install -ldflags="-s -w" github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway@${PROTOC_GEN_GRPC_GATEWAY_VERSION}
 RUN go install -ldflags="-s -w" github.com/google/go-jsonnet/cmd/jsonnet@${JSONNET_VERSION}

--- a/perf_dashboard/settings/views.py
+++ b/perf_dashboard/settings/views.py
@@ -15,7 +15,7 @@
 import os
 from django.shortcuts import render
 
-#current_release = [os.getenv('CUR_RELEASE')]
+# current_release = [os.getenv('CUR_RELEASE')]
 
 
 # Create your views here.


### PR DESCRIPTION
After this change I was able to run `golangci-lint` and see the usage instead of the missing library error.

I still see a su-exec issue when trying to run the shell in istio/proxy (which isn't typically done). I'll work on that in another PR.

```
> IMG=ericvn/build-tools:master-latest-amd64 make shell 
build-tools:/work$ golangci-lint
Smart, fast linters runner.

Usage:
  golangci-lint [flags]
  golangci-lint [command]

Available Commands:
  cache       Cache control and information
  completion  Generate the autocompletion script for the specified shell
```
before was:
```
build-tools:/work$ golangci-lint
golangci-lint: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by golangci-lint)
golangci-lint: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by golangci-lint)
build-tools:/work$ exit
```