### PR TITLE
[release-1.19] Update release branch to Go 1.21.0

### DIFF
--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -25,7 +25,7 @@
 ################
 # Binary tools
 ################
-ARG GOLANG_IMAGE=golang:1.21rc4-bullseye
+ARG GOLANG_IMAGE=golang:1.21.0-bullseye
 # hadolint ignore=DL3006
 FROM ${GOLANG_IMAGE} as binary_tools_context
 # TARGETARCH is an automatic platform ARG enabled by Docker BuildKit.


### PR DESCRIPTION
Manual cherry-pick of https://github.com/istio/tools/pull/2620