### PR TITLE
fix: fix fortio helm template in perf

### DIFF
--- a/perf/benchmark/templates/fortio.yaml
+++ b/perf/benchmark/templates/fortio.yaml
@@ -375,11 +375,11 @@ spec:
         sidecar.istio.io/proxyCPU: {{ $.Values.proxy.cpu }}
         sidecar.istio.io/proxyMemory: {{ $.Values.proxy.memory }}
 {{- if $.Values.proxy.memLimit }}
-         sidecar.istio.io/proxyMemoryLimit: {{ $.Values.proxy.memLimit }}
+        sidecar.istio.io/proxyMemoryLimit: {{ $.Values.proxy.memLimit }}
 {{- end }}
 
 {{- if $.Values.proxy.cpuLimit }}
-         sidecar.istio.io/proxyCPULimit: {{ $.Values.proxy.cpuLimit }}
+        sidecar.istio.io/proxyCPULimit: {{ $.Values.proxy.cpuLimit }}
 {{- end }}
 
 {{- if $.Values.proxy.image }}


### PR DESCRIPTION
If `proxy.cpuLimit` and/or `proxy.memLimit` are specified for performance test, setup_test fails due to indentation bug in fortio helm template
```
[ERROR] templates/fortio.yaml: unable to parse YAML: error converting YAML to JSON: yaml: line 23: mapping values are not allowed in this context
```

This fixes fortio helm template.