### PR TITLE
Change su-exec to static binary

### DIFF
--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -69,7 +69,7 @@ ENV PROTOC_GEN_VALIDATE_VERSION=1.0.1
 ENV PROTOC_VERSION=23.2
 ENV PROTOLOCK_VERSION=v0.16.0
 ENV SHELLCHECK_VERSION=v0.9.0
-ENV SU_EXEC_VERSION=0.2
+ENV SU_EXEC_VERSION=0.3.1
 ENV TRIVY_VERSION=0.42.1
 ENV YQ_VERSION=4.34.1
 
@@ -248,11 +248,8 @@ RUN wget -nv -O "${OUTDIR}/usr/bin/buf" "https://github.com/bufbuild/buf/release
     chmod 555 "${OUTDIR}/usr/bin/buf"
 
 # Install su-exec which is a tool that operates like sudo without the overhead
-ADD https://github.com/ncopa/su-exec/archive/v${SU_EXEC_VERSION}.tar.gz /tmp
-RUN tar -xzvf v${SU_EXEC_VERSION}.tar.gz
-WORKDIR /tmp/su-exec-${SU_EXEC_VERSION}
-RUN make
-RUN cp -a su-exec ${OUTDIR}/usr/bin
+RUN wget -nv -O "${OUTDIR}/usr/bin/su-exec" https://github.com/NobodyXu/su-exec/releases/download/v${SU_EXEC_VERSION}/su-exec-musl-static && \
+    chmod 555 "${OUTDIR}/usr/bin/su-exec"
 
 ADD https://github.com/GoogleContainerTools/kpt/releases/download/${KPT_VERSION}/kpt_linux_${TARGETARCH} ${OUTDIR}/usr/bin/kpt
 RUN chmod 555 ${OUTDIR}/usr/bin/kpt

--- a/perf_dashboard/settings/views.py
+++ b/perf_dashboard/settings/views.py
@@ -15,7 +15,7 @@
 import os
 from django.shortcuts import render
 
-#current_release = [os.getenv('CUR_RELEASE')]
+# current_release = [os.getenv('CUR_RELEASE')]
 
 
 # Create your views here.


### PR DESCRIPTION
After the latest update su-exec has errors in the build-tools-proxy image:
```
> IMG=ericvn/build-tools-proxy:master-latest-amd64 BUILD_WITH_CONTAINER=1 make shell
su-exec: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by su-exec)
su-exec: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by su-exec)
chmod: changing permissions of '/config-copy': Operation not permitted
su-exec: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by su-exec)
su-exec: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by su-exec)
cp: cannot stat '/config-copy/*': No such file or directory
```

This PR changes to another repo forked from the prior repo that builds a static binary. I tried to use the new repo source and run make sis-exec-static but ran into an error, so pulling the built image directly. 

I don't have an ARM computer to verify the binary works there.