### PR TITLE
[qual tests] Update kube-state-metrics

### DIFF
--- a/perf/stability/alertmanager/templates/kube_state_metrics.yaml
+++ b/perf/stability/alertmanager/templates/kube_state_metrics.yaml
@@ -97,6 +97,7 @@ rules:
       - networking.k8s.io
     resources:
       - networkpolicies
+      - ingresses
     verbs:
       - list
       - watch
@@ -105,6 +106,13 @@ rules:
     resources:
       - validatingwebhookconfigurations
       - mutatingwebhookconfigurations
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
     verbs:
       - list
       - watch
@@ -175,7 +183,7 @@ spec:
       serviceAccountName: prometheus-kube-state-metrics
       containers:
         - name: prometheus-kube-state-metrics
-          image: "quay.io/coreos/kube-state-metrics:v1.9.7"
+          image: "registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.10.0"
           imagePullPolicy: "IfNotPresent"
           ports:
             - name: metrics


### PR DESCRIPTION
Upgrade kube-state-metrics to latest release, kube-state-metrics/v1.9.7 is calling APIs removed in 1.25
* /apis/extensions/v1beta1/ingresses 
* /apis/certificates.k8s.io/v1beta1/certificatesigningrequests
* /apis/batch/v1beta1/cronjobs
* /apis/policy/v1beta1/poddisruptionbudgets
* /apis/autoscaling/v2beta1/horizontalpodautoscalers