### PR TITLE
protoc-gen-crd: remove spam on generation

### DIFF
--- a/cmd/protoc-gen-crd/main.go
+++ b/cmd/protoc-gen-crd/main.go
@@ -72,7 +72,7 @@ func generate(request *plugin.CodeGeneratorRequest) (*plugin.CodeGeneratorRespon
 		}
 	}
 
-	m := protomodel.NewModel(request, false)
+	m := protomodel.NewModel(request, true)
 
 	filesToGen := make(map[*protomodel.FileDescriptor]bool)
 	for _, fileName := range request.FileToGenerate {


### PR DESCRIPTION
This is how the docs gen works; without this set it all works out the
same but logs a ton of spam in the logs.

This does not impact CRDs at all, just logs during protoc.
