### PR TITLE
cmd/kubetype-gen: omit empty status, like we do for spec

### DIFF
--- a/cmd/kubetype-gen/generators/types.go
+++ b/cmd/kubetype-gen/generators/types.go
@@ -123,7 +123,7 @@ type $.KubeType.Type|public$ struct {
 	// +optional
 	Spec $.RawType|raw$ ` + "`" + `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"` + "`" + `
 
-	Status $.IstioStatus|raw$ ` + "`" + `json:"status"` + "`" + `
+	Status $.IstioStatus|raw$ ` + "`" + `json:"status,omitempty"` + "`" + `
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object


### PR DESCRIPTION
I see no reason to write this out -- we don't do it for spec, and other
k8s objects do not
