### PR TITLE
Isotope: add ability to set custom labels on generated entities.

### DIFF
--- a/isotope/convert/pkg/graph/svc/service.go
+++ b/isotope/convert/pkg/graph/svc/service.go
@@ -51,4 +51,7 @@ type Service struct {
 
 	// Script is sequentially called each time the service is called.
 	Script script.Script `json:"script,omitempty"`
+
+	// Labels to add to the generated K8S entities.
+	Labels map[string]string `json:"labels,omitempty"`
 }


### PR DESCRIPTION
It's useful to set labels to the isotope-generated Services/Deployments to be able to select those neatly.
Especially if there are other external entities you'd like to select/manipulate with one command (e.g. deployment for the Gateway).