### PR TITLE
Populate default values in CRD for all enum types

### DIFF
--- a/cmd/protoc-gen-crd/main.go
+++ b/cmd/protoc-gen-crd/main.go
@@ -46,6 +46,7 @@ func extractParams(parameter string) map[string]string {
 func generate(request *plugin.CodeGeneratorRequest) (*plugin.CodeGeneratorResponse, error) {
 	includeDescription := true
 	enumAsIntOrString := false
+	enumWithDefaultValue := true
 
 	p := extractParams(request.GetParameter())
 	for k, v := range p {
@@ -66,6 +67,15 @@ func generate(request *plugin.CodeGeneratorRequest) (*plugin.CodeGeneratorRespon
 				enumAsIntOrString = false
 			default:
 				return nil, fmt.Errorf("unknown value '%s' for enum_as_int_or_string", v)
+			}
+		} else if k == "enum_with_default_values" {
+			switch strings.ToLower(v) {
+			case "true":
+				enumWithDefaultValue = true
+			case "false":
+				enumWithDefaultValue = false
+			default:
+				return nil, fmt.Errorf("unknown value '%s' for enum_with_default_values", v)
 			}
 		} else {
 			return nil, fmt.Errorf("unknown argument '%s' specified", k)
@@ -90,7 +100,8 @@ func generate(request *plugin.CodeGeneratorRequest) (*plugin.CodeGeneratorRespon
 	g := newOpenAPIGenerator(
 		m,
 		descriptionConfiguration,
-		enumAsIntOrString)
+		enumAsIntOrString,
+		enumWithDefaultValue)
 	return g.generateOutput(filesToGen)
 }
 


### PR DESCRIPTION
Hello,

this is just a suggestion that could help improve context information in Istio CRDS.

The purpose of the PR is to set defaults for all enum types to reflect API behaviour as information in kubernetes objects.

Example for random resource:

```
apiVersion: networking.istio.io/v1beta1
kind: ServiceEntry
metadata:
  name: test
spec:
  hosts:
    - example.com
```

Current behaviour:
```
kubectl get serviceentry test -o=jsonpath='{.spec}'

{"hosts":["example.com"]}
```

With this patch:

```
kubectl get serviceentry test -o=jsonpath='{.spec}'

{"hosts":["example.com"],"location":"MESH_EXTERNAL","resolution":"NONE"}
```

