### PR TITLE
Small fixes for gen-release-notes for QoL

### DIFF
--- a/cmd/gen-release-notes/main.go
+++ b/cmd/gen-release-notes/main.go
@@ -283,9 +283,17 @@ func populateTemplate(filename string, releaseNotes []Note, oldRelease string, n
 		if err != nil {
 			return "", fmt.Errorf("unable to parse templates: %s", err.Error())
 		}
-		joinedContents := strings.Join(contents, "\n")
-		output = strings.Replace(output, result, joinedContents, -1)
+		if len(contents) > 0 {
+			joinedContents := strings.Join(contents, "\n")
+			output = strings.Replace(output, result, joinedContents, -1)
+		}
 	}
+
+	// Here we get rid of whatever placeholders were left without
+	// any substitutions. Note that we also get rid of the end of line
+	// when it's there.
+	placeholder := regexp.MustCompile("<!--(.*)-->\\s*$?")
+	output = placeholder.ReplaceAllString(output, "")
 
 	return output, nil
 }

--- a/cmd/gen-release-notes/note.go
+++ b/cmd/gen-release-notes/note.go
@@ -79,7 +79,9 @@ func (note Note) getReleaseNotes(kind string, area string, action string) []stri
 		if filterNote(kind, note.Kind) &&
 			filterNote(area, note.Area) &&
 			filterNote(action, releaseNote.Action) {
-			noteEntry := fmt.Sprintf("%s %s %s\n", releaseNote, note.getDocs(), note.getIssues())
+			noteEntry := fmt.Sprintf("%s %s %s", releaseNote, note.getDocs(), note.getIssues())
+			noteEntry = strings.TrimSpace(noteEntry)
+			noteEntry += "\n"
 			if noteEntry != "" {
 				notes = append(notes, noteEntry)
 			}


### PR DESCRIPTION
This PR removes some unnecessary doubled spaces and new lines caught by the documentation linters.