### PR TITLE
[release-1.24] bump go to 1.23.10

### DIFF
--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -27,7 +27,7 @@
 ################
 # Binary tools
 ################
-ARG GOLANG_IMAGE=golang:1.23.8
+ARG GOLANG_IMAGE=golang:1.23.10
 # hadolint ignore=DL3006
 FROM ${GOLANG_IMAGE} as binary_tools_context_base
 # TARGETARCH is an automatic platform ARG enabled by Docker BuildKit.


### PR DESCRIPTION
Bump go to 1.23.10, we should do this before a final patch release before EOL