### PR TITLE
Update to networking.istio.io/v1 instead of v1alpha3

### DIFF
--- a/ambient-tests/scripts/fortio/results_to_csv.py
+++ b/ambient-tests/scripts/fortio/results_to_csv.py
@@ -50,7 +50,7 @@ writer = csv.DictWriter(
 writer.writeheader()
 
 for run in runs:
-    row = dict()
+    row = {}
     run = run.strip()
     run = run.split("\n")
 

--- a/ambient-tests/scripts/netperf/results_to_csv.py
+++ b/ambient-tests/scripts/netperf/results_to_csv.py
@@ -20,14 +20,14 @@ TEST_RUN_SEPARATOR = sys.argv[1]
 
 fieldnames: Set[str] = set()
 rows: List[Dict[str, str]] = []
-row: Dict[str, str] = dict()
+row: Dict[str, str] = {}
 
 for line in sys.stdin:
     line = line.strip()
     if line.strip() == TEST_RUN_SEPARATOR:
         fieldnames.update(row.keys())
         rows.append(row)
-        row = dict()
+        row = {}
         continue
 
     line = line.split("=")

--- a/examples/luacheck/templates/filter.yaml
+++ b/examples/luacheck/templates/filter.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: EnvoyFilter
 metadata:
   name: jwt-reject-lua-filter

--- a/isotope/local_gateways.yaml
+++ b/isotope/local_gateways.yaml
@@ -1,6 +1,6 @@
 # Gateway config, and associated virtual services
 
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
   name: entrypoint-gateway
@@ -15,7 +15,7 @@ spec:
     hosts:
     - "*"
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: grafana
@@ -31,7 +31,7 @@ spec:
         port:
           number: 3000
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: prom
@@ -47,7 +47,7 @@ spec:
         port:
           number: 9090
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: client
@@ -63,7 +63,7 @@ spec:
         port:
           number: 8080
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: client
@@ -74,7 +74,7 @@ spec:
       mode: DISABLE
       #mode: ISTIO_MUTUAL
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: grafana
@@ -84,7 +84,7 @@ spec:
     tls:
       mode: DISABLE
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: prometheus

--- a/perf/benchmark/configs/istio/plaintext/prerun.sh
+++ b/perf/benchmark/configs/istio/plaintext/prerun.sh
@@ -33,7 +33,7 @@ spec:
 EOF
   # Explicitly disable mTLS by DestinationRule to avoid potential auto mTLS effect.
 cat <<EOF | kubectl apply -f -
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: plaintext-dr-twopods

--- a/perf/benchmark/templates/fortio.yaml
+++ b/perf/benchmark/templates/fortio.yaml
@@ -558,7 +558,7 @@ spec:
 {{ toYaml $.Values.appresources1 | indent 10 }}
 {{- end }}
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: {{ $.name }}
@@ -582,7 +582,7 @@ spec:
 
 ---
 {{- if or $.Values.server.inject $.Values.client.inject }}
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
   name: {{ .Values.gateway }}

--- a/perf/benchmark/templates/mtls.yaml
+++ b/perf/benchmark/templates/mtls.yaml
@@ -7,7 +7,7 @@ spec:
   mtls:
     mode: PERMISSIVE
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: fortioserver

--- a/perf/istio-install/base/templates/istio-gateway.yaml
+++ b/perf/istio-install/base/templates/istio-gateway.yaml
@@ -1,6 +1,6 @@
 # Gateway config, and associated virtual services
 
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
   name: istio-gateway
@@ -35,7 +35,7 @@ spec:
     - "tracing.local"
     - "*"
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: grafana
@@ -55,7 +55,7 @@ spec:
         port:
           number: 3000
 ---
-apiVersion: "networking.istio.io/v1alpha3"
+apiVersion: "networking.istio.io/v1"
 kind: "DestinationRule"
 metadata:
   name: "grafana"
@@ -66,7 +66,7 @@ spec:
     tls:
       mode: DISABLE
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: kiali
@@ -86,7 +86,7 @@ spec:
         port:
           number: 20001
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: prom
@@ -106,7 +106,7 @@ spec:
         port:
           number: 9090
 ---
-apiVersion: "networking.istio.io/v1alpha3"
+apiVersion: "networking.istio.io/v1"
 kind: "DestinationRule"
 metadata:
   name: "prom"
@@ -117,7 +117,7 @@ spec:
     tls:
       mode: DISABLE
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: tracing
@@ -137,7 +137,7 @@ spec:
         port:
           number: 80
 ---
-apiVersion: "networking.istio.io/v1alpha3"
+apiVersion: "networking.istio.io/v1"
 kind: "DestinationRule"
 metadata:
   name: "tracing"

--- a/perf/istio-install/base/templates/prometheus-install.yaml
+++ b/perf/istio-install/base/templates/prometheus-install.yaml
@@ -97,7 +97,7 @@ subjects:
     name: prometheus
     namespace: istio-prometheus
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: prometheus

--- a/perf/load/auto-mtls/templates/ingress.yaml
+++ b/perf/load/auto-mtls/templates/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
   name: {{ .Values.serviceNamePrefix }}0-gateway
@@ -13,7 +13,7 @@ spec:
     hosts:
     - {{ .Values.serviceNamePrefix }}0.local
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: automtls

--- a/perf/load/bootstrap-vm.sh
+++ b/perf/load/bootstrap-vm.sh
@@ -55,7 +55,7 @@ kubectl get cm -n "${VM_NAMESPACE}" service-graph-config -ojsonpath='{.data.serv
 
 istioctl x workload group create --name "${VM_APP}" --namespace "${VM_NAMESPACE}" --labels app="${VM_APP}" --serviceAccount "${SERVICE_ACCOUNT}" >  "${WORK_DIR}"/workloadgroup.yaml
 cat <<EOF > "${WORK_DIR}"/workloadgroup.yaml
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: WorkloadGroup
 metadata:
   name: "${VM_APP}"

--- a/perf/load/pilot/templates/service-entries.yaml
+++ b/perf/load/pilot/templates/service-entries.yaml
@@ -1,5 +1,5 @@
 {{ range until (int .Values.serviceEntries) }}
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: ServiceEntry
 metadata:
   name: ext-svc-{{.}}

--- a/perf/load/templates/config-map.yaml
+++ b/perf/load/templates/config-map.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ .Values.Namespace }}
 data:
   cfg.yaml: |
-    apiVersion: networking.istio.io/v1alpha3
+    apiVersion: networking.istio.io/v1
     kind: VirtualService
     metadata:
       name: entrypoint

--- a/perf/load/templates/h2upgrade.yaml
+++ b/perf/load/templates/h2upgrade.yaml
@@ -1,5 +1,5 @@
 {{- define "h2upgrade" }}
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: EnvoyFilter
 metadata:
   name: {{ .serviceNamePrefix }}{{ .serviceName }}-h2upgrade

--- a/perf/load/templates/istio-ingress.gen.yaml
+++ b/perf/load/templates/istio-ingress.gen.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
   name: entrypoint-gateway
@@ -26,7 +26,7 @@ spec:
     - {{ .Values.serviceNamePrefix }}0.{{ .Values.domain }}
 {{- end }}
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: entrypoint
@@ -51,7 +51,7 @@ spec:
           number: 8080
       weight: 70
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: {{ .Values.serviceNamePrefix }}0

--- a/perf/load/templates/service-graph.gen.yaml
+++ b/perf/load/templates/service-graph.gen.yaml
@@ -1651,7 +1651,7 @@ spec:
   selector:
     app: {{ .Values.serviceNamePrefix }}0-9
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: WorkloadGroup
 metadata:
   name: {{ .Values.serviceNamePrefix }}0-9
@@ -1665,7 +1665,7 @@ spec:
     {{ toJson .Values.readinessProbe }}
   {{- end}}
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: WorkloadGroup
 metadata:
   name: {{ .Values.serviceNamePrefix }}0-9-0

--- a/perf/load/templates/sidecar.yaml
+++ b/perf/load/templates/sidecar.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: Sidecar
 metadata:
   name: default

--- a/perf/security/sds-tests/egress-sds/setup_destinationrule.sh
+++ b/perf/security/sds-tests/egress-sds/setup_destinationrule.sh
@@ -24,7 +24,7 @@ function setup_destinationrules() {
     local credential_name="client-credential-${id}"
 
     cat <<-EOF | kubectl apply -n istio-system --cluster "${cs}" -f -
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: "${dr_name}"

--- a/perf/security/sds-tests/egress-sds/setup_gateway.sh
+++ b/perf/security/sds-tests/egress-sds/setup_gateway.sh
@@ -27,7 +27,7 @@ function setup_gateways() {
     local host_nginx="my-nginx-${id}.mesh-external.svc.cluster.local"
 
     cat <<-EOF | kubectl apply -n "${ns}" --cluster "${cs}" -f -
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
   name: "${gateway_name}"
@@ -44,7 +44,7 @@ spec:
     tls:
       mode: ISTIO_MUTUAL
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: "${gateway_dr}"

--- a/perf/security/sds-tests/egress-sds/setup_virtualservice.sh
+++ b/perf/security/sds-tests/egress-sds/setup_virtualservice.sh
@@ -27,7 +27,7 @@ function setup_virtualservices() {
     local host_nginx="my-nginx-${id}.mesh-external.svc.cluster.local"
 
     cat <<EOF | kubectl apply -n "${ns}" --cluster "${cs}" -f -
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: "${vs_name}"

--- a/perf/security/sds-tests/ingress-sds/setup_gateway.sh
+++ b/perf/security/sds-tests/ingress-sds/setup_gateway.sh
@@ -25,7 +25,7 @@ function deploy_gateway() {
     local host="httpbin-${id}.example.com"
 
     cat <<-EOF | kubectl apply -n "${ns}" --cluster "${cs}" -f -
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
   name: "${gateway_name}"

--- a/perf/security/sds-tests/ingress-sds/setup_virtualservice.sh
+++ b/perf/security/sds-tests/ingress-sds/setup_virtualservice.sh
@@ -24,7 +24,7 @@ function deploy_virtualservice() {
     local host="httpbin-${id}.example.com"
 
     cat <<EOF | kubectl apply -n "${ns}" --cluster "${cs}" -f -
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: "${gateway_name}"


### PR DESCRIPTION
Update all references to `networking.istio.io/v1alpha3` to the v1 version.
Examples in the [documentation](https://istio.io/latest/docs/reference/config/networking/gateway/) consistently use `v1`.

I am sneaking in two unrelated changes to the Python scripts. Please refrain from using literals like `dict()` and `list()` as they are slower and not Pythonic. This [flake8-comprehensions extension](https://pypi.org/project/flake8-comprehensions/) highlights them. 