### PR TITLE
Revamp release-notes tool

### DIFF
--- a/cmd/gen-release-notes/main.go
+++ b/cmd/gen-release-notes/main.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"embed"
-	_ "embed"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -171,7 +170,8 @@ func checkReleaseNotesLabel(info PRInfo) error {
 		log.Printf("%d release notes found.\n", len(info.ReleaseNoteFiles))
 		return nil
 	}
-	newUrl := fmt.Sprintf("https://github.com/%s/%s/new/%s/releasenotes/notes", info.Author, os.Getenv("PULL_HEAD_REF"), os.Getenv("PULL_BASE_REF"))
+	newURL := fmt.Sprintf("https://github.com/%s/%s/new/%s/releasenotes/notes", info.Author, os.Getenv("PULL_HEAD_REF"), os.Getenv("PULL_BASE_REF"))
+	// nolint: lll
 	log.Printf(`
 ERROR: Missing release notes and missing %q label.
 
@@ -180,7 +180,7 @@ If this pull request contains user facing changes, please create a release note 
 Release notes documentation can be found here: https://github.com/istio/istio/tree/master/releasenotes.
 
 If this pull request has no user facing changes, please add the %qlabel to the pull request. Note that the test will have to be manually retriggered (/retest) after adding the label.
-`, ReleaseNoteNone, newUrl, ReleaseNoteNone)
+`, ReleaseNoteNone, newURL, ReleaseNoteNone)
 	return fmt.Errorf("missing release notes and missing %q label", ReleaseNoteNone)
 }
 

--- a/cmd/gen-release-notes/main.go
+++ b/cmd/gen-release-notes/main.go
@@ -21,7 +21,7 @@ import (
 	"flag"
 	"fmt"
 	"io/fs"
-	"istio.io/tools/pkg/schemavalidation"
+	"log"
 	"os"
 	"os/exec"
 	"path"
@@ -32,6 +32,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"istio.io/tools/pkg/markdown"
+	"istio.io/tools/pkg/schemavalidation"
 )
 
 //go:embed release_notes_schema.json
@@ -58,25 +59,27 @@ func (flagString *flagStrings) Set(value string) error {
 }
 
 func main() {
-	var oldBranch, newBranch, outDir, oldRelease, newRelease, pullRequest string
-	var validateOnly bool
+	var oldBranch, newBranch, outDir, oldRelease, newRelease string
+	var validateOnly, checkLabel bool
 	var notesDirs flagStrings
 
 	flag.StringVar(&oldBranch, "oldBranch", "a", "branch to compare against")
 	flag.StringVar(&newBranch, "newBranch", "b", "branch containing new files")
-	flag.StringVar(&pullRequest, "pullRequest", "", "the pull request to check. Either this or oldBranch & newBranch are required.")
 	flag.Var(&notesDirs, "notes", "the directory containing release notes. Repeat for multiple notes directories")
 	flag.StringVar(&outDir, "outDir", ".", "the directory containing release notes")
 	flag.BoolVar(&validateOnly, "validateOnly", false, "set to true to perform validation only")
+	flag.BoolVar(&checkLabel, "checkLabel", false, "set to true to check PR has release notes OR a release-notes-none label")
 	flag.StringVar(&oldRelease, "oldRelease", "x.y.(z-1)", "old release")
 	flag.StringVar(&newRelease, "newRelease", "x.y.z", "new release")
 	flag.Parse()
 
-	// Prow, at the time of writing this, does not use Git clone, meaning that there is no remote for the pull request. Generate a URL instead if we're using Prow.
+	// Detect if we are in CI, if so we are checking a single PR...
 	RepoOwner := os.Getenv("REPO_OWNER")
 	RepoName := os.Getenv("REPO_NAME")
-	if RepoOwner != "" && RepoName != "" {
-		pullRequest = fmt.Sprintf("https://github.com/%s/%s/pull/%s", RepoOwner, RepoName, pullRequest)
+	PullRequest := os.Getenv("PULL_NUMBER")
+	var pullRequest string
+	if RepoOwner != "" && RepoName != "" && PullRequest != "" {
+		pullRequest = fmt.Sprintf("https://github.com/%s/%s/pull/%s", RepoOwner, RepoName, PullRequest)
 	}
 
 	if len(notesDirs) == 0 {
@@ -85,42 +88,41 @@ func main() {
 
 	var releaseNotes []Note
 	for _, notesDir := range notesDirs {
-		var releaseNoteFiles []string
 
-		fmt.Printf("Looking for release notes in %s.\n", notesDir)
+		log.Printf("Looking for release notes in %q.\n", notesDir)
 
 		releaseNotesDir := "releasenotes/notes"
 		if _, err := os.Stat(notesDir); os.IsNotExist(err) {
-			fmt.Printf("Could not find repository -- directory %s does not exist.\n", notesDir)
+			log.Printf("Could not find repository -- directory %s does not exist.\n", notesDir)
 			os.Exit(1)
 		}
 
 		if _, err := os.Stat(filepath.Join(notesDir, releaseNotesDir)); os.IsNotExist(err) {
-			fmt.Printf("Could not find release notes directory -- %s does not exist.\n", filepath.Join(notesDir, releaseNotesDir))
+			log.Printf("Could not find release notes directory -- %s does not exist.\n", filepath.Join(notesDir, releaseNotesDir))
 			os.Exit(2)
 		}
 
-		var err error
-		releaseNoteFiles, err = getNewFilesInBranch(oldBranch, newBranch, pullRequest, notesDir, releaseNotesDir)
+		branchInfo, err := getNewFilesInBranch(oldBranch, newBranch, pullRequest, notesDir, releaseNotesDir)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "failed to list files: %s\n", err.Error())
 			os.Exit(1)
 		}
-		fmt.Printf("Found %d files.\n\n", len(releaseNoteFiles))
+		log.Printf("Found %d release note files.\n", len(branchInfo.ReleaseNoteFiles))
 
-		fmt.Printf("Parsing release notes\n")
-		releaseNotesEntries, err := parseReleaseNotesFiles(notesDir, releaseNoteFiles)
+		if checkLabel {
+			log.Println("Checking label or release notes are present...")
+			if err := checkReleaseNotesLabel(branchInfo); err != nil {
+				os.Exit(1)
+			}
+		}
+
+		log.Printf("Parsing release notes\n")
+		releaseNotesEntries, err := parseReleaseNotesFiles(notesDir, branchInfo.ReleaseNoteFiles)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Unable to read release notes: %s\n", err.Error())
 			os.Exit(1)
 		}
 		releaseNotes = append(releaseNotes, releaseNotesEntries...)
-	}
-
-	if len(releaseNotes) < 1 {
-		fmt.Fprintf(os.Stderr, "failed to find any release notes.\n")
-		// maps to EX_NOINPUT, but more importantly lets us differentiate between no files found and other errors
-		os.Exit(66)
 	}
 
 	if validateOnly {
@@ -132,7 +134,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "failed to list files: %s\n", err.Error())
 		os.Exit(1)
 	}
-	fmt.Printf("Found %d files.\n\n", len(templateFiles))
+	log.Printf("Found %d files.\n\n", len(templateFiles))
 
 	if err := createDirIfNotExists(outDir); err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to create our dir: %s\n", err.Error())
@@ -148,15 +150,38 @@ func main() {
 		if err := writeAsMarkdown(path.Join(outDir, filename), output); err != nil {
 			fmt.Fprintf(os.Stderr, "Failed to write markdown: %s\n", err.Error())
 		} else {
-			fmt.Printf("Wrote markdown to %s\n", filename)
+			log.Printf("Wrote markdown to %s\n", filename)
 		}
 
 		if err := writeAsHTML(path.Join(outDir, filename), output); err != nil {
 			fmt.Fprintf(os.Stderr, "Failed to write HTML: %s\n", err.Error())
 		} else {
-			fmt.Printf("Wrote markdown to %s.html\n", filename)
+			log.Printf("Wrote markdown to %s.html\n", filename)
 		}
 	}
+}
+
+// Check we have release-notes-none label OR we have release notes
+func checkReleaseNotesLabel(info PRInfo) error {
+	if info.HasReleaseNoteNoneLabel {
+		log.Printf("Found %q label. This pull request will not include release notes.\n", ReleaseNoteNone)
+		return nil
+	}
+	if len(info.ReleaseNoteFiles) > 0 {
+		log.Printf("%d release notes found.\n", len(info.ReleaseNoteFiles))
+		return nil
+	}
+	newUrl := fmt.Sprintf("https://github.com/%s/%s/new/%s/releasenotes/notes", info.Author, os.Getenv("PULL_HEAD_REF"), os.Getenv("PULL_BASE_REF"))
+	log.Printf(`
+ERROR: Missing release notes and missing %q label.
+
+If this pull request contains user facing changes, please create a release note based on the template: https://github.com/istio/istio/blob/master/releasenotes/template.yaml by going here: %s.
+
+Release notes documentation can be found here: https://github.com/istio/istio/tree/master/releasenotes.
+
+If this pull request has no user facing changes, please add the %qlabel to the pull request. Note that the test will have to be manually retriggered (/retest) after adding the label.
+`, ReleaseNoteNone, newUrl, ReleaseNoteNone)
+	return fmt.Errorf("missing release notes and missing %q label", ReleaseNoteNone)
 }
 
 func createDirIfNotExists(path string) error {
@@ -226,15 +251,14 @@ func parseReleaseNotesFiles(filePath string, files []string) ([]Note, error) {
 		}
 		note.File = file
 		notes = append(notes, note)
-		fmt.Printf("found %d upgrade notes, %d release notes, and %d security notes in %s\n", len(note.UpgradeNotes),
+		log.Printf("found %d upgrade notes, %d release notes, and %d security notes in %s\n", len(note.UpgradeNotes),
 			len(note.ReleaseNotes), len(note.SecurityNotes), note.File)
-
 	}
 	return notes, nil
 }
 
 func populateTemplate(filename string, releaseNotes []Note, oldRelease string, newRelease string) (string, error) {
-	fmt.Printf("Processing %s\n", filename)
+	log.Printf("Processing %s\n", filename)
 
 	contents, err := fs.ReadFile(templates, filename)
 	if err != nil {
@@ -265,23 +289,32 @@ type prView struct {
 	Files []struct {
 		Path string `json:"path"`
 	} `json:"files"`
+	Labels []struct {
+		Name string `json:"name"`
+	} `json:"labels"`
+	Author struct {
+		Login string `json:"login"`
+	} `json:"author"`
 }
 
-func getFilesFromGHPRView(path string, pullRequest string, notesSubpath string) ([]string, error) {
-	cmdStr := fmt.Sprintf("cd %s; gh pr view %s --json files", path, pullRequest)
-	fmt.Printf("Executing: %s\n", cmdStr)
-
-	cmd := exec.Command("bash", "-c", cmdStr)
-	cmd.Env = os.Environ()
-	out, err := cmd.CombinedOutput()
-	fmt.Printf("%s\n", out)
+func ReadGithubPR(path string, pullRequest string, notesSubpath string) (PRInfo, error) {
+	c := exec.Command(
+		"gh",
+		"pr",
+		"view",
+		pullRequest,
+		"--json=files,labels,author",
+	)
+	c.Dir = path
+	log.Printf("Executing: %s\n", strings.Join(c.Args, " "))
+	out, err := c.CombinedOutput()
 	if err != nil {
-		return nil, fmt.Errorf("received error running GH: %s", err.Error())
+		return PRInfo{}, fmt.Errorf("received error running GH: %s", err.Error())
 	}
 
 	var prResults prView
 	if err := json.Unmarshal(out, &prResults); err != nil {
-		return nil, fmt.Errorf("failed to parse GH results: %s", err.Error())
+		return PRInfo{}, fmt.Errorf("failed to parse GH results: %s", err.Error())
 	}
 
 	var results []string
@@ -294,29 +327,59 @@ func getFilesFromGHPRView(path string, pullRequest string, notesSubpath string) 
 		}
 	}
 
-	return results, nil
-}
-
-func getNewFilesInBranch(oldBranch string, newBranch string, pullRequest string, path string, notesSubpath string) ([]string, error) {
-	// if there's a pull request, we can just get the changed files from GitHub. If not, we have to do it manually.
-	if pullRequest != "" {
-		return getFilesFromGHPRView(path, pullRequest, notesSubpath)
+	info := PRInfo{
+		Author:                  prResults.Author.Login,
+		ReleaseNoteFiles:        results,
+		HasReleaseNoteNoneLabel: false,
+	}
+	for _, l := range prResults.Labels {
+		if l.Name == ReleaseNoteNone {
+			info.HasReleaseNoteNoneLabel = true
+			break
+		}
 	}
 
-	cmd := fmt.Sprintf("cd %s; git diff-tree -r --diff-filter=AMR --name-only --relative=%s '%s' '%s'", path, notesSubpath, oldBranch, newBranch)
-	fmt.Printf("Executing: %s\n", cmd)
-	out, err := exec.Command("bash", "-c", cmd).CombinedOutput()
+	return info, nil
+}
+
+const ReleaseNoteNone = "release-notes-none"
+
+type PRInfo struct {
+	Author                  string
+	ReleaseNoteFiles        []string
+	HasReleaseNoteNoneLabel bool
+}
+
+func getNewFilesInBranch(oldBranch string, newBranch string, pullRequest string, path string, notesSubpath string) (PRInfo, error) {
+	// if there's a pull request, we can just get the changed files from GitHub. If not, we have to do it manually.
+	if pullRequest != "" {
+		return ReadGithubPR(path, pullRequest, notesSubpath)
+	}
+
+	c := exec.Command(
+		"git",
+		"diff-tree",
+		"-r",
+		"--diff-filter=AMR",
+		"--name-only",
+		"--relative="+notesSubpath,
+		oldBranch,
+		newBranch,
+	)
+	c.Dir = path
+	log.Printf("Executing: %s\n", strings.Join(c.Args, " "))
+	out, err := c.CombinedOutput()
 	if err != nil {
-		return nil, err
+		return PRInfo{}, err
 	}
 	outFiles := strings.Split(string(out), "\n")
 
-	// the getFilesFromGHPRView(path, pullRequest, notesSubpath) method returns file names which are relative to the repo path.
+	// the ReadGithubPR(path, pullRequest, notesSubpath) method returns file names which are relative to the repo path.
 	// the git diff-tree is relative to the notesSupbpath, so we need to add the subpath back to the filenames.
 	outFileswithPath := []string{}
 	for _, f := range outFiles[:len(outFiles)-1] { // skip the last file which is empty
 		outFileswithPath = append(outFileswithPath, filepath.Join(notesSubpath, f))
 	}
 
-	return outFileswithPath, nil
+	return PRInfo{ReleaseNoteFiles: outFileswithPath}, nil
 }

--- a/cmd/schema-validator/validate.go
+++ b/cmd/schema-validator/validate.go
@@ -16,11 +16,12 @@ package main
 import (
 	"flag"
 	"fmt"
-	"istio.io/tools/pkg/schemavalidation"
 	"log"
 	"os"
 
 	"sigs.k8s.io/yaml"
+
+	"istio.io/tools/pkg/schemavalidation"
 )
 
 func main() {
@@ -41,9 +42,8 @@ func main() {
 
 	if err := schemavalidation.Validate(doc, schema); err != nil {
 		log.Fatal(err)
-	} else {
-		log.Println("document is valid")
 	}
+	log.Println("document is valid")
 }
 
 func readYAMLAsJSON(filename string) (string, error) {

--- a/pkg/schemavalidation/validation.go
+++ b/pkg/schemavalidation/validation.go
@@ -1,0 +1,38 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schemavalidation
+
+import (
+	"fmt"
+	"github.com/xeipuuv/gojsonschema"
+	"sigs.k8s.io/yaml"
+)
+
+func Validate(document, schema []byte) error {
+	documentAsYaml, err := yaml.YAMLToJSON(document)
+	if err != nil {
+		return fmt.Errorf("unable to parse YAML: %s", err.Error())
+	}
+	documentLoader := gojsonschema.NewBytesLoader(documentAsYaml)
+	schemaLoader := gojsonschema.NewBytesLoader(schema)
+	result, err := gojsonschema.Validate(schemaLoader, documentLoader)
+	if err != nil {
+		return fmt.Errorf("unable to validate: %v", err)
+	}
+	if !result.Valid() {
+		return fmt.Errorf("document is not valid: %v", result.Errors())
+	}
+	return nil
+}

--- a/pkg/schemavalidation/validation.go
+++ b/pkg/schemavalidation/validation.go
@@ -16,6 +16,7 @@ package schemavalidation
 
 import (
 	"fmt"
+
 	"github.com/xeipuuv/gojsonschema"
 	"sigs.k8s.io/yaml"
 )


### PR DESCRIPTION
to be safe, I would prefer we do this after https://github.com/istio/test-infra/pull/4808. This will ensure that, if we mess this up badly, we only leak a very low priv github token.

This change dramatically simplifies the release notes check.

Currently, the job checks out istio/tools and istio/test-infra. It calls a script in istio/test-infra which does a bunch of complex bash stuff, builds 2 binaries in istio/tools (schema checker and release notes checker), then fetches the files changed and calls the schema checker, runs the release note validator (which also fetches files changed), and then checks labels.

We call github in 3 ways:
* `gh` in bash
* `curl` in bash
* `gh` in Go

The new logic will be for the job to just run `gen-release-notes --checkLabel`; that is it. No need to clone extra repos or any bash.

gen-release-notes has been adopted to handle this:
* Add schema validation inline, no need for another binary (note: binary still exists for backwards compatibility)
* Add label checking. This is the same API call to github, we just re-use it now instead of making multiple
* Simplify some of the code by just embedding the schema and templates
* Auto detect PR info from prow environment variables