### PR TITLE
podman: update build-and-push script

### DIFF
--- a/docker/build-tools/build-and-push.sh
+++ b/docker/build-tools/build-and-push.sh
@@ -49,6 +49,18 @@ ARCH="${TARGET_ARCH:-amd64}"
 # Generally, this should always be set even with a single architecture build or we will end up with only an image with a `-{arch}` suffix.
 MANIFEST_ARCH="${MANIFEST_ARCH-amd64}"
 
+# CACHE_FROM_TAG, if present, defines an image tag which is used in the build --cache-from option.
+# Allow overriding for other tools like podman
+CACHE_FROM_TAG="${CACHE_FROM_TAG:-:master-latest-amd64}"
+
+# The podman build --cache-from option value must contain neither a tag nor digest.
+# Allow overriding of the CACHE_FROM_TAG by setting an empty string.
+if [[ "${CONTAINER_CLI}" == "podman" ]]; then
+  CACHE_FROM_TAG=""
+else
+  CACHE_FROM_TAG=":${BRANCH}-latest-${ARCH}"
+fi
+
 # The docker image runs `go get istio.io/tools@${SHA}`
 # In postsubmit, if we pull from the head of the branch, we get a race condition and usually will pull and old version
 # In presubmit, this SHA does not exist, so we should just pull from the head of the branch (eg master)
@@ -68,7 +80,7 @@ fi
 ${CONTAINER_CLI} ${CONTAINER_BUILDER} --target build_tools \
   ${ADDITIONAL_BUILD_ARGS} --build-arg "ISTIO_TOOLS_SHA=${SHA}" --build-arg "VERSION=${VERSION}" \
   --build-arg BUILDKIT_INLINE_CACHE=1 \
-  --cache-from "${HUB}/build-tools:${BRANCH}-latest-${ARCH}" \
+  --cache-from "${HUB}/build-tools${CACHE_FROM_TAG}" \
   -t "${HUB}/build-tools:${BRANCH}-latest-${ARCH}" \
   -t "${HUB}/build-tools:${VERSION}-${ARCH}" \
   .
@@ -77,7 +89,7 @@ ${CONTAINER_CLI} ${CONTAINER_BUILDER} --target build_tools \
 ${CONTAINER_CLI} ${CONTAINER_BUILDER} --target build_env_proxy \
   ${ADDITIONAL_BUILD_ARGS} --build-arg "ISTIO_TOOLS_SHA=${SHA}" --build-arg "VERSION=${VERSION}" \
   --build-arg BUILDKIT_INLINE_CACHE=1 \
-  --cache-from "${HUB}/build-tools-proxy:${BRANCH}-latest-${ARCH}" \
+  --cache-from "${HUB}/build-tools-proxy${CACHE_FROM_TAG}" \
   -t "${HUB}/build-tools-proxy:${BRANCH}-latest-${ARCH}" \
   -t "${HUB}/build-tools-proxy:${VERSION}-${ARCH}" \
   .

--- a/docker/build-tools/build-and-push.sh
+++ b/docker/build-tools/build-and-push.sh
@@ -50,15 +50,11 @@ ARCH="${TARGET_ARCH:-amd64}"
 MANIFEST_ARCH="${MANIFEST_ARCH-amd64}"
 
 # CACHE_FROM_TAG, if present, defines an image tag which is used in the build --cache-from option.
-# Allow overriding for other tools like podman
-CACHE_FROM_TAG="${CACHE_FROM_TAG:-:master-latest-amd64}"
-
+CACHE_FROM_TAG=":${BRANCH}-latest-${ARCH}"
 # The podman build --cache-from option value must contain neither a tag nor digest.
-# Allow overriding of the CACHE_FROM_TAG by setting an empty string.
+# Overriding of the CACHE_FROM_TAG by setting an empty string when running podman build.
 if [[ "${CONTAINER_CLI}" == "podman" ]]; then
   CACHE_FROM_TAG=""
-else
-  CACHE_FROM_TAG=":${BRANCH}-latest-${ARCH}"
 fi
 
 # The docker image runs `go get istio.io/tools@${SHA}`


### PR DESCRIPTION
This change is fixing a podman build error when using podman as CONTAINER_CLI to run `make containers-test` target.

According to the podman CLI doc[1], currently, the `--cache-from` option requires the value must contain neither a tag nor digest. Without this change, podman build failed with the following error.

```bash
$ make containers-test \ 
  DOCKER_SOCKET_MOUNT="-v /var/run/user/501/podman/podman.sock:/var/run/docker.sock" \
  HUB=localhost CONTAINER_CLI=podman \
  BUILD_WITH_CONTAINER=0 
...
Error: unable to parse value provided `` to --cache-from: repository must contain neither a tag nor digest
 
```

podman version

```
Client:       Podman Engine
Version:      4.5.1
API Version:  4.5.1
Go Version:   go1.20.4
```

Thanks,

[1] https://docs.podman.io/en/latest/markdown/podman-build.1.html#cache-from

---

btw, here are steps running rootless podman on a macOS host and then build build-tools images.

- To install `podman` engine from a MacOS host, run:

```bash
$ brew install podman;
$ podman machine init -v "${HOME}":"${HOME}";
$ podman machine start;
$ podman info;
```

- To expose the podman.sock on macOS, run:

```bash
$ podman system connection list
Name                         URI                                                         Identity                                Default
podman-machine-default       ssh://core@127.0.0.1:[SSH_PORT]/run/user/[UID]/podman/podman.sock  /Users/[USER]/.ssh/podman-machine-default  true
podman-machine-default-root  ssh://root@127.0.0.1:[SSH_PORT]/run/podman/podman.sock           /Users/[USER]/.ssh/podman-machine-default  false

# replace the following 501 with your UID above.
# replace the port 50865 with the SSH_PORT above.
$ ssh -fnNT -L/tmp/podman.sock:/run/user/501/podman/podman.sock -i ~/.ssh/podman-machine-default ssh://core@localhost:50865 -o StreamLocalBindUnlink=yes
$ export DOCKER_HOST='unix:///tmp//podman.sock'
```

```bash
$ make containers-test \ 
  DOCKER_SOCKET_MOUNT="-v /var/run/user/501/podman/podman.sock:/var/run/docker.sock" \
  HUB=localhost CONTAINER_CLI=podman \
  BUILD_WITH_CONTAINER=0 
```
