### PR TITLE
Added libssl-dev to support building the OpenSSL variant of ztunnel

### DIFF
--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -594,6 +594,7 @@ RUN --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
     libltdl7 \
     libc-dev \
     libcurl4-openssl-dev \
+    libssl-dev \
     less \
     make \
     pkg-config \


### PR DESCRIPTION
This PR installs the OpenSSL header package `libssl-dev` into the builder image.
This is required when building the OpenSSL variant of ztunnel (see istio/ztunnel#1436).
More specifically, these headers are required for building the [openssl-sys](https://crates.io/crates/openssl-sys) crate.