### PR TITLE
skip Go type aliases and fix comment pollution from gengo v2

### DIFF
--- a/cmd/kubetype-gen/scanner/scanner.go
+++ b/cmd/kubetype-gen/scanner/scanner.go
@@ -16,6 +16,7 @@ package scanner
 
 import (
 	"fmt"
+	gotypes "go/types"
 	"os"
 	"path/filepath"
 	"strings"
@@ -117,10 +118,31 @@ func (s *Scanner) Targets(c *generator.Context) []generator.Target {
 		}
 
 		for _, t := range pkg.Types {
+			// Skip Go type aliases (type X = Y). Alias packages (v1, v1beta1)
+			// re-export types from another package (v1alpha3); the original type
+			// already carries the kubetype-gen tag and cue-gen version list that
+			// generate for all target versions, so processing aliases here would
+			// produce duplicate output types.
+			//
+			// gengo v2 represents aliases as types.Alias normally, but falls
+			// back to types.Unsupported (with GoType == *go/types.Alias) when
+			// compiled without Go 1.22+ alias support.
+			if t.Kind == types.Alias {
+				continue
+			}
+			if _, isAlias := t.GoType.(*gotypes.Alias); isAlias {
+				continue
+			}
+			// Only examine CommentLines (immediate doc comment) for the kubetype-gen
+			// enable tag. SecondClosestCommentLines can be polluted in gengo v2 when
+			// an alias type with no doc comment sits immediately after a tagged type
+			// in the same file, causing gengo v2 to attribute the tagged type's
+			// comment block as the alias's "second closest" comment, which then
+			// propagates to the underlying (aliased) type in the universe.
+			typeTags := codetags.Extract("+", t.CommentLines)
 			comments := make([]string, 0, len(t.CommentLines)+len(t.SecondClosestCommentLines))
 			comments = append(comments, t.CommentLines...)
 			comments = append(comments, t.SecondClosestCommentLines...)
-			typeTags := codetags.Extract("+", comments)
 			if _, exists := typeTags[enabledTagName]; exists {
 				var gv *schema.GroupVersion
 				gv, err = getGroupVersion(typeTags, defaultGV)

--- a/cmd/kubetype-gen/testdata/test_output/defaults/group/version/register.go
+++ b/cmd/kubetype-gen/testdata/test_output/defaults/group/version/register.go
@@ -23,7 +23,7 @@ import (
 )
 
 var (
-	// Package-wide variables from generator "register".
+	// Package-wide variables from generator "register.go".
 	SchemeGroupVersion = schema.GroupVersion{Group: GroupName, Version: "version"}
 	SchemeBuilder      = runtime.NewSchemeBuilder(addKnownTypes)
 	localSchemeBuilder = &SchemeBuilder
@@ -31,7 +31,7 @@ var (
 )
 
 const (
-	// Package-wide consts from generator "register".
+	// Package-wide consts from generator "register.go".
 	GroupName = "group"
 )
 

--- a/cmd/kubetype-gen/testdata/test_output/defaults/group/version/types.go
+++ b/cmd/kubetype-gen/testdata/test_output/defaults/group/version/types.go
@@ -17,13 +17,11 @@
 package version
 
 import (
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	v1alpha1 "istio.io/api/meta/v1alpha1"
 	defaults "istio.io/tools/cmd/kubetype-gen/testdata/test_input/positive/defaults"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-//
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Defaulted is for test
@@ -37,7 +35,7 @@ type Defaulted struct {
 	// +optional
 	Spec defaults.Defaulted `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
 
-	Status v1alpha1.IstioStatus `json:",inline"`
+	Status v1alpha1.IstioStatus `json:"status,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -47,5 +45,5 @@ type DefaultedList struct {
 	v1.TypeMeta `json:",inline"`
 	// +optional
 	v1.ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
-	Items       []Defaulted `json:"items" protobuf:"bytes,2,rep,name=items"`
+	Items       []*Defaulted `json:"items" protobuf:"bytes,2,rep,name=items"`
 }

--- a/cmd/kubetype-gen/testdata/test_output/defaults/group2/version2/register.go
+++ b/cmd/kubetype-gen/testdata/test_output/defaults/group2/version2/register.go
@@ -23,7 +23,7 @@ import (
 )
 
 var (
-	// Package-wide variables from generator "register".
+	// Package-wide variables from generator "register.go".
 	SchemeGroupVersion = schema.GroupVersion{Group: GroupName, Version: "version2"}
 	SchemeBuilder      = runtime.NewSchemeBuilder(addKnownTypes)
 	localSchemeBuilder = &SchemeBuilder
@@ -31,7 +31,7 @@ var (
 )
 
 const (
-	// Package-wide consts from generator "register".
+	// Package-wide consts from generator "register.go".
 	GroupName = "group2"
 )
 

--- a/cmd/kubetype-gen/testdata/test_output/defaults/group2/version2/types.go
+++ b/cmd/kubetype-gen/testdata/test_output/defaults/group2/version2/types.go
@@ -17,13 +17,11 @@
 package version2
 
 import (
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	v1alpha1 "istio.io/api/meta/v1alpha1"
 	defaults "istio.io/tools/cmd/kubetype-gen/testdata/test_input/positive/defaults"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-//
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // AllOverridden is for test
@@ -39,7 +37,7 @@ type AllOverridden struct {
 	// +optional
 	Spec defaults.AllOverridden `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
 
-	Status v1alpha1.IstioStatus `json:",inline"`
+	Status v1alpha1.IstioStatus `json:"status,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -49,5 +47,5 @@ type AllOverriddenList struct {
 	v1.TypeMeta `json:",inline"`
 	// +optional
 	v1.ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
-	Items       []AllOverridden `json:"items" protobuf:"bytes,2,rep,name=items"`
+	Items       []*AllOverridden `json:"items" protobuf:"bytes,2,rep,name=items"`
 }


### PR DESCRIPTION
Follow-up to #3472 and #3474. Fixes `gencheck_client-go` failures when running without `GODEBUG=gotypesalias=0`.

istio/api's v1 and v1beta1 packages re-export types from v1alpha3 as Go type aliases. With `gotypesalias=1` (the default since Go 1.23), `go/types` represents these as `*go/types.Alias`, and gengo v2 surfaces them in `pkg.Types` alongside the canonical types.

This caused two issues in the scanner:

1. Duplicate generation: Aliases were processed as real types, producing duplicate output types that failed to compile.

2. Comment pollution: When an alias type with no doc comment appears immediately after a tagged type (no blank line between them), gengo v2's `priorDetachedComment` picks up the tagged type's comment block as the alias's `SecondClosestCommentLines`. That polluted comment then propagates to the underlying type in the universe, causing the scanner to falsely detect a `+kubetype-gen` tag on types that don't have one.

I already ran the fix, built the binary and the result in the client-go repo is good:

<img width="1157" height="294" alt="image" src="https://github.com/user-attachments/assets/67c9d0c7-5b7c-4f06-bfd9-cd2f1e3a8830" />

It only add minor changes on comments