### PR TITLE
docker: upgrade clang_context_amd64 to ubuntu:eoan

### DIFF
--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -662,7 +662,7 @@ ENTRYPOINT ["/usr/local/bin/docker-entrypoint"]
 # Clang+LLVM
 ##############
 
-FROM ubuntu:xenial AS clang_context_amd64
+FROM ubuntu:eoan AS clang_context_amd64
 FROM ubuntu:bionic AS clang_context_arm64
 # hadolint ignore=DL3006
 FROM clang_context_${TARGETARCH} AS clang_context


### PR DESCRIPTION
ubuntu:xenial doesn't have libncurses6, which is needed to build the [new version of BoringSSL](https://github.com/envoyproxy/envoy/pull/27087).

```
%  docker run -it --entrypoint "/bin/bash" ubuntu:xenial
root@05789bff8c1f:/# apt-get install libncurses6
Reading package lists... Done
Building dependency tree       
Reading state information... Done
E: Unable to locate package libncurses6

 % docker run -it --entrypoint "/bin/bash" ubuntu:18.04
root@de7017050bec:/# apt-get install libncurses6
Reading package lists... Done
Building dependency tree       
Reading state information... Done
E: Unable to locate package libncurses6

% docker run -it --entrypoint "/bin/bash" ubuntu:19.04
root@269ccc8c7e41:/# apt-get install libncurses6
Reading package lists... Done
Building dependency tree       
Reading state information... Done
libncurses6 is already the newest version (6.1+20181013-2ubuntu2).
0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.

%  docker run -it --entrypoint "/bin/bash" ubuntu:eoan  
root@bedf06428897:/# cat /etc/os-release 
NAME="Ubuntu"
VERSION="19.10 (Eoan Ermine)"
```