### PR TITLE
add sidecar resources limit for istio proxy

### DIFF
--- a/perf/benchmark/templates/fortio.yaml
+++ b/perf/benchmark/templates/fortio.yaml
@@ -374,6 +374,14 @@ spec:
         traffic.sidecar.istio.io/excludeOutboundPorts: "80,8076,8077,8078, 8081"
         sidecar.istio.io/proxyCPU: {{ $.Values.proxy.cpu }}
         sidecar.istio.io/proxyMemory: {{ $.Values.proxy.memory }}
+{{- if $.Values.proxy.memLimit }}
+         sidecar.istio.io/proxyMemoryLimit: {{ $.Values.proxy.memLimit }}
+{{- end }}
+
+{{- if $.Values.proxy.cpuLimit }}
+         sidecar.istio.io/proxyCPULimit: {{ $.Values.proxy.cpuLimit }}
+{{- end }}
+
 {{- if $.Values.proxy.image }}
         sidecar.istio.io/proxyImage: {{ $.Values.proxy.image }}
 {{- end }}


### PR DESCRIPTION
Sometimes, we need to do benchmark under limited resources, so may be these annotations are required