### PR TITLE
Remove arbitrary sleep(1) from Go testing

### DIFF
--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -601,6 +601,8 @@ ENV GOROOT=/usr/local/go
 ENV GOPATH=/go
 ENV GOCACHE=/gocache
 ENV GOBIN=/gobin
+# Go sleeps for 1s after tests with out this, see https://github.com/golang/go/issues/61852
+ENV GORACE="atexit_sleep_ms=0"
 ENV PATH=/usr/local/go/bin:/gobin:/usr/local/google-cloud-sdk/bin:$PATH
 
 # Ruby support


### PR DESCRIPTION
Regression in Go 1.21, they do not intend to fix it