### PR TITLE
Enabled modernize linter configuration.

### DIFF
--- a/cmd/kubetype-gen/generators/package.go
+++ b/cmd/kubetype-gen/generators/package.go
@@ -16,6 +16,7 @@ package generators
 
 import (
 	"fmt"
+	"slices"
 
 	"k8s.io/gengo/generator"
 	"k8s.io/gengo/types"
@@ -36,12 +37,7 @@ func NewPackageGenerator(source metadata.PackageMetadata, boilerplate []byte) ge
 // +groupName=%s
 `, source.GroupVersion().Group)),
 		FilterFunc: func(c *generator.Context, t *types.Type) bool {
-			for _, it := range source.RawTypes() {
-				if t == it {
-					return true
-				}
-			}
-			return false
+			return slices.Contains(source.RawTypes(), t)
 		},
 		GeneratorList: []generator.Generator{
 			// generate types.go

--- a/cmd/kubetype-gen/generators/register.go
+++ b/cmd/kubetype-gen/generators/register.go
@@ -19,6 +19,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"slices"
 
 	"k8s.io/gengo/generator"
 	"k8s.io/gengo/namer"
@@ -79,7 +80,7 @@ func (g registerGenerator) Finalize(c *generator.Context, w io.Writer) error {
 	sw := generator.NewSnippetWriter(w, c, "$", "$")
 	var lowerCaseSchemeKubeTypes, camelCaseSchemeKubeTypes []metadata.KubeType
 	for _, k := range g.source.AllKubeTypes() {
-		if isLowerCaseScheme(k.Tags()) {
+		if slices.Contains(k.Tags(), "kubetype-gen:lowerCaseScheme") {
 			lowerCaseSchemeKubeTypes = append(lowerCaseSchemeKubeTypes, k)
 		} else {
 			camelCaseSchemeKubeTypes = append(camelCaseSchemeKubeTypes, k)
@@ -96,17 +97,6 @@ func (g registerGenerator) Finalize(c *generator.Context, w io.Writer) error {
 	sw.Do(addKnownTypesFuncTemplate, m)
 
 	return sw.Error()
-}
-
-// isLowerCaseScheme checks if the kubetype is reflected as lower case in Kubernetes scheme.
-// This is a workaround as Istio CRDs should have CamelCase scheme in Kubernetes, e.g. `VirtualService` instead of `virtualservice`
-func isLowerCaseScheme(tags []string) bool {
-	for _, s := range tags {
-		if s == "kubetype-gen:lowerCaseScheme" {
-			return true
-		}
-	}
-	return false
 }
 
 const resourceFuncTemplate = `

--- a/cmd/protoc-gen-alias/main.go
+++ b/cmd/protoc-gen-alias/main.go
@@ -38,7 +38,7 @@ func generateFile(gen *protogen.Plugin, file *protogen.File) {
 	ourVersion := filepath.Base(filepath.Dir(file.Desc.Path()))
 	var versions []string
 	for _, msg := range file.Messages {
-		for _, line := range strings.Split(msg.Comments.Leading.String(), "\n") {
+		for line := range strings.SplitSeq(msg.Comments.Leading.String(), "\n") {
 			// Looking for something like '// +cue-gen:Simple:versions:v1,v1alpha'
 			if strings.HasPrefix(line, "// +cue-gen:") {
 				items := strings.Split(line, ":")
@@ -46,7 +46,7 @@ func generateFile(gen *protogen.Plugin, file *protogen.File) {
 					continue
 				}
 				if items[2] == "versions" {
-					for _, v := range strings.Split(items[3], ",") {
+					for v := range strings.SplitSeq(items[3], ",") {
 						if v != ourVersion {
 							versions = append(versions, v)
 						}

--- a/cmd/protoc-gen-crd/main.go
+++ b/cmd/protoc-gen-crd/main.go
@@ -28,15 +28,15 @@ import (
 // in the parameter string into an easy to use map.
 func extractParams(parameter string) map[string]string {
 	m := make(map[string]string)
-	for _, p := range strings.Split(parameter, ",") {
+	for p := range strings.SplitSeq(parameter, ",") {
 		if p == "" {
 			continue
 		}
 
-		if i := strings.Index(p, "="); i < 0 {
+		if before, after, ok := strings.Cut(p, "="); !ok {
 			m[p] = ""
 		} else {
-			m[p[0:i]] = p[i+1:]
+			m[before] = after
 		}
 	}
 

--- a/cmd/protoc-gen-crd/openapiGenerator.go
+++ b/cmd/protoc-gen-crd/openapiGenerator.go
@@ -377,8 +377,8 @@ func (g *openapiGenerator) generateFile(
 				},
 			}
 			if pk, f := cfg["printerColumn"]; f {
-				pcs := strings.Split(pk, ";;")
-				for _, pc := range pcs {
+				pcs := strings.SplitSeq(pk, ";;")
+				for pc := range pcs {
 					if pc == "" {
 						continue
 					}
@@ -872,7 +872,7 @@ var Celpp = func() *celpp.Preprocessor {
 }()
 
 func applyExtraValidations(schema *apiext.JSONSchemaProps, m protomodel.CoreDesc, t markers.TargetType) {
-	for _, line := range strings.Split(m.Location().GetLeadingComments(), "\n") {
+	for line := range strings.SplitSeq(m.Location().GetLeadingComments(), "\n") {
 		line = strings.TrimSpace(line)
 		if !strings.Contains(line, KubeBuilderValidationPrefix) &&
 			!strings.Contains(line, "+list") &&

--- a/cmd/protoc-gen-crd/openapiGenerator.go
+++ b/cmd/protoc-gen-crd/openapiGenerator.go
@@ -670,12 +670,7 @@ func isRequired(fd *protomodel.FieldDescriptor) bool {
 	if !ok {
 		return false
 	}
-	for _, o := range opts {
-		if o == annotations.FieldBehavior_REQUIRED {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(opts, annotations.FieldBehavior_REQUIRED)
 }
 
 // buildCELOneOf builds a CEL expression to select oneOf the fields below

--- a/cmd/protoc-gen-docs/main.go
+++ b/cmd/protoc-gen-docs/main.go
@@ -31,15 +31,15 @@ import (
 // in the parameter string into an easy to use map.
 func extractParams(parameter string) map[string]string {
 	m := make(map[string]string)
-	for _, p := range strings.Split(parameter, ",") {
+	for p := range strings.SplitSeq(parameter, ",") {
 		if p == "" {
 			continue
 		}
 
-		if i := strings.Index(p, "="); i < 0 {
+		if before, after, ok := strings.Cut(p, "="); !ok {
 			m[p] = ""
 		} else {
-			m[p[0:i]] = p[i+1:]
+			m[before] = after
 		}
 	}
 

--- a/common/config/.golangci.yml
+++ b/common/config/.golangci.yml
@@ -15,6 +15,7 @@ linters:
     - ineffassign
     - lll
     - misspell
+    - modernize
     - revive
     - staticcheck
     - unconvert
@@ -94,6 +95,38 @@ linters:
       locale: US
       ignore-rules:
         - cancelled
+    modernize:
+      # List of analyzers to disable.
+      # By default, all analyzers are enabled.
+      disable:
+        # Replace interface{} with any.
+        - any
+        # Replace []byte(fmt.Sprintf) with fmt.Appendf.
+        - fmtappendf
+        # Replace explicit loops over maps with calls to maps package.
+        - mapsloop
+        # Simplify code by using go1.26's new(expr).
+        - newexpr
+        # Suggest replacing omitempty with omitzero for struct fields.
+        - omitzero
+        # Replace reflect.TypeOf(x) with TypeFor[T]().
+        - reflecttypefor
+        # Replace loops with slices.Contains or slices.ContainsFunc.
+        - slicescontains
+        # Replace sort.Slice with slices.Sort for basic types.
+        - slicessort
+        # Use iterators instead of Len/At-style APIs.
+        - stditerators
+        # Replace HasPrefix/TrimPrefix with CutPrefix.
+        - stringscutprefix
+        # Replace += with strings.Builder.
+        - stringsbuilder
+        # Replace context.WithCancel with t.Context in tests.
+        - testingcontext
+        # Replace unsafe pointer arithmetic with function calls.
+        - unsafefuncs
+        # Replace wg.Add(1)/go/wg.Done() with wg.Go.
+        - waitgroup
     revive:
       confidence: 0
       severity: warning

--- a/perf/benchmark/security/generate_policies/generate.go
+++ b/perf/benchmark/security/generate_policies/generate.go
@@ -32,7 +32,7 @@ func (operationGenerator) generate(policyData SecurityPolicy) *authzpb.Rule {
 
 	if numPaths := policyData.AuthZ.NumPaths; numPaths > 0 {
 		paths := make([]string, numPaths)
-		for i := 0; i < numPaths; i++ {
+		for i := range numPaths {
 			paths[i] = fmt.Sprintf("/invalid-path-%d", i)
 		}
 		operation := &authzpb.Rule_To{
@@ -54,7 +54,7 @@ func (conditionGenerator) generate(policyData SecurityPolicy) *authzpb.Rule {
 
 	if numValues := policyData.AuthZ.NumValues; numValues > 0 {
 		values := make([]string, numValues)
-		for i := 0; i < numValues; i++ {
+		for i := range numValues {
 			if i == numValues-1 && policyData.AuthZ.Action == "ALLOW" {
 				values[i] = "admin"
 			} else {
@@ -79,7 +79,7 @@ func (sourceGenerator) generate(policyData SecurityPolicy) *authzpb.Rule {
 
 	if numSourceIP := policyData.AuthZ.NumSourceIP; numSourceIP > 0 {
 		sourceIPList := make([]string, numSourceIP)
-		for i := 0; i < numSourceIP; i++ {
+		for i := range numSourceIP {
 			sourceIPList[i] = fmt.Sprintf("0.0.%d.%d", i/256, i%256)
 		}
 		source := &authzpb.Rule_From{
@@ -92,7 +92,7 @@ func (sourceGenerator) generate(policyData SecurityPolicy) *authzpb.Rule {
 
 	if numNamepaces := policyData.AuthZ.NumNamespaces; numNamepaces > 0 {
 		namespaces := make([]string, numNamepaces)
-		for i := 0; i < numNamepaces; i++ {
+		for i := range numNamepaces {
 			namespaces[i] = fmt.Sprintf("invalid-namespace-%d", i)
 		}
 		source := &authzpb.Rule_From{
@@ -105,7 +105,7 @@ func (sourceGenerator) generate(policyData SecurityPolicy) *authzpb.Rule {
 
 	if numPrincipals := policyData.AuthZ.NumPrincipals; numPrincipals > 0 {
 		principals := make([]string, numPrincipals)
-		for i := 0; i < numPrincipals; i++ {
+		for i := range numPrincipals {
 			principals[i] = fmt.Sprintf("cluster.local/ns/twopods-istio/sa/Invalid-%d", i)
 		}
 		source := &authzpb.Rule_From{
@@ -118,7 +118,7 @@ func (sourceGenerator) generate(policyData SecurityPolicy) *authzpb.Rule {
 
 	if numRequestPrincipals := policyData.AuthZ.NumRequestPrincipals; numRequestPrincipals > 0 {
 		requestPrincipals := make([]string, numRequestPrincipals)
-		for i := 0; i < numRequestPrincipals; i++ {
+		for i := range numRequestPrincipals {
 			principalValue := "invalid-issuer/subject"
 			if i == numRequestPrincipals-1 {
 				principalValue = fmt.Sprintf("issuer-%d/subject", policyData.RequestAuthN.NumJwks)

--- a/pkg/protomodel/frontMatter.go
+++ b/pkg/protomodel/frontMatter.go
@@ -67,8 +67,8 @@ func extractFrontMatter(name string, loc *descriptor.SourceCodeInfo_Location, fi
 	var extra []string
 
 	for _, para := range loc.LeadingDetachedComments {
-		lines := strings.Split(para, "\n")
-		for _, l := range lines {
+		lines := strings.SplitSeq(para, "\n")
+		for l := range lines {
 			l = strings.Trim(l, " ")
 
 			if strings.HasPrefix(l, "$") {


### PR DESCRIPTION
Spawned from #3399 which is too messy to clean up because I made some mistakes with git.
@Stevenjin8 @fjglira Can you please add the `ok-to-test` label, so this one could land more quickly. Thank you!

Modernize is a golang tool that contains many built-in replacements to use newer golang semantics and standard library features. The PR enables the rules that have been dealt with in the istio repository.

The entire list for GoLang 1.26 is in the documentation.
https://golangci-lint.run/docs/linters/configuration/#modernize

* `forvar`. I believe it's already covered by copyloopvar, so it's easier to just enable it here.
* `rangeint` (currently on its way to being enforced in istio in a PR).
* Some strings-rules
* `slicescontains` and `slicessort` have only been dealt with in batches. These rules are also quite neat to simplify code. I fixed the few cases of `slicescontains` that modernize found. It also removed one internal function.