### PR TITLE
Fix build tools image so make test in ztunnel can work without root

### DIFF
--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -751,25 +751,24 @@ RUN mkdir -p /go && \
     mkdir -p /home/.cargo/registry && \
     mkdir -p /home/.cargo/git && \
     mkdir -p /home/.helm && \
-    mkdir -p /home/.gsutil
+    mkdir -p /home/.gsutil && \
+    mkdir -p /var/run/netns
 
 # TODO must sort out how to use uid mapping in docker so these don't need to be 777
 # They are created as root 755.  As a result they are not writeable, which fails in
 # the developer environment as a volume or bind mount inherits the permissions of
 # the directory mounted rather then overriding with the permission of the volume file.
-RUN chmod 777 /go && \
-    chmod 777 /gocache && \
-    chmod 777 /gobin && \
-    chmod 777 /config && \
-    chmod 777 /config/.docker && \
-    chmod 777 /config/.config/gcloud && \
-    chmod 777 /config/.kube && \
-    chmod 777 /home/.cache && \
-    chmod 777 /home/.cargo && \
-    chmod 777 /home/.cargo/registry && \
-    chmod 777 /home/.cargo/git && \
-    chmod 777 /home/.helm && \
-    chmod 777 /home/.gsutil
+RUN chmod -R 777 /go && \
+    chmod -R 777 /gocache && \
+    chmod -R 777 /gobin && \
+    chmod -R 777 /config && \
+    chmod -R 777 /config/.docker && \
+    chmod -R 777 /config/.config/gcloud && \
+    chmod -R 777 /config/.kube && \
+    chmod -R 777 /home/.cache && \
+    chmod -R 777 /home/.cargo && \
+    chmod -R 777 /home/.helm && \
+    chmod -R 777 /home/.gsutil
 
 WORKDIR /
 


### PR DESCRIPTION
There were a few issues that prevented me from being able to successfully run `make test` in ztunnel code:

1. Cargo directories are owned by root, while the `make test` runs cargo as non root; there was an attempt to give cargo directories in the build tools image broad enough permissions, so that user does not matter anymore (see #249) but when cargo directories were added on top of that we should have applied chmod recursively for this to work;
2. /var/run/netns directory just does not exist in the container
3. AppArmor transfer process to a restricted profile when it creates a new user namespace and the restrictions breaks the test.

This change addresses issues 1 and 2. To test that the change works I worked around the issue 3 by running this:

```
echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
```

And once I did that, I was able to run `make test` in ztunnel repo successfully with the locally built build-tools image.

+cc @keithmattix @Stevenjin8 @jaellio