### PR TITLE
tools: add moreutils

### DIFF
--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -603,6 +603,7 @@ RUN --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
     wget \
     rpm \
     jq \
+    moreutils \
     gettext-base \
     locales-all \
     file \


### PR DESCRIPTION
I want to use https://manpages.debian.org/testing/moreutils/ts.1.en.html to help add timestamps to some tests to get more info
