### PR TITLE
CRD gen: better doc extraction

### DIFF
--- a/cmd/cue-gen/genoapi.go
+++ b/cmd/cue-gen/genoapi.go
@@ -429,12 +429,10 @@ func (x *builder) genOpenAPI(name string, inst cue.Value) (cue.Value, error) {
 			if strings.HasPrefix(doc.Text(), "$hide_from_docs") {
 				return ""
 			}
-			if paras := strings.Split(doc.Text(), "\n"); len(paras) > 0 {
-				words := strings.Split(paras[0], " ")
-				for i, w := range words {
-					if strings.HasSuffix(w, ".") {
-						return strings.Join(words[:i+1], " ")
-					}
+			words := strings.Fields(doc.Text())
+			for i, w := range words {
+				if strings.HasSuffix(w, ".") {
+					return strings.Join(words[:i+1], " ")
 				}
 			}
 		}


### PR DESCRIPTION
We try to get the first sentance. But a string like:

```
foo bar
baz.
```

is not treated as a sentance.

This PR strictly adds more docs to the CRDs. Diff attached:
[diff.txt](https://github.com/istio/tools/files/12784967/diff.txt)
