### PR TITLE
build-tools: take advantage of modern docker features

### DIFF
--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -22,12 +22,14 @@
 # We pin versions of stuff we install. Modify the various XXX_VERSION variables within the individual build contexts
 # in order to control these versions.
 
+# hadolint global ignore=SC2086
+
 ################
 # Binary tools
 ################
 ARG GOLANG_IMAGE=golang:1.22.4
 # hadolint ignore=DL3006
-FROM ${GOLANG_IMAGE} as binary_tools_context
+FROM ${GOLANG_IMAGE} as binary_tools_context_base
 # TARGETARCH is an automatic platform ARG enabled by Docker BuildKit.
 ARG TARGETARCH
 
@@ -92,8 +94,12 @@ RUN mkdir -p ${OUTDIR}/usr/bin
 RUN mkdir -p ${OUTDIR}/usr/local
 
 # Update distro and install dependencies
-# hadolint ignore=DL3008
-RUN apt-get update && apt-get install -y --no-install-recommends \
+# hadolint ignore=DL3042
+RUN --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+    --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    rm -f /etc/apt/apt.conf.d/docker-clean \
+    && apt-get update \
+    && apt-get -y --no-install-recommends install \
     apt-transport-https \
     build-essential \
     ca-certificates \
@@ -121,58 +127,6 @@ RUN set -eux; \
 ADD https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_${TARGETARCH}.deb /tmp/
 RUN dpkg -i /tmp/gh_${GH_VERSION}_linux_${TARGETARCH}.deb
 RUN mv /usr/bin/gh ${OUTDIR}/usr/bin
-
-# Build and install a bunch of Go tools
-RUN CGO_ENABLED=0 go install -ldflags="-extldflags -static -s -w" google.golang.org/protobuf/cmd/protoc-gen-go@${GOLANG_PROTOBUF_VERSION}
-RUN CGO_ENABLED=0 go install -ldflags="-extldflags -static -s -w" google.golang.org/grpc/cmd/protoc-gen-go-grpc@${GOLANG_GRPC_PROTOBUF_VERSION}
-RUN CGO_ENABLED=0 go install -ldflags="-extldflags -static -s -w" github.com/nilslice/protolock/cmd/protolock@${PROTOLOCK_VERSION}
-RUN CGO_ENABLED=0 go install -ldflags="-extldflags -static -s -w" golang.org/x/tools/cmd/goimports@${GOIMPORTS_VERSION}
-RUN CGO_ENABLED=0 go install -ldflags="-extldflags -static -s -w" github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANGCI_LINT_VERSION}
-RUN CGO_ENABLED=0 go install -ldflags="-extldflags -static -s -w" github.com/go-bindata/go-bindata/go-bindata@${GO_BINDATA_VERSION}
-RUN CGO_ENABLED=0 go install -ldflags="-extldflags -static -s -w" github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway@${PROTOC_GEN_GRPC_GATEWAY_VERSION}
-RUN CGO_ENABLED=0 go install -ldflags="-extldflags -static -s -w" github.com/google/go-jsonnet/cmd/jsonnet@${JSONNET_VERSION}
-RUN CGO_ENABLED=0 go install -ldflags="-extldflags -static -s -w" github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@${JB_VERSION}
-RUN CGO_ENABLED=0 go install -ldflags="-extldflags -static -s -w" github.com/istio/go-junit-report@${GO_JUNIT_REPORT_VERSION}
-RUN CGO_ENABLED=0 go install -ldflags="-extldflags -static -s -w" sigs.k8s.io/bom/cmd/bom@${BOM_VERSION}
-RUN CGO_ENABLED=0 go install -ldflags="-extldflags -static -s -w" sigs.k8s.io/kind@${KIND_VERSION}
-RUN CGO_ENABLED=0 go install -ldflags="-extldflags -static -s -w" github.com/wadey/gocovmerge@${GOCOVMERGE_VERSION}
-RUN CGO_ENABLED=0 go install -ldflags="-extldflags -static -s -w" github.com/imsky/junit-merger/src/junit-merger@${JUNIT_MERGER_VERSION}
-RUN CGO_ENABLED=0 go install -ldflags="-extldflags -static -s -w" golang.org/x/perf/cmd/benchstat@${BENCHSTAT_VERSION}
-RUN CGO_ENABLED=0 go install -ldflags="-extldflags -static -s -w" chainguard.dev/apko@${APKO_VERSION}
-RUN CGO_ENABLED=0 go install -ldflags="-extldflags -static -s -w" github.com/google/go-containerregistry/cmd/crane@${CRANE_VERSION}
-RUN CGO_ENABLED=0 go install -ldflags="-extldflags -static -s -w" github.com/equinix-labs/otel-cli@${OTEL_CLI_VERSION}
-RUN CGO_ENABLED=0 go install -ldflags="-extldflags -static -s -w" github.com/mikefarah/yq/v4@v${YQ_VERSION}
-# Install latest version of Istio-owned tools in this release
-RUN CGO_ENABLED=0 go install -ldflags="-extldflags -static -s -w" \
-  istio.io/tools/cmd/protoc-gen-docs@${ISTIO_TOOLS_SHA} \
-  istio.io/tools/cmd/protoc-gen-alias@${ISTIO_TOOLS_SHA} \
-  istio.io/tools/cmd/annotations_prep@${ISTIO_TOOLS_SHA} \
-  istio.io/tools/cmd/envvarlinter@${ISTIO_TOOLS_SHA} \
-  istio.io/tools/cmd/testlinter@${ISTIO_TOOLS_SHA} \
-  istio.io/tools/cmd/protoc-gen-golang-deepcopy@${ISTIO_TOOLS_SHA} \
-  istio.io/tools/cmd/protoc-gen-golang-jsonshim@${ISTIO_TOOLS_SHA} \
-  istio.io/tools/cmd/kubetype-gen@${ISTIO_TOOLS_SHA} \
-  istio.io/tools/cmd/license-lint@${ISTIO_TOOLS_SHA} \
-  istio.io/tools/cmd/gen-release-notes@${ISTIO_TOOLS_SHA} \
-  istio.io/tools/cmd/org-gen@${ISTIO_TOOLS_SHA} \
-  istio.io/tools/cmd/protoc-gen-crd@${ISTIO_TOOLS_SHA}
-RUN CGO_ENABLED=0 go install -ldflags="-extldflags -static -s -w" \
-  k8s.io/code-generator/cmd/applyconfiguration-gen@kubernetes-${K8S_CODE_GENERATOR_VERSION} \
-  k8s.io/code-generator/cmd/defaulter-gen@kubernetes-${K8S_CODE_GENERATOR_VERSION} \
-  k8s.io/code-generator/cmd/client-gen@kubernetes-${K8S_CODE_GENERATOR_VERSION} \
-  k8s.io/code-generator/cmd/lister-gen@kubernetes-${K8S_CODE_GENERATOR_VERSION} \
-  k8s.io/code-generator/cmd/informer-gen@kubernetes-${K8S_CODE_GENERATOR_VERSION} \
-  k8s.io/code-generator/cmd/deepcopy-gen@kubernetes-${K8S_CODE_GENERATOR_VERSION} \
-  k8s.io/code-generator/cmd/go-to-protobuf@kubernetes-${K8S_CODE_GENERATOR_VERSION}
-RUN CGO_ENABLED=0 go install -ldflags="-extldflags -static -s -w" \
-    sigs.k8s.io/kubetest2@${KUBETEST2_VERSION} \
-    sigs.k8s.io/kubetest2/kubetest2-gke@${KUBETEST2_VERSION} \
-    sigs.k8s.io/kubetest2/kubetest2-tester-exec@${KUBETEST2_VERSION}
-RUN CGO_ENABLED=0 go install -ldflags="-extldflags -static -s -w" \
-  k8s.io/test-infra/robots/pr-creator@${K8S_TEST_INFRA_VERSION} \
-  k8s.io/test-infra/pkg/benchmarkjunit@${K8S_TEST_INFRA_VERSION}
-RUN CGO_ENABLED=0 go install -ldflags="-extldflags -static -s -w" \
-  sigs.k8s.io/prow/cmd/peribolos@${K8S_PROW_VERSION}
 
 # Add gen-release-notes templates to filesystem
 RUN mkdir -p ${OUTDIR}/usr/share/gen-release-notes
@@ -318,15 +272,138 @@ RUN set -eux; \
     chmod +x ${OUTDIR}/usr/bin/oc; \
     rm -rf /tmp/oc*
 
-# Move Go tools to their final location
-RUN mv /tmp/go/bin/* ${OUTDIR}/usr/bin
-
 # Cleanup stuff we don't need in the final image
 RUN rm -fr /usr/local/go/doc
 RUN rm -fr /usr/local/go/test
 RUN rm -fr /usr/local/go/api
 RUN rm -fr /usr/local/go/bin/godoc
 RUN rm -fr /usr/local/go/bin/gofmt
+
+# Go tools: part 1
+# We split these out to get better docker layer caching to avoid needing to pull *everything* down when just one thing changes
+FROM binary_tools_context_base as go_tools_1
+
+# Build and install a bunch of Go tools
+RUN --mount=type=cache,target=/tmp/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 go install -ldflags="-extldflags -static -s -w" \
+    google.golang.org/protobuf/cmd/protoc-gen-go@${GOLANG_PROTOBUF_VERSION}
+RUN --mount=type=cache,target=/tmp/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 go install -ldflags="-extldflags -static -s -w" \
+    google.golang.org/grpc/cmd/protoc-gen-go-grpc@${GOLANG_GRPC_PROTOBUF_VERSION}
+RUN --mount=type=cache,target=/tmp/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 go install -ldflags="-extldflags -static -s -w" \
+    github.com/nilslice/protolock/cmd/protolock@${PROTOLOCK_VERSION}
+RUN --mount=type=cache,target=/tmp/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 go install -ldflags="-extldflags -static -s -w" \
+    golang.org/x/tools/cmd/goimports@${GOIMPORTS_VERSION}
+RUN --mount=type=cache,target=/tmp/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 go install -ldflags="-extldflags -static -s -w" \
+    github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANGCI_LINT_VERSION}
+RUN --mount=type=cache,target=/tmp/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 go install -ldflags="-extldflags -static -s -w" \
+    github.com/go-bindata/go-bindata/go-bindata@${GO_BINDATA_VERSION}
+RUN --mount=type=cache,target=/tmp/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 go install -ldflags="-extldflags -static -s -w" \
+    github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway@${PROTOC_GEN_GRPC_GATEWAY_VERSION}
+RUN --mount=type=cache,target=/tmp/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 go install -ldflags="-extldflags -static -s -w" \
+    github.com/google/go-jsonnet/cmd/jsonnet@${JSONNET_VERSION}
+RUN --mount=type=cache,target=/tmp/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 go install -ldflags="-extldflags -static -s -w" \
+    github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@${JB_VERSION}
+RUN --mount=type=cache,target=/tmp/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 go install -ldflags="-extldflags -static -s -w" \
+    github.com/istio/go-junit-report@${GO_JUNIT_REPORT_VERSION}
+RUN --mount=type=cache,target=/tmp/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 go install -ldflags="-extldflags -static -s -w" \
+    sigs.k8s.io/bom/cmd/bom@${BOM_VERSION}
+RUN --mount=type=cache,target=/tmp/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 go install -ldflags="-extldflags -static -s -w" \
+    sigs.k8s.io/kind@${KIND_VERSION}
+RUN --mount=type=cache,target=/tmp/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 go install -ldflags="-extldflags -static -s -w" \
+    github.com/wadey/gocovmerge@${GOCOVMERGE_VERSION}
+RUN --mount=type=cache,target=/tmp/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 go install -ldflags="-extldflags -static -s -w" \
+    github.com/imsky/junit-merger/src/junit-merger@${JUNIT_MERGER_VERSION}
+RUN --mount=type=cache,target=/tmp/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 go install -ldflags="-extldflags -static -s -w" \
+    golang.org/x/perf/cmd/benchstat@${BENCHSTAT_VERSION}
+RUN --mount=type=cache,target=/tmp/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 go install -ldflags="-extldflags -static -s -w" \
+    chainguard.dev/apko@${APKO_VERSION}
+RUN --mount=type=cache,target=/tmp/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 go install -ldflags="-extldflags -static -s -w" \
+    github.com/google/go-containerregistry/cmd/crane@${CRANE_VERSION}
+RUN --mount=type=cache,target=/tmp/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 go install -ldflags="-extldflags -static -s -w" \
+    github.com/equinix-labs/otel-cli@${OTEL_CLI_VERSION}
+RUN --mount=type=cache,target=/tmp/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 go install -ldflags="-extldflags -static -s -w" \
+    github.com/mikefarah/yq/v4@v${YQ_VERSION}
+RUN --mount=type=cache,target=/tmp/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 go install -ldflags="-extldflags -static -s -w" \
+    k8s.io/code-generator/cmd/applyconfiguration-gen@kubernetes-${K8S_CODE_GENERATOR_VERSION} \
+    k8s.io/code-generator/cmd/defaulter-gen@kubernetes-${K8S_CODE_GENERATOR_VERSION} \
+    k8s.io/code-generator/cmd/client-gen@kubernetes-${K8S_CODE_GENERATOR_VERSION} \
+    k8s.io/code-generator/cmd/lister-gen@kubernetes-${K8S_CODE_GENERATOR_VERSION} \
+    k8s.io/code-generator/cmd/informer-gen@kubernetes-${K8S_CODE_GENERATOR_VERSION} \
+    k8s.io/code-generator/cmd/deepcopy-gen@kubernetes-${K8S_CODE_GENERATOR_VERSION} \
+    k8s.io/code-generator/cmd/go-to-protobuf@kubernetes-${K8S_CODE_GENERATOR_VERSION}
+RUN --mount=type=cache,target=/tmp/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 go install -ldflags="-extldflags -static -s -w" \
+    sigs.k8s.io/kubetest2@${KUBETEST2_VERSION} \
+    sigs.k8s.io/kubetest2/kubetest2-gke@${KUBETEST2_VERSION} \
+    sigs.k8s.io/kubetest2/kubetest2-tester-exec@${KUBETEST2_VERSION}
+RUN --mount=type=cache,target=/tmp/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 go install -ldflags="-extldflags -static -s -w" \
+    k8s.io/test-infra/robots/pr-creator@${K8S_TEST_INFRA_VERSION} \
+    k8s.io/test-infra/pkg/benchmarkjunit@${K8S_TEST_INFRA_VERSION}
+RUN --mount=type=cache,target=/tmp/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 go install -ldflags="-extldflags -static -s -w" \
+    sigs.k8s.io/prow/cmd/peribolos@${K8S_PROW_VERSION}
+
+FROM binary_tools_context_base as go_tools_2
+
+# Install latest version of Istio-owned tools in this release
+RUN --mount=type=cache,target=/tmp/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 go install -ldflags="-extldflags -static -s -w" \
+    istio.io/tools/cmd/protoc-gen-docs@${ISTIO_TOOLS_SHA} \
+    istio.io/tools/cmd/protoc-gen-alias@${ISTIO_TOOLS_SHA} \
+    istio.io/tools/cmd/annotations_prep@${ISTIO_TOOLS_SHA} \
+    istio.io/tools/cmd/envvarlinter@${ISTIO_TOOLS_SHA} \
+    istio.io/tools/cmd/testlinter@${ISTIO_TOOLS_SHA} \
+    istio.io/tools/cmd/protoc-gen-golang-deepcopy@${ISTIO_TOOLS_SHA} \
+    istio.io/tools/cmd/protoc-gen-golang-jsonshim@${ISTIO_TOOLS_SHA} \
+    istio.io/tools/cmd/kubetype-gen@${ISTIO_TOOLS_SHA} \
+    istio.io/tools/cmd/license-lint@${ISTIO_TOOLS_SHA} \
+    istio.io/tools/cmd/gen-release-notes@${ISTIO_TOOLS_SHA} \
+    istio.io/tools/cmd/org-gen@${ISTIO_TOOLS_SHA} \
+    istio.io/tools/cmd/protoc-gen-crd@${ISTIO_TOOLS_SHA}
 
 #############
 # Node.js
@@ -490,7 +567,10 @@ ENV OUTDIR=/out
 # required for python: python3, pkg-config
 # required for ebpf build: clang,llvm,libbpf-dev
 # hadolint ignore=DL3008
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+    --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    rm -f /etc/apt/apt.conf.d/docker-clean \
+    && apt-get update && apt-get install -y --no-install-recommends \
     apt-transport-https \
     ca-certificates \
     curl \
@@ -553,15 +633,15 @@ RUN curl --proto '=https' -v --tlsv1.2 -sSf https://sh.rustup.rs | \
     mv /home/.cargo/bin/* /usr/bin
 
 # Clean up stuff we don't need in the final image
-RUN rm -rf /var/lib/apt/lists/*
-RUN rm -fr /usr/share/python
-RUN rm -fr /usr/share/bash-completion
-RUN rm -fr /usr/share/bug
-RUN rm -fr /usr/share/doc
-RUN rm -fr /usr/share/dh-python
-RUN rm -fr /usr/share/locale
-RUN rm -fr /usr/share/man
-RUN rm -fr /tmp/*
+RUN rm -rf /var/lib/apt/lists/* \
+  && rm -fr /usr/share/python \
+  && rm -fr /usr/share/bash-completion \
+  && rm -fr /usr/share/bug \
+  && rm -fr /usr/share/doc \
+  && rm -fr /usr/share/dh-python \
+  && rm -fr /usr/share/locale \
+  && rm -fr /usr/share/man \
+  && rm -fr /tmp/*
 
 # Run dockerd in CI
 COPY prow-entrypoint.sh /usr/local/bin/entrypoint
@@ -606,22 +686,23 @@ ENV PATH=/usr/local/go/bin:/gobin:/usr/local/google-cloud-sdk/bin:$PATH
 ENV RUBYOPT="-KU -E utf-8:utf-8"
 
 # Create the file system
-COPY --from=base_os_context / /
-COPY --from=binary_tools_context /out/ /
-COPY --from=binary_tools_context /usr/local/go /usr/local/go
+COPY --link --from=base_os_context / /
+COPY --link --from=binary_tools_context_base /out/ /
+COPY --link --from=go_tools_1 /tmp/go/bin/* /usr/local/go/
+COPY --link --from=go_tools_2 /tmp/go/bin/* /usr/local/go/
 
-COPY --from=nodejs_tools_context /usr/local/bin /usr/local/bin
-COPY --from=nodejs_tools_context /usr/local/lib/node_modules /usr/local/lib/node_modules
-COPY --from=nodejs_tools_context /node/node_modules /node_modules
+COPY --link --from=nodejs_tools_context /usr/local/bin /usr/local/bin
+COPY --link --from=nodejs_tools_context /usr/local/lib/node_modules /usr/local/lib/node_modules
+COPY --link --from=nodejs_tools_context /node/node_modules /node_modules
 
-COPY --from=ruby_tools_context /usr/bin /usr/bin
-COPY --from=ruby_tools_context /usr/lib /usr/lib
-COPY --from=ruby_tools_context /etc/alternatives /etc/alternatives
-COPY --from=ruby_tools_context /var/lib/gems /var/lib/gems
-COPY --from=ruby_tools_context /usr/local/bin /usr/local/bin
+COPY --link --from=ruby_tools_context /usr/bin /usr/bin
+COPY --link --from=ruby_tools_context /usr/lib /usr/lib
+COPY --link --from=ruby_tools_context /etc/alternatives /etc/alternatives
+COPY --link --from=ruby_tools_context /var/lib/gems /var/lib/gems
+COPY --link --from=ruby_tools_context /usr/local/bin /usr/local/bin
 
-COPY --from=python_context /usr/local/bin /usr/local/bin
-COPY --from=python_context /usr/local/lib /usr/local/lib
+COPY --link --from=python_context /usr/local/bin /usr/local/bin
+COPY --link --from=python_context /usr/local/lib /usr/local/lib
 
 # su-exec is used in place of complex sudo setup operations
 RUN chmod u+sx /usr/bin/su-exec
@@ -670,9 +751,9 @@ ENTRYPOINT ["/usr/local/bin/docker-entrypoint"]
 # Clang+LLVM
 ##############
 
-FROM ubuntu:18.04 AS clang_context_amd64
+FROM ubuntu:bionic AS clang_context_amd64
 ENV UBUNTU_RELEASE_CODE_NAME=bionic
-FROM ubuntu:20.04 AS clang_context_arm64
+FROM ubuntu:focal AS clang_context_arm64
 ENV UBUNTU_RELEASE_CODE_NAME=focal
 # hadolint ignore=DL3006
 FROM clang_context_${TARGETARCH} AS clang_context
@@ -735,16 +816,19 @@ RUN ./proxy-tsan-instrumented-libcxx.sh
 # GN
 ###########
 
-FROM debian:buster AS gn_context
+FROM ubuntu:bionic AS gn_context_amd64
+FROM ubuntu:focal AS gn_context_arm64
+# hadolint ignore=DL3006
+FROM gn_context_${TARGETARCH} AS gn_context
 
-RUN set -eux; \
-    \
-    apt-get update; \
-    apt-get install -qqy --no-install-recommends \
-        ca-certificates git \
-        clang python ninja-build \
-        libclang-dev libc++-dev \
-        ;
+RUN --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+    --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    rm -f /etc/apt/apt.conf.d/docker-clean \
+    && apt-get update \
+    && apt-get -y --no-install-recommends install \
+    ca-certificates git \
+    clang python ninja-build \
+    libclang-dev libc++-dev
 
 WORKDIR /tmp
 RUN git clone https://gn.googlesource.com/gn;
@@ -752,7 +836,6 @@ RUN git clone https://gn.googlesource.com/gn;
 WORKDIR /tmp/gn
 
 RUN set -eux; \
-    \
     git checkout 501b49a3; \
     python build/gen.py; \
     ninja -v -C out; \
@@ -765,8 +848,8 @@ RUN set -eux; \
 # Bazel
 ###########
 
-FROM ubuntu:xenial AS bazel_context_amd64
-FROM ubuntu:bionic AS bazel_context_arm64
+FROM ubuntu:bionic AS bazel_context_amd64
+FROM ubuntu:focal AS bazel_context_arm64
 # hadolint ignore=DL3006
 FROM bazel_context_${TARGETARCH} AS bazel_context
 
@@ -778,7 +861,11 @@ ENV BAZELISK_BIN="bazelisk-linux-${TARGETARCH}"
 ENV BAZELISK_URL="${BAZELISK_BASE_URL}/${BAZELISK_VERSION}/${BAZELISK_BIN}"
 
 # hadolint ignore=DL3008
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+    --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    rm -f /etc/apt/apt.conf.d/docker-clean \
+    && apt-get update \
+    && apt-get -y --no-install-recommends install \
     wget \
     ca-certificates
 
@@ -790,10 +877,10 @@ RUN mv ${BAZELISK_BIN} /usr/local/bin/bazel
 # Final image for proxy
 ########################
 
-FROM ubuntu:18.04 AS build_env_proxy_amd64
+FROM ubuntu:bionic AS build_env_proxy_amd64
 ENV UBUNTU_RELEASE_CODE_NAME=bionic
 ENV UBUNTU_RELEASE_VERSION=18.04
-FROM ubuntu:20.04 AS build_env_proxy_arm64
+FROM ubuntu:focal AS build_env_proxy_arm64
 ENV UBUNTU_RELEASE_CODE_NAME=focal
 ENV UBUNTU_RELEASE_VERSION=20.04
 # hadolint ignore=DL3006
@@ -841,13 +928,16 @@ ENV DEBIAN_FRONTEND=noninteractive
 # required for general build: make, wget, curl, ssh
 # required for python: python3, pkg-config
 # hadolint ignore=DL3008, DL3009
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+    --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    rm -f /etc/apt/apt.conf.d/docker-clean \
+    && apt-get update \
+    && apt-get -y --no-install-recommends install \
     apt-transport-https \
     ca-certificates \
     curl \
     gnupg-agent \
     software-properties-common \
-    ca-certificates \
     gcc \
     ssh \
     libltdl7 \
@@ -860,24 +950,19 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     wget \
     jq \
     rsync \
-    tshark
-
-# Build git from source. Golang now requires a recent git version
-# hadolint ignore=DL3003,DL3009,DL4001
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    build-essential \
-    libssl-dev \
-    libcurl4-gnutls-dev \
-    libexpat1-dev \
-    zlib1g-dev \
-    gettext \
-    unzip && \
-    wget -q https://github.com/git/git/archive/v2.39.1.zip -O git.zip && \
-    unzip git.zip && \
-    cd git-* && \
-    make prefix=/usr/local all && \
-    make prefix=/usr/local install && \
-    cd .. && rm -r git-*
+    tshark \
+    git \
+    # Dependencies to build envoy
+    autoconf \
+    automake \
+    cmake \
+    libtool \
+    ninja-build \
+    python \
+    unzip \
+    libncurses5 \
+    libtinfo5 \
+    virtualenv
 
 # Docker including docker-ce, docker-ce-cli, and containerd.io
 ADD https://download.docker.com/linux/ubuntu/gpg /tmp/docker-key
@@ -909,29 +994,15 @@ RUN set -eux; \
         *) echo "skip" ;; \
     esac;
 
-# binary dependencies to build envoy at v1.12.0
-# https://github.com/envoyproxy/envoy/blob/v1.12.0/bazel/README.md
-# hadolint ignore=DL3008,DL3009
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    autoconf \
-    automake \
-    cmake \
-    libtool \
-    ninja-build \
-    python \
-    unzip \
-    libncurses5 \
-    libtinfo5 \
-    virtualenv
-
-COPY --from=binary_tools_context /out/ /
-COPY --from=binary_tools_context /usr/local/go /usr/local/go
-COPY --from=gn_context /gn/gn /usr/local/bin/gn
-COPY --from=bazel_context /usr/local/bin /usr/local/bin
-COPY --from=clang_context ${LLVM_DIRECTORY}/lib ${LLVM_DIRECTORY}/lib
-COPY --from=clang_context ${LLVM_DIRECTORY}/bin ${LLVM_DIRECTORY}/bin
-COPY --from=clang_context ${LLVM_DIRECTORY}/include ${LLVM_DIRECTORY}/include
-COPY --from=clang_context /opt/libcxx_tsan /opt/libcxx_tsan
+COPY --link --from=binary_tools_context_base /out/ /
+COPY --link --from=go_tools_1 /tmp/go/bin/* /usr/local/go/
+COPY --link --from=go_tools_2 /tmp/go/bin/* /usr/local/go/
+COPY --link --from=gn_context /gn/gn /usr/local/bin/gn
+COPY --link --from=bazel_context /usr/local/bin /usr/local/bin
+COPY --link --from=clang_context ${LLVM_DIRECTORY}/lib ${LLVM_DIRECTORY}/lib
+COPY --link --from=clang_context ${LLVM_DIRECTORY}/bin ${LLVM_DIRECTORY}/bin
+COPY --link --from=clang_context ${LLVM_DIRECTORY}/include ${LLVM_DIRECTORY}/include
+COPY --link --from=clang_context /opt/libcxx_tsan /opt/libcxx_tsan
 
 COPY install-python.sh install-python.sh
 RUN ./install-python.sh


### PR DESCRIPTION
* Add caching for go build and apt cache. This can be re-used across
  builds. CI doesn't re-use across invocations, but will across
multi-stage builds, and we have a LOT of multi-stage builds.
* Use --link in copying to avoid invalidation of layers. I think this
  means when a new build is published, users just need to download the
layer that changed... TBD if this will fully work
* Split out the biggest layer (binary) into 3 layers, especially the
  istio/tools binaries which change the most often. Again, I think this
means only that one needs to be downloaded
* Standardize on common base images. Note this is only changing
  intermediate layers, so it should have no impact
* Drop legacy 'build git from source' hack for ubuntu 16; we don't use
  16 anymore
