### PR TITLE
kubetype-gen: fix gengo/v2 codetag value extraction

### DIFF
--- a/cmd/kubetype-gen/scanner/scanner.go
+++ b/cmd/kubetype-gen/scanner/scanner.go
@@ -203,14 +203,41 @@ func extractVersions(comments []string) []string {
 }
 
 func getGroupVersion(tags map[string][]string, defaultGV *schema.GroupVersion) (*schema.GroupVersion, error) {
-	if value, exists := tags[groupVersionTagName]; exists && len(value) > 0 {
-		gv, err := schema.ParseGroupVersion(value[0])
+	if values := tagValues(tags, groupVersionTagName); len(values) > 0 {
+		gv, err := schema.ParseGroupVersion(values[0])
 		if err == nil {
 			return &gv, nil
 		}
-		return nil, fmt.Errorf("invalid group version '%s' specified: %v", value[0], err)
+		return nil, fmt.Errorf("invalid group version '%s' specified: %v", values[0], err)
 	}
 	return defaultGV, nil
+}
+
+// tagValues extracts values from gengo/v2 codetag lines. Unlike gengo v1, v2 stores
+// the full tag line after '+' (e.g. "kubetype-gen:groupVersion=extensions.istio.io/v1alpha1")
+// rather than just the value portion.
+func tagValues(tags map[string][]string, tagName string) []string {
+	raw, exists := tags[tagName]
+	if !exists {
+		return nil
+	}
+	values := make([]string, 0, len(raw))
+	prefix := tagName + "="
+	for _, line := range raw {
+		if strings.HasPrefix(line, prefix) {
+			values = append(values, line[len(prefix):])
+			continue
+		}
+		if line == tagName {
+			continue
+		}
+		if idx := strings.Index(line, "="); idx >= 0 {
+			values = append(values, line[idx+1:])
+			continue
+		}
+		values = append(values, line)
+	}
+	return values
 }
 
 func createKubeTypesForType(c *generator.Context, t *types.Type, outputPackage *types.Package) []metadata.KubeType {
@@ -229,16 +256,15 @@ func kubeTypeNamesForType(t *types.Type) []string {
 	comments = append(comments, t.CommentLines...)
 	comments = append(comments, t.SecondClosestCommentLines...)
 	tags := codetags.Extract("+", comments)
-	if value, exists := tags[kubeTypeTagName]; exists {
-		if len(value) == 0 || len(value[0]) == 0 {
+	if values := tagValues(tags, kubeTypeTagName); len(values) > 0 {
+		for _, name := range values {
+			if len(name) > 0 {
+				names = append(names, name)
+			}
+		}
+		if len(names) == 0 {
 			klog.Errorf("Invalid value specified for +%s in type %s.  Using default name %s.", kubeTypeTagName, t, t.Name.Name)
 			names = append(names, t.Name.Name)
-		} else {
-			for _, name := range value {
-				if len(name) > 0 {
-					names = append(names, name)
-				}
-			}
 		}
 	} else {
 		names = append(names, t.Name.Name)
@@ -252,8 +278,5 @@ func getTagsForKubeType(t *types.Type, name string) []string {
 	comments = append(comments, t.CommentLines...)
 	comments = append(comments, t.SecondClosestCommentLines...)
 	tags := codetags.Extract("+", comments)
-	if value, exists := tags[tagName]; exists {
-		return value
-	}
-	return []string{}
+	return tagValues(tags, tagName)
 }

--- a/cmd/kubetype-gen/scanner/scanner_test.go
+++ b/cmd/kubetype-gen/scanner/scanner_test.go
@@ -1,0 +1,60 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scanner
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/gengo/v2/codetags"
+)
+
+func TestTagValues(t *testing.T) {
+	tags := codetags.Extract("+", []string{
+		"+kubetype-gen:groupVersion=extensions.istio.io/v1alpha1",
+		"+kubetype-gen:kubeType=TrafficExtension",
+		"+kubetype-gen",
+	})
+
+	got := tagValues(tags, groupVersionTagName)
+	want := []string{"extensions.istio.io/v1alpha1"}
+	if len(got) != len(want) || got[0] != want[0] {
+		t.Fatalf("tagValues(groupVersion) = %#v, want %#v", got, want)
+	}
+
+	got = tagValues(tags, kubeTypeTagName)
+	want = []string{"TrafficExtension"}
+	if len(got) != len(want) || got[0] != want[0] {
+		t.Fatalf("tagValues(kubeType) = %#v, want %#v", got, want)
+	}
+}
+
+func TestGetGroupVersion(t *testing.T) {
+	tags := codetags.Extract("+", []string{
+		"+kubetype-gen:groupVersion=networking.istio.io/v1alpha3",
+	})
+
+	gv, err := getGroupVersion(tags, nil)
+	if err != nil {
+		t.Fatalf("getGroupVersion returned error: %v", err)
+	}
+	if gv == nil {
+		t.Fatal("getGroupVersion returned nil")
+	}
+	want := schema.GroupVersion{Group: "networking.istio.io", Version: "v1alpha3"}
+	if *gv != want {
+		t.Fatalf("getGroupVersion = %#v, want %#v", *gv, want)
+	}
+}


### PR DESCRIPTION
Fix `kubetype-gen` tag parsing after the gengo/v2 migration in #3472