### PR TITLE
Update apko

### DIFF
--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -37,7 +37,7 @@ ARG TARGETARCH
 ARG ISTIO_TOOLS_SHA
 
 # Pinned versions of stuff we pull in, keep this list sorted alphabetically
-ENV APKO_VERSION=v0.22.6
+ENV APKO_VERSION=v0.27.6
 ENV BENCHSTAT_VERSION=9c9101da8316
 ENV BOM_VERSION=v0.6.0
 ENV BUF_VERSION=v1.49.0


### PR DESCRIPTION
Route around build failures due to https://www.chainguard.dev/unchained/wolfi-moves-to-usrmerge-standard