### PR TITLE
add telemetry-fix addon and update long-running scripts for Grafana

### DIFF
--- a/perf/istio-install/addons/telemetry-fix.yaml
+++ b/perf/istio-install/addons/telemetry-fix.yaml
@@ -1,0 +1,44 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: prometheus-node-exporter
+rules:
+- apiGroups: [""]
+  resources: ["nodes/metrics", "nodes/proxy", "nodes/stats"]
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus-node-exporter-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus-node-exporter
+subjects:
+- kind: ServiceAccount
+  name: prometheus
+  namespace: istio-prometheus
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: kubelet-cadvisor
+  namespace: istio-prometheus
+  labels:
+    release: prometheus
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kubelet
+  namespaceSelector:
+    matchNames:
+    - kube-system
+  endpoints:
+  - port: https-metrics
+    scheme: https
+    path: /metrics/cadvisor
+    interval: 15s
+    tlsConfig:
+      insecureSkipVerify: true
+    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token

--- a/perf/stability/long_running.sh
+++ b/perf/stability/long_running.sh
@@ -62,6 +62,10 @@ fi
 NAMESPACE="istio-prometheus" ./setup_test.sh alertmanager
 kubectl apply -f ./alertmanager/prometheusrule.yaml
 
+# --- APPLY THE TELEMETRY FIX ---
+echo "Applying Telemetry and RBAC fixes (CPU/Memory/Traffic)..."
+kubectl apply -f "${ROOT}/istio-install/addons/telemetry-fix.yaml"
+
 # Setup workloads
 pushd "${ROOT}/load"
 # shellcheck disable=SC1091


### PR DESCRIPTION
Fix Grafana dashboard for OSS qual tests Added telemetry-fix.yaml to resolve missing metrics in Grafana. Updated long_running.sh to apply telemetry fixes during test execution.