### PR TITLE
Build protoc-gen-crd in build-tools

### DIFF
--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -163,7 +163,8 @@ RUN go install -ldflags="-s -w" \
   istio.io/tools/cmd/kubetype-gen@${ISTIO_TOOLS_SHA} \
   istio.io/tools/cmd/license-lint@${ISTIO_TOOLS_SHA} \
   istio.io/tools/cmd/gen-release-notes@${ISTIO_TOOLS_SHA} \
-  istio.io/tools/cmd/org-gen@${ISTIO_TOOLS_SHA}
+  istio.io/tools/cmd/org-gen@${ISTIO_TOOLS_SHA} \
+  istio.io/tools/cmd/protoc-gen-crd@${ISTIO_TOOLS_SHA}
 RUN go install -ldflags="-s -w" \
   k8s.io/code-generator/cmd/applyconfiguration-gen@kubernetes-${K8S_CODE_GENERATOR_VERSION} \
   k8s.io/code-generator/cmd/defaulter-gen@kubernetes-${K8S_CODE_GENERATOR_VERSION} \


### PR DESCRIPTION
Missing command in https://storage.googleapis.com/istio-prow/pr-logs/pull/istio_api/2941/gencheck_api/1709973617132965888/build-log.txt