### PR TITLE
Updating golangci-lint to support 1.27.0 Go

### DIFF
--- a/docker/build-tools/Dockerfile
+++ b/docker/build-tools/Dockerfile
@@ -51,7 +51,7 @@ ENV GH_VERSION=2.88.1
 ENV GOCOVMERGE_VERSION=b5bfa59ec0adc420475f97f89b58045c721d761c
 ENV GOIMPORTS_VERSION=v0.42.0
 # When updating the golangci version, you may want to update the common-files config/.golangci* files as well.
-ENV GOLANGCI_LINT_VERSION=v2.11.3
+ENV GOLANGCI_LINT_VERSION=v2.13.1
 ENV GOLANG_GRPC_PROTOBUF_VERSION=v1.5.1
 ENV GOLANG_PROTOBUF_VERSION=v1.36.11
 # From May 13, 2025. The latest tagged version at the time (0.6.0) is missing


### PR DESCRIPTION
Updating golangci-lint to be able to support 1.27.0 go. Support added from 2.13.0: https://golangci-lint.run/docs/product/changelog/#2131. This PR will make get rid of the lint issues: https://github.com/istio/istio/pull/61431