### PR TITLE
org: allow `thelinuxfoundation` to be an admin

### DIFF
--- a/pkg/orggen/org.go
+++ b/pkg/orggen/org.go
@@ -193,7 +193,9 @@ var AllowedAdmins = sets.New(
 	// Robots
 	"google-admin",
 	"googlebot",
-	"istio-testing")
+	"istio-testing",
+	"thelinuxfoundation",
+)
 
 func ReadConfig(input string) (Organization, error) {
 	dir, err := os.ReadDir(input)


### PR DESCRIPTION
This is needed for various CNCF operations. Kubernetes also does this.
