### PR TITLE
protoc-gen-docs: mark proto3 as supported

### DIFF
--- a/cmd/protoc-gen-docs/htmlGenerator.go
+++ b/cmd/protoc-gen-docs/htmlGenerator.go
@@ -148,7 +148,10 @@ func (g *htmlGenerator) generatePerPackageOutput(filesToGen map[*protomodel.File
 
 func (g *htmlGenerator) generateOutput(filesToGen map[*protomodel.FileDescriptor]bool) (*plugin.CodeGeneratorResponse, error) {
 	// process each package; we produce one output file per package
-	response := plugin.CodeGeneratorResponse{}
+	supported := uint64(plugin.CodeGeneratorResponse_FEATURE_PROTO3_OPTIONAL)
+	response := plugin.CodeGeneratorResponse{
+		SupportedFeatures: &supported,
+	}
 
 	for _, pkg := range g.model.Packages {
 		g.currentPackage = pkg


### PR DESCRIPTION
Without this, we will get a warning/error in buf. Error in new versions,
which blocks everything. Indicating we support it makes it fine.
