### PR TITLE
[release-1.17] Pin golang base container to bullseye

### DIFF
--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -25,7 +25,7 @@
 ################
 # Binary tools
 ################
-ARG GOLANG_IMAGE=golang:1.20.5
+ARG GOLANG_IMAGE=golang:1.20.5-bullseye
 # hadolint ignore=DL3006
 FROM ${GOLANG_IMAGE} as binary_tools_context
 # TARGETARCH is an automatic platform ARG enabled by Docker BuildKit.


### PR DESCRIPTION
Latest images were using bookworm, not bullseye. Previous versions were built on bullseye base image.