### PR TITLE
Update codegen to workaround k8s client-go limits

### DIFF
--- a/cmd/protoc-gen-alias/main.go
+++ b/cmd/protoc-gen-alias/main.go
@@ -74,16 +74,16 @@ func generateFile(gen *protogen.Plugin, file *protogen.File) {
 		processEnums = func(enums []*protogen.Enum) {
 			for _, e := range enums {
 				typeName := e.GoIdent.GoName
-				p.P(`type `, typeName, `= `, file.GoPackageName, ".", e.GoIdent)
+				p.P(e.Comments.Leading, `type `, typeName, `= `, file.GoPackageName, ".", e.GoIdent)
 				for _, v := range e.Values {
-					p.P(`const `, v.GoIdent, " ", typeName, `= `, file.GoPackageName, ".", v.GoIdent)
+					p.P(v.Comments.Leading, `const `, v.GoIdent, " ", typeName, `= `, file.GoPackageName, ".", v.GoIdent)
 				}
 			}
 		}
 		processOneofs = func(oneofs []*protogen.Oneof) {
 			for _, e := range oneofs {
 				for _, f := range e.Fields {
-					p.P(`type `, f.GoIdent, `= `, file.GoPackageName, ".", f.GoIdent)
+					p.P(f.Comments.Leading, `type `, f.GoIdent, `= `, file.GoPackageName, ".", f.GoIdent)
 				}
 			}
 		}
@@ -94,7 +94,7 @@ func generateFile(gen *protogen.Plugin, file *protogen.File) {
 					continue
 				}
 				typeName := message.GoIdent.GoName
-				p.P(`type `, typeName, "= ", file.GoPackageName, ".", message.GoIdent)
+				p.P(message.Comments.Leading, `type `, typeName, "= ", file.GoPackageName, ".", message.GoIdent)
 				processMessages(message.Messages)
 				processEnums(message.Enums)
 				processOneofs(message.Oneofs)
@@ -102,6 +102,5 @@ func generateFile(gen *protogen.Plugin, file *protogen.File) {
 		}
 		processMessages(file.Messages)
 		processEnums(file.Enums)
-
 	}
 }

--- a/cmd/protoc-gen-alias/test/v1alpha/types_alias.gen.go
+++ b/cmd/protoc-gen-alias/test/v1alpha/types_alias.gen.go
@@ -3,10 +3,18 @@ package v1alpha
 
 import "istio.io/tools/cmd/protoc-gen-alias/test/v1"
 
+// Simple case
+// +cue-gen:Simple:versions:v1,v1alpha
 type Simple = v1.Simple
 type Simple_Name = v1.Simple_Name
 type Simple_Number = v1.Simple_Number
+
+// Simple case with map and map field should not have MarshalJSON/UnmarshalJSON
 type SimpleWithMap = v1.SimpleWithMap
 type SimpleWithMap_Nested = v1.SimpleWithMap_Nested
+
+// verify no MarshalJSON/UnmarshalJSON functions are created for referenced map
 type ReferencedMap = v1.ReferencedMap
+
+// verify no MarshalJSON/UnmarshalJSON functions are created for imported map
 type ImportedReference = v1.ImportedReference


### PR DESCRIPTION
The k8s client generators don't like aliases much. This makes it work.

1. Add comments to aliases; without this types are not noticed by the
   k8s gen
2. Synthetically add our per-version copies back in in kubetype-gen

Manually testeded this e2e
