### PR TITLE
CRD generation tooling: use our own prefix 

### DIFF
--- a/cmd/protoc-gen-crd/openapiGenerator.go
+++ b/cmd/protoc-gen-crd/openapiGenerator.go
@@ -851,9 +851,10 @@ type SchemaApplier interface {
 
 const (
 	ValidationPrefix         = "+kubebuilder:validation:"
-	MapValidationPrefix      = "+kubebuilder:map-value-validation:"
-	ListValidationPrefix     = "+kubebuilder:list-value-validation:"
-	DurationValidationPrefix = "+kubebuilder:duration-validation:"
+	MapValidationPrefix      = "+protoc-gen-crd:map-value-validation:"
+	ListValidationPrefix     = "+protoc-gen-crd:list-value-validation:"
+	DurationValidationPrefix = "+protoc-gen-crd:duration-validation:"
+	IntOrStrValidation       = "+protoc-gen-crd:validation:XIntOrString"
 )
 
 func applyExtraValidations(schema *apiext.JSONSchemaProps, m protomodel.CoreDesc, t markers.TargetType) {
@@ -883,7 +884,7 @@ func applyExtraValidations(schema *apiext.JSONSchemaProps, m protomodel.CoreDesc
 			return
 		}
 		// Kubernetes is very particular about the format for XIntOrString, must match exactly this
-		if strings.Contains(line, "+kubebuilder:validation:XIntOrString") {
+		if strings.Contains(line, IntOrStringValidation) {
 			schema.Format = ""
 			schema.Type = ""
 			schema.AnyOf = []apiext.JSONSchemaProps{

--- a/cmd/protoc-gen-crd/openapiGenerator.go
+++ b/cmd/protoc-gen-crd/openapiGenerator.go
@@ -34,6 +34,7 @@ import (
 	structuralschema "k8s.io/apiextensions-apiserver/pkg/apiserver/schema"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/controller-tools/pkg/crd"
 	crdmarkers "sigs.k8s.io/controller-tools/pkg/crd/markers"
 	"sigs.k8s.io/controller-tools/pkg/markers"
 	"sigs.k8s.io/yaml"
@@ -850,21 +851,23 @@ type SchemaApplier interface {
 }
 
 const (
-	ValidationPrefix         = "+kubebuilder:validation:"
-	MapValidationPrefix      = "+protoc-gen-crd:map-value-validation:"
-	ListValidationPrefix     = "+protoc-gen-crd:list-value-validation:"
-	DurationValidationPrefix = "+protoc-gen-crd:duration-validation:"
-	IntOrStrValidation       = "+protoc-gen-crd:validation:XIntOrString"
+	KubeBuilderValidationPrefix = "+kubebuilder:validation:"
+	ProtocGenValidationPrefix   = "+protoc-gen-crd:"
+	MapValidationPrefix         = "+protoc-gen-crd:map-value-validation:"
+	ListValidationPrefix        = "+protoc-gen-crd:list-value-validation:"
+	DurationValidationPrefix    = "+protoc-gen-crd:duration-validation:"
+	IntOrStringValidation       = "+protoc-gen-crd:validation:XIntOrString"
+	// IgnoreSubValidation is a custom validation allowing to refer to a type, but remove some validation
+	// This is useful when we are embedding a different type in a different context.
+	IgnoreSubValidation = "+protoc-gen-crd:validation:IgnoreSubValidation:"
 )
 
 func applyExtraValidations(schema *apiext.JSONSchemaProps, m protomodel.CoreDesc, t markers.TargetType) {
 	for _, line := range strings.Split(m.Location().GetLeadingComments(), "\n") {
 		line = strings.TrimSpace(line)
-		if !strings.Contains(line, ValidationPrefix) &&
+		if !strings.Contains(line, KubeBuilderValidationPrefix) &&
 			!strings.Contains(line, "+list") &&
-			!strings.Contains(line, MapValidationPrefix) &&
-			!strings.Contains(line, DurationValidationPrefix) &&
-			!strings.Contains(line, ListValidationPrefix) {
+			!strings.Contains(line, ProtocGenValidationPrefix) {
 			continue
 		}
 		schema := schema
@@ -872,11 +875,11 @@ func applyExtraValidations(schema *apiext.JSONSchemaProps, m protomodel.CoreDesc
 		// Custom logic to apply validations to map values. In go, they just make a type alias and apply policy there; proto cannot do that.
 		if strings.Contains(line, MapValidationPrefix) {
 			schema = schema.AdditionalProperties.Schema
-			line = strings.ReplaceAll(line, MapValidationPrefix, ValidationPrefix)
+			line = strings.ReplaceAll(line, MapValidationPrefix, KubeBuilderValidationPrefix)
 		}
 		if strings.Contains(line, ListValidationPrefix) {
 			schema = schema.Items.Schema
-			line = strings.ReplaceAll(line, ListValidationPrefix, ValidationPrefix)
+			line = strings.ReplaceAll(line, ListValidationPrefix, KubeBuilderValidationPrefix)
 		}
 		// This is a hack to allow a certain field to opt-out of the default "Duration must be non-zero"
 		if strings.Contains(line, DurationValidationPrefix+"none") {
@@ -891,6 +894,17 @@ func applyExtraValidations(schema *apiext.JSONSchemaProps, m protomodel.CoreDesc
 				{Type: "integer"},
 				{Type: "string"},
 			}
+			line = strings.ReplaceAll(line, ProtocGenValidationPrefix+"validation:", KubeBuilderValidationPrefix)
+		}
+
+		if strings.Contains(line, IgnoreSubValidation) {
+			li := strings.TrimPrefix(line, IgnoreSubValidation)
+			items := []string{}
+			if err := json.Unmarshal([]byte(li), &items); err != nil {
+				log.Fatalf("invalid %v %v: %v", IgnoreSubValidation, line, err)
+			}
+			recursivelyStripValidation(schema, items)
+			continue
 		}
 
 		def := markerRegistry.Lookup(line, t)
@@ -905,6 +919,43 @@ func applyExtraValidations(schema *apiext.JSONSchemaProps, m protomodel.CoreDesc
 			log.Fatalf("failed to apply schema %q: %v", schema.Description, err)
 		}
 	}
+}
+
+type stripVisitor struct {
+	removeMessages sets.Set[string]
+}
+
+func (s stripVisitor) Visit(schema *apiext.JSONSchemaProps) crd.SchemaVisitor {
+	if schema != nil && schema.XValidations != nil {
+		schema.XValidations = FilterInPlace(schema.XValidations, func(rule apiext.ValidationRule) bool {
+			return !s.removeMessages.Has(rule.Message)
+		})
+	}
+	return s
+}
+
+func recursivelyStripValidation(schema *apiext.JSONSchemaProps, items []string) {
+	crd.EditSchema(schema, stripVisitor{sets.New(items...)})
+}
+
+func FilterInPlace[E any](s []E, f func(E) bool) []E {
+	n := 0
+	for _, val := range s {
+		if f(val) {
+			s[n] = val
+			n++
+		}
+	}
+
+	// If those elements contain pointers you might consider zeroing those elements
+	// so that objects they reference can be garbage collected."
+	var empty E
+	for i := n; i < len(s); i++ {
+		s[i] = empty
+	}
+
+	s = s[:n]
+	return s
 }
 
 func (g *openapiGenerator) fieldName(field *protomodel.FieldDescriptor) string {
@@ -943,7 +994,8 @@ func validateStructural(s *apiext.JSONSchemaProps) error {
 	}
 
 	if errs := structuralschema.ValidateStructural(nil, r); len(errs) != 0 {
-		return fmt.Errorf("schema is not structural: %v", errs.ToAggregate().Error())
+		b, _ := yaml.Marshal(s)
+		return fmt.Errorf("schema is not structural: %v (%+v)", errs.ToAggregate().Error(), string(b))
 	}
 
 	return nil

--- a/go.mod
+++ b/go.mod
@@ -46,6 +46,7 @@ require (
 	github.com/go-openapi/jsonpointer v0.20.2 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
 	github.com/go-openapi/swag v0.22.8 // indirect
+	github.com/gobuffalo/flect v1.0.2 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/google/gnostic-models v0.6.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -69,6 +69,8 @@ github.com/go-openapi/swag v0.22.8 h1:/9RjDSQ0vbFR+NyjGMkFTsA1IA0fmhKSThmfGZjicb
 github.com/go-openapi/swag v0.22.8/go.mod h1:6QT22icPLEqAM/z/TChgb4WAveCHF92+2gF0CNjHpPI=
 github.com/go-test/deep v1.0.8 h1:TDsG77qcSprGbC6vTN8OuXp5g+J+b5Pcguhf7Zt61VM=
 github.com/go-test/deep v1.0.8/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
+github.com/gobuffalo/flect v1.0.2 h1:eqjPGSo2WmjgY2XlpGwo2NXgL3RucAKo4k4qQMNA5sA=
+github.com/gobuffalo/flect v1.0.2/go.mod h1:A5msMlrHtLqh9umBSnvabjsMrCcCpAyzglnDvkbYKHs=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang-jwt/jwt/v5 v5.2.0 h1:d/ix8ftRUorsN+5eMIlF4T6J8CAt9rch3My2winC1Jw=

--- a/licenses/github.com/gobuffalo/flect/LICENSE
+++ b/licenses/github.com/gobuffalo/flect/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2019 Mark Bates
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Usage of the kubebuilder prefix breaks other third party tools parsing our configs. using our own tooling allows clear distinction between the two

Also implement a new one to fix https://github.com/istio/istio/issues/52749