### PR TITLE
Make fortio latency numbers useful

### DIFF
--- a/perf/benchmark/runner/runner.py
+++ b/perf/benchmark/runner/runner.py
@@ -143,8 +143,8 @@ class Fortio:
         self.frequency = frequency
         self.protocol_mode = protocol_mode
         self.ns = NAMESPACE
-        # bucket resolution in seconds
-        self.r = "0.001"
+        # bucket resolution in seconds. This gives us buckets of .001ms each.
+        self.r = "0.000001"
         self.telemetry_mode = telemetry_mode
         self.perf_record = perf_record
         self.server = pod_info("-lapp=" + server, namespace=self.ns)


### PR DESCRIPTION
The histogram buckets we configure are 1ms

So our buckets look like:
0-1ms: [9999 requests]
1-2ms: [1 request]

Which is not useful for measuring latency.
