### PR TITLE
bump go to 1.27.0

### DIFF
--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -29,7 +29,7 @@ ARG BASE_OS_CONTEXT=base_os_context
 ################
 # Binary tools
 ################
-ARG GOLANG_IMAGE=golang:1.26.5-bookworm
+ARG GOLANG_IMAGE=golang:1.27.0-bookworm
 # hadolint ignore=DL3006
 FROM ${GOLANG_IMAGE} AS binary_tools_context_base
 # TARGETARCH is an automatic platform ARG enabled by Docker BuildKit.


### PR DESCRIPTION
This can be merged before updating istio/istio; indeed, it is needed to merge this before updating the istio/istio go version because we need the container image to have the latest go version to be able to run the test