### PR TITLE
Fix tracing script masking return code

### DIFF
--- a/docker/build-tools/prow-entrypoint.sh
+++ b/docker/build-tools/prow-entrypoint.sh
@@ -63,7 +63,6 @@ function tracing::run() {
   # Setup a default implementation that just logs May be overridden if the repo has tracing support.
   log "Running ${1}"
   "${@:2}"
-  log "Completed ${1}"
 }
 if [[ -f common/scripts/tracing.sh ]]; then
   # shellcheck source=/dev/null


### PR DESCRIPTION
Testing:

```
$ ENABLE_DOCKER=false ./docker/build-tools/prow-entrypoint.sh false &>/dev/null; echo $?
1
$ ENABLE_DOCKER=false ./docker/build-tools/prow-entrypoint.sh true &>/dev/null; echo $?
0
```
