### PR TITLE
fix(lint): fix linter issues

### DIFF
--- a/cmd/mvpage/mover.go
+++ b/cmd/mvpage/mover.go
@@ -109,7 +109,7 @@ func (m *mover) validate(file string) (absFile string, link string, err error) {
 				link = "/" + lang + strings.TrimPrefix(absDir, contentDir)
 			}
 
-			return
+			return absFile, link, nil
 		}
 	}
 

--- a/pkg/protomodel/baseDesc.go
+++ b/pkg/protomodel/baseDesc.go
@@ -81,7 +81,7 @@ const class = "$class: "
 func getClass(com string) (cl string, newCom string) {
 	start := strings.Index(com, class)
 	if start < 0 {
-		return
+		return "", ""
 	}
 
 	name := start + len(class)
@@ -95,7 +95,7 @@ func getClass(com string) (cl string, newCom string) {
 		cl = com[name:end]
 	}
 
-	return
+	return cl, newCom
 }
 
 func (bd baseDesc) PackageDesc() *PackageDescriptor {


### PR DESCRIPTION
Currently main branch doesn't pass linter checks
```
../../cmd/mvpage/mover.go:112:1: File is not properly formatted (gofumpt)
			return
^
../../pkg/protomodel/baseDesc.go:84:1: File is not properly formatted (gofumpt)
		return
^
2 issues:
* gofumpt: 2
```

This is to fix linter issues.

