### PR TITLE
Update remnant networking/security.istio.io to v1

### DIFF
--- a/perf/benchmark/security/generate_policies/generate.go
+++ b/perf/benchmark/security/generate_policies/generate.go
@@ -17,7 +17,7 @@ package main
 import (
 	"fmt"
 
-	authzpb "istio.io/api/security/v1beta1"
+	authzpb "istio.io/api/security/v1"
 )
 
 type generator interface {

--- a/perf/benchmark/security/generate_policies/generate_policies.go
+++ b/perf/benchmark/security/generate_policies/generate_policies.go
@@ -32,7 +32,7 @@ import (
 	"google.golang.org/protobuf/proto"
 	"sigs.k8s.io/yaml"
 
-	authzpb "istio.io/api/security/v1beta1"
+	authzpb "istio.io/api/security/v1"
 )
 
 type ruleGenerator struct {
@@ -264,7 +264,7 @@ func createPolicyHeader(namespace, name, kind string, dryRun bool) *MyPolicy {
 		namespace = "twopods-istio"
 	}
 	ret := &MyPolicy{
-		APIVersion: "security.istio.io/v1beta1",
+		APIVersion: "security.istio.io/v1",
 		Kind:       kind,
 		Metadata:   MetadataStruct{Namespace: namespace, Name: name},
 	}

--- a/perf/benchmark/templates/mtls.yaml
+++ b/perf/benchmark/templates/mtls.yaml
@@ -1,4 +1,4 @@
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: PeerAuthentication
 metadata:
   name: default

--- a/perf/security/sds-tests/workload-sds/workload.yaml
+++ b/perf/security/sds-tests/workload-sds/workload.yaml
@@ -118,7 +118,7 @@ spec:
 ##################################################################################################
 # DestinationRule
 ##################################################################################################
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: httpbin-reqperconn-policy


### PR DESCRIPTION
These I overlooked in my two previous PRs.

I am hesitant to update code references. However, there are references to `v1alpha1` etc. in the go code.