### PR TITLE
helper function to safely load AWS secrets

### DIFF
--- a/cmd/protoc-gen-golang-jsonshim/test/jsonshim_test.go
+++ b/cmd/protoc-gen-golang-jsonshim/test/jsonshim_test.go
@@ -20,9 +20,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/golang/protobuf/jsonpb" // nolint: depguard // We need the deprecated module since the jsonpb replacement is not backwards compatible.
-	// nolint: staticcheck
-	legacyproto "github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/jsonpb"            // nolint: depguard,staticcheck // We need the deprecated module since the jsonpb replacement is not backwards compatible.
+	legacyproto "github.com/golang/protobuf/proto" // nolint:staticcheck // We need the deprecated module since the jsonpb replacement is not backwards compatible.
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/protobuf/testing/protocmp"
 

--- a/docker/build-tools/prow-entrypoint.sh
+++ b/docker/build-tools/prow-entrypoint.sh
@@ -99,6 +99,41 @@ function log() {
   fi
 }
 
+function load_cf_secrets() {
+    # Loads secrets from a cloudflare secret file into environment variables.
+    # The secret file is expected to be a JSON file with the following structure:
+    # {
+    #   "endpoint": "https://accountid.r2.cloudflarestorage.com",
+    #   "access_key": "your_access_key",
+    #   "secret_key": "your_secret_key",
+    #   "region": "auto",
+    #   "session_token": "your_session_token"
+    # }
+    #
+    # disable x for this function to avoid leaking secrets in logs
+    # 
+    { [[ $- = *x* ]] && was_execution_trace=1 || was_execution_trace=0; } 2>/dev/null
+    { set +x; } 2>/dev/null
+
+    # check arg count
+    if [[ $# -ne 1 ]]; then
+        echo "Usage: load_cf_secrets <secret_file>"
+        exit 1
+    fi
+
+    secret_file=$1
+    ENDPOINT="$(jq -r '.endpoint' < "${secret_file}" | tr -d '\n')"
+    AWS_ACCESS_KEY_ID="$(jq -r '.access_key' < "${secret_file}" | tr -d '\n')"
+    AWS_SECRET_ACCESS_KEY="$(jq -r '.secret_key' < "${secret_file}" | tr -d '\n')"
+    AWS_REGION="$(jq -r '.region' < "${secret_file}" | tr -d '\n')"
+    AWS_SESSION_TOKEN="$(jq -r '.session_token' < "${secret_file}" | tr -d '\n')"
+    export ENDPOINT AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_REGION AWS_SESSION_TOKEN
+
+    if [[ $was_execution_trace == 1 ]]; then
+      { set -x; } 2>/dev/null
+    fi
+}
+
 function tracing::run() {
   # Setup a default implementation that just logs May be overridden if the repo has tracing support.
   log "Running ${1}"

--- a/docker/build-tools/prow-entrypoint.sh
+++ b/docker/build-tools/prow-entrypoint.sh
@@ -99,6 +99,7 @@ function log() {
   fi
 }
 
+# shellcheck disable=SC2329
 function load_cf_secrets() {
     # Loads secrets from a cloudflare secret file into environment variables.
     # The secret file is expected to be a JSON file with the following structure:

--- a/perf/benchmark/security/generate_policies/generate_policies.go
+++ b/perf/benchmark/security/generate_policies/generate_policies.go
@@ -26,9 +26,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/golang/protobuf/jsonpb" // nolint: depguard // We need the deprecated module since the jsonpb replacement is not backwards compatible.
-	// nolint: staticcheck
-	legacyproto "github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/jsonpb"            // nolint: depguard,staticcheck // We need the deprecated module since the jsonpb replacement is not backwards compatible.
+	legacyproto "github.com/golang/protobuf/proto" // nolint:staticcheck // We need the deprecated module since the jsonpb replacement is not backwards compatible.
 	"google.golang.org/protobuf/proto"
 	"sigs.k8s.io/yaml"
 


### PR DESCRIPTION
Got tired of worrying about flags leaking env vars in logs, especially since we don't use workload identity. This is an abstraction that will help me sleep.