### PR TITLE
Pin pycodestyle version

### DIFF
--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -449,6 +449,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Pinned versions of stuff we pull in
 ENV AUTOPEP8_VERSION=2.0.2
+ENV PYCODESTYLE_VERSION=2.10.0
 ENV JWCRYPTO_VERSION=1.5.0
 ENV PIP_INSTALL_VERSION=23.1.2
 ENV PYGITHUB_VERSION=1.58.2
@@ -470,6 +471,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Install Python stuff
 RUN python3 -m pip install --no-cache-dir --upgrade pip==${PIP_INSTALL_VERSION}
+# FIXME: Pycodestyle had a breaking change in 2.11.0 and broke autopep8.
+# Pin pycodestyle version until autopep8 is updated.
+# https://github.com/hhatto/autopep8/issues/689
+RUN python3 -m pip install --no-cache-dir pycodestyle==${PYCODESTYLE_VERSION}
 RUN python3 -m pip install --no-cache-dir --no-binary :all: autopep8==${AUTOPEP8_VERSION}
 RUN python3 -m pip install --no-cache-dir yamllint==${YAMLLINT_VERSION}
 RUN python3 -m pip install --no-cache-dir requests==${REQUESTS_VERSION}


### PR DESCRIPTION
Pycodestyle had a breaking change in a minor release which broke autopep8: https://github.com/hhatto/autopep8/issues/689.
This means that any PR with python changes won't pass CI checks.

Temporary solution is to pin pycodestyle version until the autopep8 folks get around to fixing it.
Thought, autopep8 doesn't seem particularly active...