### PR TITLE
auth-before-secret - move SA auth before secrets are read

### DIFF
--- a/docker/build-tools/prow-entrypoint.sh
+++ b/docker/build-tools/prow-entrypoint.sh
@@ -36,6 +36,12 @@ function read_gcp_secrets() {
   done
 }
 
+# Authenticate gcloud, allow failures
+if [[ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then
+  # Jobs that need this will fail later and jobs that don't should fail because of this
+  gcloud auth activate-service-account --key-file="${GOOGLE_APPLICATION_CREDENTIALS}" || true
+fi
+
 read_gcp_secrets
 
 # Output a message, with a timestamp matching istio log format
@@ -92,11 +98,6 @@ function cleanup() {
 
 trap cleanup EXIT
 
-# Authenticate gcloud, allow failures
-if [[ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then
-  # Jobs that need this will fail later and jobs that don't should fail because of this
-  gcloud auth activate-service-account --key-file="${GOOGLE_APPLICATION_CREDENTIALS}" || true
-fi
 # Always try to authenticate to GCR.
 gcloud auth configure-docker -q || true
 


### PR DESCRIPTION
Whom should have access to read secrets?
The Node WI or the prowjob?

I believe the prowjob should have secret access not the node, in which case we should auth before reading secrets.