### PR TITLE
Revert to Helm 3.18.4

### DIFF
--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -61,6 +61,7 @@ ENV GO_BINDATA_VERSION=v3.1.2
 ENV GO_JUNIT_REPORT_VERSION=df0ed838addb0fa189c4d76ad4657f6007a5811c
 ENV GO_VULNCHECK_VERSION=v1.1.4
 ENV HADOLINT_VERSION=v2.12.0
+# Do not bump to 3.18.6 -- https://github.com/helm/helm/issues/31148#issuecomment-3203897598
 ENV HELM3_VERSION=v3.18.4
 # Consult the Docs WG before bumping Hugo.
 # Specifically, the version here should match netlify.toml in istio/istio.io.

--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -61,7 +61,7 @@ ENV GO_BINDATA_VERSION=v3.1.2
 ENV GO_JUNIT_REPORT_VERSION=df0ed838addb0fa189c4d76ad4657f6007a5811c
 ENV GO_VULNCHECK_VERSION=v1.1.4
 ENV HADOLINT_VERSION=v2.12.0
-ENV HELM3_VERSION=v3.18.6
+ENV HELM3_VERSION=v3.18.4
 # Consult the Docs WG before bumping Hugo.
 # Specifically, the version here should match netlify.toml in istio/istio.io.
 ENV HUGO_VERSION=0.147.8


### PR DESCRIPTION
Helm changed their jsonschema library in 3.18.5 and that's had several issues. Reverting until things are more stable