### PR TITLE
Update to use security.istio.io/v1

### DIFF
--- a/perf/benchmark/configs/istio/ext_authz/policy.yaml
+++ b/perf/benchmark/configs/istio/ext_authz/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
   name: http-allow

--- a/perf/benchmark/configs/istio/plaintext/prerun.sh
+++ b/perf/benchmark/configs/istio/plaintext/prerun.sh
@@ -22,7 +22,7 @@ kubectl -n "${NAMESPACE}" delete dr --all || true
 kubectl -n "${NAMESPACE}" delete policy --all || true
 echo "Configure plaintext..."
 cat <<EOF | kubectl apply -f -
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: PeerAuthentication
 metadata:
   name: default

--- a/perf/benchmark/security/generate_policies/README.md
+++ b/perf/benchmark/security/generate_policies/README.md
@@ -83,7 +83,7 @@ go run generate_policies.go generate.go jwt.go -configFile="config.json"
 This will create an Authorization Policy as follows and print it out to the stdout.
 
 ```yaml
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
   name: test-AuthorizationPolicy-1
@@ -141,7 +141,7 @@ go run generate_policies.go generate.go jwt.go -configFile="config.json"
 This will create a PeerAuthentication policy as follows and print it out to the stdout.
 
 ```yaml
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: PeerAuthentication
 metadata:
   name: test-PeerAuthentication-1
@@ -189,7 +189,7 @@ go run generate_policies.go generate.go jwt.go -configFile="config.json"
 This will create a RequestAuthentication Policy as follows and print it out to the stdout. When creating a jwks rule each key is formed of a public key of an RSA256 public/private key pair. This key pair is generated at random and created a new pair every time generate_policies are run.
 
 ```yaml
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: RequestAuthentication
 metadata:
   name: test-requestauthentication-1
@@ -243,7 +243,7 @@ go run generate_policies.go generate.go jwt.go -configFile="twoPolicies.json"
 Which outputs the following yaml:
 
 ```yaml
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
   name: test-AuthorizationPolicy-1
@@ -256,7 +256,7 @@ spec:
        principals:
        - cluster.local/ns/twopods-istio/sa/Invalid-0
 ---
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: PeerAuthentication
 metadata:
   name: test-PeerAuthentication-1

--- a/perf/load/templates/strict.yaml
+++ b/perf/load/templates/strict.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.mtls }}
-apiVersion: "security.istio.io/v1beta1"
+apiVersion: "security.istio.io/v1"
 kind: "PeerAuthentication"
 metadata:
   name: "default"


### PR DESCRIPTION
`security.istio.io/v1beta1` is deprecated.

Examples in the [documentation](https://istio.io/latest/docs/concepts/security/#authentication-policies) also use the `v1` consistently.