### PR TITLE
[release-1.21] Update Go to 1.21.7

### DIFF
--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -25,7 +25,7 @@
 ################
 # Binary tools
 ################
-ARG GOLANG_IMAGE=golang:1.21.6-bullseye
+ARG GOLANG_IMAGE=golang:1.21.7-bullseye
 # hadolint ignore=DL3006
 FROM ${GOLANG_IMAGE} as binary_tools_context
 # TARGETARCH is an automatic platform ARG enabled by Docker BuildKit.


### PR DESCRIPTION
I'm not sure if the RMs want to update to Go 1.22.0 (master has moved there), or if they just want to update the 1.21 versions. For now, I've just updated the Go 1.21 version. Feel free to close this PR if moving to Go 1.22.0.

There is a cherry-pick listed for https://github.com/istio/tools/pull/2804 if the decision is to move to 1.22.0.