### PR TITLE
NOP change to 1.22 docker image to retrigger build

### DIFF
--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -25,6 +25,7 @@
 ################
 # Binary tools
 ################
+
 ARG GOLANG_IMAGE=golang:1.22.4-bullseye
 # hadolint ignore=DL3006
 FROM ${GOLANG_IMAGE} as binary_tools_context


### PR DESCRIPTION
The last change to update to 1.22.4 did not succeed, and went un-updated