### PR TITLE
Fix deprecation notice content for releasenotes generation

### DIFF
--- a/cmd/gen-release-notes/templates/minorReleaseNotes.md
+++ b/cmd/gen-release-notes/templates/minorReleaseNotes.md
@@ -18,7 +18,7 @@ This is an automatically generated rough draft of the release notes and has not 
 
 ## Deprecation Notices
 
-These notices describe functionality that will be removed in a future release according to [Istio's deprecation policy](/about/feature-stages/#feature-phase-definitions). Please consider upgrading your environment to remove the deprecated functionality.
+These notices describe functionality that will be removed in a future release according to [Istio's deprecation policy](/docs/releases/feature-stages/#feature-phase-definition). Please consider upgrading your environment to remove the deprecated functionality.
 
 <!-- releaseNotes action:Deprecated -->
 


### PR DESCRIPTION
The link is out-to-date, which will fail the lint test with a 404 error.